### PR TITLE
feat: move export job state from in-memory dict to database

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -21,9 +21,9 @@ environments:
       capacity: "CU_1"  # Options: CU_1, CU_2, CU_4, CU_8
 
   development:
-    app_name: "ai-slide-generator-dev-2"
+    app_name: "db-tellr-dev"
     description: "AI Slide Generator - dev Environment"
-    workspace_path: "/Workspace/Users/robert.whiffin@databricks.com/.apps/databricks-tellr/dev2"
+    workspace_path: "/Workspace/Users/robert.whiffin@databricks.com/.apps/dev/tellr"
     permissions:
       - user_name: "robert.whiffin@databricks.com"
         permission_level: "CAN_MANAGE"
@@ -31,11 +31,11 @@ environments:
     env_vars:
       ENVIRONMENT: "development"
       LOG_LEVEL: "DEBUG"
-      LAKEBASE_INSTANCE: "ai-slide-generator-db-dev"
-      LAKEBASE_SCHEMA: "app_data_staging"
+      LAKEBASE_INSTANCE: "db-tellr"
+      LAKEBASE_SCHEMA: "app_data_dev"
     lakebase:
-      database_name: "db-tellr-dev"
-      schema: "app_data_dev2"
+      database_name: "db-tellr"
+      schema: "app_data_dev"
       capacity: "CU_1"  # Options: CU_1, CU_2, CU_4, CU_8
 
   production:

--- a/docs/technical/export-features.md
+++ b/docs/technical/export-features.md
@@ -160,11 +160,13 @@ Both export options are accessible through a unified dropdown menu in the slide 
 - Validates slide deck availability before queuing
 
 **Export Job Queue** (`src/api/services/export_job_queue.py`):
-- In-memory job queue using `asyncio.Queue`
+- Database-backed job tracking via `ExportJob` SQLAlchemy model
+- `asyncio.Queue` for local worker dispatch within each process
 - Background worker processes jobs in thread pool
 - Thread pool execution prevents blocking event loop during LLM calls
-- Progress tracking per job (slides completed / total)
-- Job cleanup after download
+- Progress tracking per job (slides completed / total) stored in DB
+- Job cleanup after download (deletes DB row + temp file)
+- Multi-worker safe: any process can read job status from the shared database
 
 **PPTX Converter Service** (`src/services/html_to_pptx.py`):
 - `HtmlToPptxConverterV3` class
@@ -277,7 +279,7 @@ Potential improvements for export features:
 - [ ] Export scheduling/automation
 - [ ] Compression options for PDF
 - [ ] Export quality presets (high/medium/low)
-- [ ] Persistent job storage (survive server restarts)
+- [x] Persistent job storage (survive server restarts) - **Implemented** (DB-backed ExportJob model)
 
 ## Related Documentation
 

--- a/src/database/models/__init__.py
+++ b/src/database/models/__init__.py
@@ -7,6 +7,7 @@ from src.database.models.profile import ConfigProfile
 from src.database.models.prompts import ConfigPrompts
 from src.database.models.session import (
     ChatRequest,
+    ExportJob,
     SessionMessage,
     SessionSlideDeck,
     SlideDeckVersion,
@@ -18,6 +19,7 @@ from src.database.models.slide_style_library import SlideStyleLibrary
 __all__ = [
     "ChatRequest",
     "ConfigAIInfra",
+    "ExportJob",
     "ConfigGenieSpace",
     "ConfigHistory",
     "ConfigProfile",

--- a/src/database/models/session.py
+++ b/src/database/models/session.py
@@ -54,6 +54,32 @@ class ChatRequest(Base):
         return f"<ChatRequest(request_id='{self.request_id}', status='{self.status}')>"
 
 
+class ExportJob(Base):
+    """Tracks async PPTX export jobs for polling.
+
+    Database-backed job tracking replaces the previous in-memory dict,
+    enabling multi-worker deployments where POST (enqueue) and GET (poll)
+    requests may hit different processes.
+    """
+
+    __tablename__ = "export_jobs"
+
+    id = Column(Integer, primary_key=True)
+    job_id = Column(String(64), unique=True, nullable=False, index=True)
+    session_id = Column(String(128), nullable=False)  # string session_id, not FK
+    status = Column(String(20), default="pending")  # pending/running/completed/error
+    progress = Column(Integer, default=0)
+    total_slides = Column(Integer, default=0)
+    title = Column(String(512), nullable=True)
+    output_path = Column(Text, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    completed_at = Column(DateTime, nullable=True)
+
+    def __repr__(self):
+        return f"<ExportJob(job_id='{self.job_id}', status='{self.status}')>"
+
+
 class UserSession(Base):
     """User session for tracking conversation state.
 

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ dev = [
     { name = "pytest-html" },
     { name = "pytest-metadata" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "twine" },
@@ -92,6 +93,7 @@ requires-dist = [
     { name = "pytest-html", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-metadata", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "python-pptx", specifier = ">=0.6.0" },
@@ -1158,6 +1160,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -4373,6 +4384,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the process-local export_jobs dict with a DB-backed ExportJob SQLAlchemy model, fixing multi-worker 404 "export job not found" errors when UVICORN_WORKERS > 1. Adds regression test that verifies poll succeeds after clearing in-memory state.