### PR TITLE
Filter empty sessions from history listing

### DIFF
--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -154,7 +154,7 @@ class SessionManager:
             List of session info dictionaries
         """
         with get_db_session() as db:
-            query = db.query(UserSession)
+            query = db.query(UserSession).filter(UserSession.messages.any())
 
             if user_id:
                 query = query.filter(UserSession.user_id == user_id)


### PR DESCRIPTION
Sessions with zero messages (created but never used) no longer appear
in the session history endpoint. Uses an EXISTS subquery via
UserSession.messages.any() to only return sessions that have at least
one message.

Co-authored-by: Cursor <cursoragent@cursor.com>