### PR TITLE
feat: Simplified local setup with browser-based SSO authentication

### DIFF
--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -15,19 +15,17 @@ Run the full stack locally for development and testing.
 git clone https://github.com/robertwhiffin/ai-slide-generator.git
 cd ai-slide-generator
 
-# 2. Copy .env.example and fill in your values
-cp .env.example .env
-# Edit .env with your Databricks workspace details
-
-# 3. Run automated setup
+# 2. Run automated setup
 ./quickstart/setup.sh
 
-# 4. Start the app
+# 3. Start the app
 ./start_app.sh
 
-# 5. Open http://localhost:3000
+# 4. Open http://localhost:3000
+#    - First run: Enter your Databricks workspace URL and sign in
+#    - Subsequent runs: Goes straight to the app
 
-# 6. To stop front and back end
+# 5. To stop front and back end
 ./stop_app.sh
 ```
 
@@ -36,6 +34,18 @@ The setup script will:
 - Create Python virtual environment with uv
 - Initialize PostgreSQL database
 - Install frontend dependencies
+
+## Authentication Options
+
+tellr supports multiple ways to authenticate with Databricks:
+
+| Method | How to Use |
+|--------|------------|
+| **Browser SSO** (recommended) | Just run the app — enter your workspace URL in the welcome screen and sign in via browser |
+| **Environment file** | Create `.env` with `DATABRICKS_HOST` and `DATABRICKS_TOKEN` (traditional method) |
+| **Databricks CLI** | If you have `~/.databrickscfg` configured, tellr will use it automatically |
+
+**No PAT tokens required** — the browser SSO method lets you sign in with your normal Databricks credentials.
 
 ## Manual Setup
 
@@ -173,10 +183,11 @@ environments:
 
 | Issue | Solution |
 |-------|----------|
-| `DATABRICKS_HOST not set` | Create `.env` file with credentials |
+| `DATABRICKS_HOST not set` | Use the welcome screen to enter your workspace URL, or create `.env` file |
 | `Database connection failed` | Run `./quickstart/setup_database.sh` |
 | `Port already in use` | Run `./stop_app.sh` first |
 | Deployment fails | Run with `--dry-run` to validate config |
+| Want to change workspace | Delete config and restart: `rm ~/.tellr/config.yaml && ./start_app.sh` |
 
 For more troubleshooting information, see the project's quickstart documentation.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -15,19 +15,17 @@ Run the full stack locally for development and testing.
 git clone https://github.com/robertwhiffin/ai-slide-generator.git
 cd ai-slide-generator
 
-# 2. Copy .env.example and fill in your values
-cp .env.example .env
-# Edit .env with your Databricks workspace details
-
-# 3. Run automated setup
+# 2. Run automated setup
 ./quickstart/setup.sh
 
-# 4. Start the app
+# 3. Start the app
 ./start_app.sh
 
-# 5. Open http://localhost:3000
+# 4. Open http://localhost:3000
+#    - First run: Enter your Databricks workspace URL and sign in
+#    - Subsequent runs: Goes straight to the app
 
-# 6. To stop front and back end
+# 5. To stop front and back end
 ./stop_app.sh
 ```
 
@@ -36,6 +34,18 @@ The setup script will:
 - Create Python virtual environment with uv
 - Initialize PostgreSQL database
 - Install frontend dependencies
+
+## Authentication Options
+
+tellr supports multiple ways to authenticate with Databricks:
+
+| Method | How to Use |
+|--------|------------|
+| **Browser SSO** (recommended) | Just run the app — enter your workspace URL in the welcome screen and sign in via browser |
+| **Environment file** | Create `.env` with `DATABRICKS_HOST` and `DATABRICKS_TOKEN` (traditional method) |
+| **Databricks CLI** | If you have `~/.databrickscfg` configured, tellr will use it automatically |
+
+**No PAT tokens required** — the browser SSO method lets you sign in with your normal Databricks credentials.
 
 ## Manual Setup
 
@@ -173,10 +183,11 @@ environments:
 
 | Issue | Solution |
 |-------|----------|
-| `DATABRICKS_HOST not set` | Create `.env` file with credentials |
+| `DATABRICKS_HOST not set` | Use the welcome screen to enter your workspace URL, or create `.env` file |
 | `Database connection failed` | Run `./quickstart/setup_database.sh` |
 | `Port already in use` | Run `./stop_app.sh` first |
 | Deployment fails | Run with `--dry-run` to validate config |
+| Want to change workspace | Delete config and restart: `rm ~/.tellr/config.yaml && ./start_app.sh` |
 
 For more troubleshooting information, see the troubleshooting guide in the quickstart directory at the project root.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
+import { useState, useEffect } from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AppLayout } from './components/Layout/AppLayout';
+import { WelcomeSetup } from './components/Setup';
 import './index.css';
 import { SelectionProvider } from './contexts/SelectionContext';
 import { ProfileProvider } from './contexts/ProfileContext';
@@ -28,6 +30,59 @@ function AppRoutes() {
 }
 
 function App() {
+  const [isConfigured, setIsConfigured] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // Check if the app is configured on load
+    const checkSetupStatus = async () => {
+      try {
+        const response = await fetch('/api/setup/status');
+        if (response.ok) {
+          const data = await response.json();
+          setIsConfigured(data.configured);
+        } else {
+          // If the endpoint doesn't exist (old version), assume configured
+          setIsConfigured(true);
+        }
+      } catch (error) {
+        // Network error or endpoint not available, assume configured
+        // This handles the case where the backend is the old version
+        console.warn('Setup status check failed, assuming configured:', error);
+        setIsConfigured(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkSetupStatus();
+  }, []);
+
+  const handleSetupComplete = () => {
+    setIsConfigured(true);
+  };
+
+  // Show loading state while checking configuration
+  if (isLoading) {
+    return (
+      <div style={{ 
+        minHeight: '100vh', 
+        display: 'flex', 
+        alignItems: 'center', 
+        justifyContent: 'center',
+        background: '#1a1a2e'
+      }}>
+        <div style={{ color: 'white' }}>Loading...</div>
+      </div>
+    );
+  }
+
+  // Show setup screen if not configured
+  if (!isConfigured) {
+    return <WelcomeSetup onSetupComplete={handleSetupComplete} />;
+  }
+
+  // Show main app if configured
   return (
     <ProfileProvider>
       <SessionProvider>

--- a/frontend/src/components/Setup/WelcomeSetup.css
+++ b/frontend/src/components/Setup/WelcomeSetup.css
@@ -1,0 +1,248 @@
+.welcome-setup {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  padding: 20px;
+}
+
+.welcome-card {
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  border-radius: 16px;
+  padding: 48px;
+  max-width: 480px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.welcome-header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.welcome-header h1 {
+  color: #ffffff;
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+}
+
+.welcome-header .subtitle {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 1rem;
+  margin: 0;
+}
+
+.setup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.form-group input {
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font-size: 1rem;
+  transition: all 0.2s ease;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: #4f9cf9;
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 0 0 3px rgba(79, 156, 249, 0.2);
+}
+
+.form-group input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.form-group input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.help-text {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.error-message {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  padding: 12px 16px;
+  color: #fca5a5;
+  font-size: 0.9rem;
+}
+
+.connect-button {
+  padding: 14px 24px;
+  background: linear-gradient(135deg, #4f9cf9 0%, #3b82f6 100%);
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.connect-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(79, 156, 249, 0.4);
+}
+
+.connect-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.sso-info {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.connecting-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 32px 0;
+}
+
+.connecting-state p {
+  color: rgba(255, 255, 255, 0.9);
+  margin: 0;
+  text-align: center;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  border-top-color: #4f9cf9;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.authenticate-state,
+.verifying-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.workspace-badge {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  border-radius: 8px;
+  padding: 12px 20px;
+  width: 100%;
+}
+
+.badge-icon {
+  color: #22c55e;
+  font-size: 1.2rem;
+}
+
+.badge-text {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.9rem;
+  word-break: break-all;
+}
+
+.auth-instruction {
+  color: rgba(255, 255, 255, 0.8);
+  text-align: center;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.auth-steps {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 16px 20px;
+  width: 100%;
+}
+
+.auth-steps p {
+  color: rgba(255, 255, 255, 0.9);
+  margin: 0 0 12px 0;
+}
+
+.auth-steps ol {
+  color: rgba(255, 255, 255, 0.7);
+  margin: 0;
+  padding-left: 20px;
+}
+
+.auth-steps li {
+  margin-bottom: 8px;
+}
+
+.auth-steps li:last-child {
+  margin-bottom: 0;
+}
+
+.back-button {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 8px 16px;
+  transition: all 0.2s ease;
+}
+
+.back-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.secondary-button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.9rem;
+  padding: 10px 20px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.secondary-button:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+}

--- a/frontend/src/components/Setup/WelcomeSetup.tsx
+++ b/frontend/src/components/Setup/WelcomeSetup.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import './WelcomeSetup.css';
+
+interface WelcomeSetupProps {
+  onSetupComplete: () => void;
+}
+
+export function WelcomeSetup({ onSetupComplete }: WelcomeSetupProps) {
+  const [workspaceUrl, setWorkspaceUrl] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [step, setStep] = useState<'input' | 'authenticate' | 'verifying'>('input');
+  const [savedUrl, setSavedUrl] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      // Normalize the URL
+      let url = workspaceUrl.trim();
+      if (!url.startsWith('http://') && !url.startsWith('https://')) {
+        url = `https://${url}`;
+      }
+      url = url.replace(/\/$/, ''); // Remove trailing slash
+
+      // Save the configuration
+      const response = await fetch('/api/setup/configure', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ host: url }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        let errorMsg = 'Failed to save configuration';
+        if (data.detail) {
+          if (Array.isArray(data.detail)) {
+            errorMsg = data.detail.map((e: { msg?: string }) => e.msg || String(e)).join(', ');
+          } else if (typeof data.detail === 'string') {
+            errorMsg = data.detail;
+          }
+        }
+        throw new Error(errorMsg);
+      }
+
+      setSavedUrl(url);
+      setStep('authenticate');
+      
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleOpenAuth = () => {
+    // Open authentication in a popup window
+    const width = 500;
+    const height = 700;
+    const left = window.screenX + (window.outerWidth - width) / 2;
+    const top = window.screenY + (window.outerHeight - height) / 2;
+    
+    // Trigger the OAuth flow - this opens Databricks auth
+    fetch('/api/setup/test-connection', { method: 'POST' })
+      .then(response => {
+        if (response.ok) {
+          // Auth succeeded, move to main app
+          onSetupComplete();
+        }
+      })
+      .catch(() => {
+        // Will handle in verify step
+      });
+
+    // Show verifying state after a short delay
+    setTimeout(() => {
+      setStep('verifying');
+    }, 1000);
+  };
+
+  const handleVerifyConnection = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/setup/test-connection', {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        let errorMsg = 'Connection failed. Please try signing in again.';
+        if (data.detail) {
+          if (Array.isArray(data.detail)) {
+            errorMsg = data.detail.map((e: { msg?: string }) => e.msg || String(e)).join(', ');
+          } else if (typeof data.detail === 'string') {
+            errorMsg = data.detail;
+          }
+        }
+        throw new Error(errorMsg);
+      }
+
+      // Success!
+      onSetupComplete();
+      
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="welcome-setup">
+      <div className="welcome-card">
+        <div className="welcome-header">
+          <h1>Welcome to tellr</h1>
+          <p className="subtitle">AI-powered slide generator for Databricks</p>
+        </div>
+
+        {step === 'input' && (
+          <form onSubmit={handleSubmit} className="setup-form">
+            <div className="form-group">
+              <label htmlFor="workspace-url">
+                Enter your Databricks workspace URL
+              </label>
+              <input
+                id="workspace-url"
+                type="text"
+                value={workspaceUrl}
+                onChange={(e) => setWorkspaceUrl(e.target.value)}
+                placeholder="https://your-workspace.cloud.databricks.com"
+                disabled={isLoading}
+                autoFocus
+              />
+              <p className="help-text">
+                This is the URL you use to access your Databricks workspace.
+              </p>
+            </div>
+
+            {error && (
+              <div className="error-message">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              className="connect-button"
+              disabled={!workspaceUrl.trim() || isLoading}
+            >
+              {isLoading ? 'Saving...' : 'Continue'}
+            </button>
+          </form>
+        )}
+
+        {step === 'authenticate' && (
+          <div className="authenticate-state">
+            <div className="workspace-badge">
+              <span className="badge-icon">✓</span>
+              <span className="badge-text">{savedUrl}</span>
+            </div>
+
+            <p className="auth-instruction">
+              Click below to sign in with your Databricks account.
+              <br />
+              A new window will open for authentication.
+            </p>
+
+            {error && (
+              <div className="error-message">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="button"
+              className="connect-button"
+              onClick={handleOpenAuth}
+            >
+              Sign in with Databricks
+            </button>
+
+            <button
+              type="button"
+              className="back-button"
+              onClick={() => setStep('input')}
+            >
+              ← Change workspace URL
+            </button>
+          </div>
+        )}
+
+        {step === 'verifying' && (
+          <div className="verifying-state">
+            <div className="workspace-badge">
+              <span className="badge-icon">✓</span>
+              <span className="badge-text">{savedUrl}</span>
+            </div>
+
+            <div className="auth-steps">
+              <p><strong>Complete these steps:</strong></p>
+              <ol>
+                <li>Sign in to Databricks in the popup window</li>
+                <li>When you see "You can close this tab", close the popup</li>
+                <li>Click the button below to continue</li>
+              </ol>
+            </div>
+
+            {error && (
+              <div className="error-message">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="button"
+              className="connect-button"
+              onClick={handleVerifyConnection}
+              disabled={isLoading}
+            >
+              {isLoading ? 'Verifying...' : "I've signed in - Continue →"}
+            </button>
+
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={handleOpenAuth}
+            >
+              Open sign-in window again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Setup/WelcomeSetup.tsx
+++ b/frontend/src/components/Setup/WelcomeSetup.tsx
@@ -58,13 +58,7 @@ export function WelcomeSetup({ onSetupComplete }: WelcomeSetupProps) {
   };
 
   const handleOpenAuth = () => {
-    // Open authentication in a popup window
-    const width = 500;
-    const height = 700;
-    const left = window.screenX + (window.outerWidth - width) / 2;
-    const top = window.screenY + (window.outerHeight - height) / 2;
-    
-    // Trigger the OAuth flow - this opens Databricks auth
+    // Trigger the OAuth flow - this opens Databricks auth in browser
     fetch('/api/setup/test-connection', { method: 'POST' })
       .then(response => {
         if (response.ok) {

--- a/frontend/src/components/Setup/index.ts
+++ b/frontend/src/components/Setup/index.ts
@@ -1,0 +1,1 @@
+export { WelcomeSetup } from './WelcomeSetup';

--- a/frontend/src/components/UpdateBanner/UpdateBanner.tsx
+++ b/frontend/src/components/UpdateBanner/UpdateBanner.tsx
@@ -12,12 +12,15 @@ interface UpdateBannerProps {
   latestVersion: string;
   updateType: 'patch' | 'major';
   onDismiss: () => void;
+  /** Optional custom message to override the default update text */
+  customMessage?: string;
 }
 
 export const UpdateBanner: React.FC<UpdateBannerProps> = ({
   latestVersion,
   updateType,
   onDismiss,
+  customMessage,
 }) => {
   const isPatch = updateType === 'patch';
 
@@ -30,9 +33,11 @@ export const UpdateBanner: React.FC<UpdateBannerProps> = ({
     ? 'text-blue-600 hover:text-blue-800'
     : 'text-amber-600 hover:text-amber-800';
 
-  const message = isPatch
-    ? `A new version (v${latestVersion}) is available. Redeploy the app to update.`
-    : `A new version (v${latestVersion}) is available. This update requires running the update command from databricks-tellr.`;
+  const message = customMessage
+    ? customMessage
+    : isPatch
+      ? `A new version (v${latestVersion}) is available. Redeploy the app to update.`
+      : `A new version (v${latestVersion}) is available. This update requires running the update command from databricks-tellr.`;
 
   return (
     <div className={`${bgColor} ${borderColor} border-b px-4 py-2`}>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
   },
 })

--- a/quickstart/PREREQUISITES.md
+++ b/quickstart/PREREQUISITES.md
@@ -221,8 +221,12 @@ Use [nvm-windows](https://github.com/coreybutler/nvm-windows)
   - Create Genie spaces
   - Generate personal access tokens
 
-### 1. Create Personal Access Token
+### 1. Authenticate with Databricks
 
+**Option A — Browser SSO (recommended, no PAT needed):**
+When you first open the app at http://localhost:3000, a welcome screen will ask for your workspace URL. Enter it, and sign in via your browser using your normal Databricks credentials (SSO). No access token or `.env` file required.
+
+**Option B — Personal Access Token (traditional):**
 1. **Login** to your Databricks workspace
 2. **Click** your user icon (top right)
 3. **Go to** Settings → Developer

--- a/quickstart/QUICKSTART.md
+++ b/quickstart/QUICKSTART.md
@@ -143,6 +143,11 @@ brew services start postgresql@14
 ```
 
 ### "DATABRICKS_HOST or DATABRICKS_TOKEN not set"
+
+**Option A — UI authentication (recommended):**
+Simply open http://localhost:3000, enter your workspace URL in the welcome screen, and sign in via browser. No `.env` file needed.
+
+**Option B — Environment file:**
 1. Create `.env` file: `cp .env.example .env`
 2. Edit and set values: `nano .env`
 3. Restart app: `./stop_app.sh && ./start_app.sh`

--- a/quickstart/TROUBLESHOOTING.md
+++ b/quickstart/TROUBLESHOOTING.md
@@ -19,7 +19,10 @@ Common issues and solutions for the AI Slide Generator.
 
 **Problem:** Application can't find environment configuration.
 
-**Solution:**
+**Solution A — Use UI authentication (no `.env` needed):**
+Open http://localhost:3000, enter your workspace URL in the welcome screen, and sign in via browser. Configuration is saved to `~/.tellr/config.yaml` automatically.
+
+**Solution B — Create `.env` file:**
 ```bash
 # Copy template and edit
 cp .env.example .env

--- a/quickstart/TROUBLESHOOTING.md
+++ b/quickstart/TROUBLESHOOTING.md
@@ -172,6 +172,19 @@ DATABRICKS_HOST=http://your-workspace.cloud.databricks.com
    - No spaces or quotes
    - Full token copied
 
+### Want to switch workspace or re-authenticate
+
+**Problem:** You want to connect to a different Databricks workspace or re-do the SSO login.
+
+**Solution:**
+```bash
+# Remove saved config and restart — the welcome screen will appear again
+rm ~/.tellr/config.yaml
+./start_app.sh
+```
+
+This only affects the UI authentication. If you use a `.env` file, edit that instead.
+
 ### "Genie space not found"
 
 **Problem:** Configured Genie space doesn't exist or you don't have access.

--- a/scripts/tellr_cli.py
+++ b/scripts/tellr_cli.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+tellr CLI - Simple command-line interface for managing the tellr app.
+
+Usage:
+    tellr          # Start the app (default)
+    tellr start    # Start the app
+    tellr stop     # Stop the app  
+    tellr status   # Check if running
+    tellr init     # Initialize database (first run)
+    tellr reset    # Reset configuration
+
+This CLI is installed by Homebrew and wraps the existing shell scripts.
+"""
+
+import os
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
+import click
+
+# Determine TELLR_HOME - where the app is installed
+TELLR_HOME = Path(os.environ.get("TELLR_HOME", Path(__file__).parent.parent))
+TELLR_CONFIG_PATH = Path.home() / ".tellr" / "config.yaml"
+
+
+def get_pid_file(name: str) -> Path:
+    """Get path to PID file."""
+    return TELLR_HOME / "logs" / f"{name}.pid"
+
+
+def is_process_running(pid: int) -> bool:
+    """Check if a process with given PID is running."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def read_pid(name: str) -> int | None:
+    """Read PID from file, return None if not found or invalid."""
+    pid_file = get_pid_file(name)
+    if not pid_file.exists():
+        return None
+    try:
+        pid = int(pid_file.read_text().strip())
+        return pid if is_process_running(pid) else None
+    except (ValueError, IOError):
+        return None
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx):
+    """tellr - AI-powered slide generator for Databricks.
+    
+    Run 'tellr' to start the app, or 'tellr --help' for more commands.
+    """
+    if ctx.invoked_subcommand is None:
+        # Default action: start
+        ctx.invoke(start)
+
+
+@cli.command()
+@click.option("--no-browser", is_flag=True, help="Don't open browser automatically")
+def start(no_browser: bool):
+    """Start the tellr application."""
+    
+    # Check if already running
+    backend_pid = read_pid("backend")
+    if backend_pid:
+        click.echo(f"tellr is already running (PID: {backend_pid})")
+        click.echo("Visit http://localhost:3000 in your browser")
+        if not no_browser:
+            webbrowser.open("http://localhost:3000")
+        return
+    
+    click.echo("Starting tellr...")
+    
+    # Ensure logs directory exists
+    logs_dir = TELLR_HOME / "logs"
+    logs_dir.mkdir(exist_ok=True)
+    
+    # Ensure PostgreSQL is running (for Homebrew installations)
+    try:
+        result = subprocess.run(
+            ["brew", "services", "list"],
+            capture_output=True,
+            text=True,
+        )
+        if "postgresql" in result.stdout and "started" not in result.stdout:
+            click.echo("Starting PostgreSQL...")
+            subprocess.run(["brew", "services", "start", "postgresql@14"], capture_output=True)
+            time.sleep(2)  # Give PostgreSQL time to start
+    except FileNotFoundError:
+        # Homebrew not installed, assume PostgreSQL is managed differently
+        pass
+    
+    # Check if database needs initialization
+    if not (TELLR_HOME / ".db_initialized").exists():
+        click.echo("Initializing database (first run)...")
+        init_result = subprocess.run(
+            [sys.executable, str(TELLR_HOME / "scripts" / "init_database.py")],
+            cwd=TELLR_HOME,
+            capture_output=True,
+            text=True,
+        )
+        if init_result.returncode == 0:
+            (TELLR_HOME / ".db_initialized").touch()
+        else:
+            click.echo(f"Warning: Database initialization may have failed: {init_result.stderr}")
+    
+    # Run the start script
+    start_script = TELLR_HOME / "start_app.sh"
+    if start_script.exists():
+        env = os.environ.copy()
+        env["TELLR_HOME"] = str(TELLR_HOME)
+        
+        result = subprocess.run(
+            ["bash", str(start_script)],
+            cwd=TELLR_HOME,
+            env=env,
+        )
+        
+        if result.returncode == 0:
+            click.echo("")
+            click.echo("✓ tellr is running!")
+            click.echo("")
+            
+            # Check if this is first run (no config)
+            if not TELLR_CONFIG_PATH.exists():
+                click.echo("First run detected. Opening browser for setup...")
+                click.echo("Enter your Databricks workspace URL to get started.")
+            
+            click.echo("Visit http://localhost:3000 in your browser")
+            
+            if not no_browser:
+                time.sleep(2)  # Give frontend time to start
+                webbrowser.open("http://localhost:3000")
+        else:
+            click.echo("Failed to start tellr. Check logs/backend.log for details.", err=True)
+            sys.exit(1)
+    else:
+        click.echo(f"Start script not found: {start_script}", err=True)
+        sys.exit(1)
+
+
+@cli.command()
+def stop():
+    """Stop the tellr application."""
+    click.echo("Stopping tellr...")
+    
+    stop_script = TELLR_HOME / "stop_app.sh"
+    if stop_script.exists():
+        subprocess.run(["bash", str(stop_script)], cwd=TELLR_HOME)
+        click.echo("tellr stopped.")
+    else:
+        # Manual cleanup
+        for name in ["backend", "frontend"]:
+            pid = read_pid(name)
+            if pid:
+                try:
+                    os.kill(pid, 15)  # SIGTERM
+                    click.echo(f"Stopped {name} (PID: {pid})")
+                except OSError:
+                    pass
+                get_pid_file(name).unlink(missing_ok=True)
+        click.echo("tellr stopped.")
+
+
+@cli.command()
+def status():
+    """Check if tellr is running."""
+    backend_pid = read_pid("backend")
+    frontend_pid = read_pid("frontend")
+    
+    if backend_pid:
+        click.echo(f"Backend:  running (PID: {backend_pid})")
+    else:
+        click.echo("Backend:  not running")
+    
+    if frontend_pid:
+        click.echo(f"Frontend: running (PID: {frontend_pid})")
+    else:
+        click.echo("Frontend: not running")
+    
+    if backend_pid:
+        click.echo("")
+        click.echo("Visit http://localhost:3000 in your browser")
+    
+    # Show config status
+    click.echo("")
+    if TELLR_CONFIG_PATH.exists():
+        import yaml
+        with open(TELLR_CONFIG_PATH) as f:
+            config = yaml.safe_load(f)
+        host = config.get("databricks", {}).get("host", "Not configured")
+        click.echo(f"Workspace: {host}")
+    else:
+        click.echo("Workspace: Not configured (will prompt on first use)")
+
+
+@cli.command()
+def init():
+    """Initialize the database (usually done automatically on first start)."""
+    click.echo("Initializing database...")
+    
+    result = subprocess.run(
+        [sys.executable, str(TELLR_HOME / "scripts" / "init_database.py")],
+        cwd=TELLR_HOME,
+    )
+    
+    if result.returncode == 0:
+        (TELLR_HOME / ".db_initialized").touch()
+        click.echo("Database initialized successfully.")
+    else:
+        click.echo("Database initialization failed.", err=True)
+        sys.exit(1)
+
+
+@cli.command()
+def reset():
+    """Reset tellr configuration (removes saved workspace URL)."""
+    if TELLR_CONFIG_PATH.exists():
+        TELLR_CONFIG_PATH.unlink()
+        click.echo("Configuration reset. You'll be prompted for workspace URL on next start.")
+    else:
+        click.echo("No configuration to reset.")
+
+
+@cli.command()
+def logs():
+    """Show recent logs."""
+    log_file = TELLR_HOME / "logs" / "backend.log"
+    if log_file.exists():
+        # Show last 50 lines
+        result = subprocess.run(
+            ["tail", "-50", str(log_file)],
+            capture_output=True,
+            text=True,
+        )
+        click.echo(result.stdout)
+    else:
+        click.echo("No logs found.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -8,23 +8,17 @@ import asyncio
 import logging
 import os
 from contextlib import ExitStack, asynccontextmanager
-from pathlib import Path
 from importlib import resources
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from src.api.routes import chat, images, slides, export, sessions, verification, version, setup
+from src.api.routes import chat, images, slides, export, sessions, verification, version, setup, local_version
 from src.core.databricks_client import create_user_client, set_user_client
 from src.core.user_context import get_current_user as get_ctx_user, set_current_user
-from src.core.database import (
-    init_db,
-    is_lakebase_environment,
-    start_token_refresh,
-    stop_token_refresh,
-)
 from src.api.routes.settings import (
     ai_infra_router,
     deck_prompts_router,
@@ -33,8 +27,15 @@ from src.api.routes.settings import (
     prompts_router,
     slide_styles_router,
 )
-from src.api.services.job_queue import recover_stuck_requests, start_worker
 from src.api.services.export_job_queue import start_export_worker
+from src.api.services.job_queue import recover_stuck_requests, start_worker
+from src.core.database import (
+    init_db,
+    is_lakebase_environment,
+    start_token_refresh,
+    stop_token_refresh,
+)
+from src.core.databricks_client import create_user_client, set_user_client
 
 logger = logging.getLogger(__name__)
 
@@ -289,6 +290,7 @@ app.include_router(sessions.router)
 app.include_router(verification.router)
 app.include_router(version.router)
 app.include_router(setup.router)
+app.include_router(local_version.router)
 
 # Configuration management routers
 app.include_router(profiles_router, prefix="/api/settings", tags=["settings"])

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -16,7 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from src.api.routes import chat, images, slides, export, sessions, verification, version
+from src.api.routes import chat, images, slides, export, sessions, verification, version, setup
 from src.core.databricks_client import create_user_client, set_user_client
 from src.core.user_context import get_current_user as get_ctx_user, set_current_user
 from src.core.database import (
@@ -288,6 +288,7 @@ app.include_router(export.router)
 app.include_router(sessions.router)
 app.include_router(verification.router)
 app.include_router(version.router)
+app.include_router(setup.router)
 
 # Configuration management routers
 app.include_router(profiles_router, prefix="/api/settings", tags=["settings"])

--- a/src/api/routes/setup.py
+++ b/src/api/routes/setup.py
@@ -1,0 +1,158 @@
+"""Setup API routes for first-time configuration.
+
+These endpoints are used by the frontend to configure the app on first run,
+primarily for Homebrew installations where users need to enter their
+Databricks workspace URL.
+"""
+
+import logging
+import re
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, field_validator
+
+from src.core.databricks_client import (
+    get_tellr_config,
+    save_tellr_config,
+    is_tellr_configured,
+    reset_client,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/setup", tags=["setup"])
+
+
+class SetupStatusResponse(BaseModel):
+    """Response for setup status check."""
+    configured: bool
+    host: Optional[str] = None
+
+
+class ConfigureWorkspaceRequest(BaseModel):
+    """Request to configure workspace URL."""
+    host: str
+    
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, v: str) -> str:
+        """Validate and normalize the workspace URL."""
+        # Remove trailing slashes
+        v = v.rstrip("/")
+        
+        # Add https:// if not present
+        if not v.startswith("http://") and not v.startswith("https://"):
+            v = f"https://{v}"
+        
+        # Validate it looks like a Databricks URL
+        # Common patterns: *.cloud.databricks.com, *.azuredatabricks.net, etc.
+        databricks_patterns = [
+            r"https://[\w\-]+\.cloud\.databricks\.com",
+            r"https://[\w\-\.]+\.azuredatabricks\.net",  # Azure: adb-123456.18.azuredatabricks.net
+            r"https://[\w\-]+\.gcp\.databricks\.com",
+            r"https://[\w\-]+\.databricks\.com",
+            r"https://[\w\-\.]+\.databricks\.com",
+        ]
+        
+        is_valid = any(re.match(pattern, v) for pattern in databricks_patterns)
+        if not is_valid:
+            raise ValueError(
+                "Invalid Databricks workspace URL. "
+                "Expected format: https://your-workspace.cloud.databricks.com"
+            )
+        
+        return v
+
+
+class ConfigureWorkspaceResponse(BaseModel):
+    """Response after configuring workspace."""
+    success: bool
+    message: str
+    host: str
+
+
+@router.get("/status", response_model=SetupStatusResponse)
+async def get_setup_status():
+    """
+    Check if the app has been configured with a Databricks workspace.
+    
+    Returns configured=True if ~/.tellr/config.yaml exists with a valid host,
+    or if DATABRICKS_HOST environment variable is set.
+    """
+    import os
+    
+    # Check tellr config file first
+    if is_tellr_configured():
+        config = get_tellr_config()
+        host = config.get("databricks", {}).get("host") if config else None
+        return SetupStatusResponse(configured=True, host=host)
+    
+    # Fall back to environment variable
+    env_host = os.getenv("DATABRICKS_HOST")
+    if env_host:
+        return SetupStatusResponse(configured=True, host=env_host)
+    
+    return SetupStatusResponse(configured=False, host=None)
+
+
+@router.post("/configure", response_model=ConfigureWorkspaceResponse)
+async def configure_workspace(request: ConfigureWorkspaceRequest):
+    """
+    Configure the Databricks workspace URL.
+    
+    Saves the workspace URL to ~/.tellr/config.yaml with OAuth browser
+    authentication enabled. On the next API call that requires Databricks
+    access, the browser will open for SSO login.
+    """
+    try:
+        # Save the configuration
+        save_tellr_config(host=request.host, auth_type="external-browser")
+        
+        # Reset the client so it picks up the new config
+        reset_client()
+        
+        logger.info(f"Workspace configured: {request.host}")
+        
+        return ConfigureWorkspaceResponse(
+            success=True,
+            message="Workspace configured successfully. SSO login will be triggered on first use.",
+            host=request.host,
+        )
+        
+    except Exception as e:
+        logger.error(f"Failed to configure workspace: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to save configuration: {str(e)}"
+        )
+
+
+@router.post("/test-connection")
+async def test_connection():
+    """
+    Test the Databricks connection after configuration.
+    
+    This will trigger the OAuth browser flow if using external-browser auth.
+    Returns user info on success.
+    """
+    try:
+        from src.core.databricks_client import get_system_client
+        
+        client = get_system_client(force_new=True)
+        user = client.current_user.me()
+        
+        return {
+            "success": True,
+            "message": "Connection successful",
+            "user": {
+                "username": user.user_name,
+                "display_name": user.display_name or user.user_name,
+            }
+        }
+        
+    except Exception as e:
+        logger.error(f"Connection test failed: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Connection failed: {str(e)}"
+        )

--- a/src/core/databricks_client.py
+++ b/src/core/databricks_client.py
@@ -93,16 +93,16 @@ TELLR_CONFIG_PATH = Path.home() / ".tellr" / "config.yaml"
 def get_tellr_config() -> Optional[dict]:
     """
     Load tellr config from ~/.tellr/config.yaml if it exists.
-    
+
     This config is created by the Homebrew formula or when user configures
     their workspace URL through the UI.
-    
+
     Returns:
         Config dict or None if no config file exists
     """
     if not TELLR_CONFIG_PATH.exists():
         return None
-    
+
     try:
         with open(TELLR_CONFIG_PATH) as f:
             config = yaml.safe_load(f)
@@ -116,25 +116,25 @@ def get_tellr_config() -> Optional[dict]:
 def save_tellr_config(host: str, auth_type: str = "external-browser") -> None:
     """
     Save tellr config to ~/.tellr/config.yaml.
-    
+
     Called when user configures their workspace URL through the UI.
-    
+
     Args:
         host: Databricks workspace URL (e.g., https://mycompany.cloud.databricks.com)
         auth_type: Authentication type (default: external-browser for OAuth SSO)
     """
     TELLR_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    
+
     config = {
         "databricks": {
             "host": host,
             "auth_type": auth_type,
         }
     }
-    
+
     with open(TELLR_CONFIG_PATH, "w") as f:
         yaml.dump(config, f, default_flow_style=False)
-    
+
     logger.info(f"Saved tellr config to {TELLR_CONFIG_PATH}")
 
 
@@ -143,7 +143,7 @@ def is_tellr_configured() -> bool:
     config = get_tellr_config()
     if not config:
         return False
-    
+
     databricks_config = config.get("databricks", {})
     return bool(databricks_config.get("host"))
 
@@ -162,13 +162,35 @@ class DatabricksClientError(Exception):
     pass
 
 
+def _refresh_oauth_env_token() -> None:
+    """Keep DATABRICKS_TOKEN fresh for MLflow when using SSO/OAuth.
+
+    The Databricks SDK handles token refresh internally, but MLflow
+    reads DATABRICKS_TOKEN from the environment.  This silently
+    updates the env var with the latest token from the SDK so MLflow
+    never sees an expired credential.  No-op for PAT/.env users.
+    """
+    if _system_client is None:
+        return
+    cfg = get_tellr_config()
+    if not cfg or cfg.get("databricks", {}).get("auth_type") != "external-browser":
+        return
+    try:
+        headers = _system_client.config.authenticate()
+        bearer = headers.get("Authorization", "")
+        if bearer.startswith("Bearer "):
+            os.environ["DATABRICKS_TOKEN"] = bearer[7:]
+    except Exception:
+        pass  # non-critical; existing token may still be valid
+
+
 def get_system_client(force_new: bool = False) -> WorkspaceClient:
     """
     Get the system-level WorkspaceClient (service principal).
 
     Used for system operations like loading settings, health checks,
-    and database operations. 
-    
+    and database operations.
+
     Authentication priority:
     1. Tellr config file (~/.tellr/config.yaml) - for Homebrew/OAuth installations
     2. Environment variables - for traditional local development or production
@@ -186,6 +208,7 @@ def get_system_client(force_new: bool = False) -> WorkspaceClient:
 
     # Fast path: return existing instance without locking
     if _system_client is not None and not force_new:
+        _refresh_oauth_env_token()
         return _system_client
 
     # Slow path: create new instance with lock
@@ -199,8 +222,10 @@ def get_system_client(force_new: bool = False) -> WorkspaceClient:
 
             # Check for tellr config file first (Homebrew/OAuth installations)
             tellr_config = get_tellr_config()
-            
-            if tellr_config and tellr_config.get("databricks", {}).get("auth_type") == "external-browser":
+
+            db_cfg = tellr_config.get("databricks", {}) if tellr_config else {}
+            auth_type = db_cfg.get("auth_type")
+            if auth_type == "external-browser":
                 # OAuth browser authentication - opens browser for SSO
                 host = tellr_config["databricks"]["host"]
                 logger.info(f"Initializing Databricks client with OAuth browser auth for {host}")
@@ -210,7 +235,24 @@ def get_system_client(force_new: bool = False) -> WorkspaceClient:
                     product=PRODUCT_NAME_SYSTEM,
                     product_version=version,
                 )
-                logger.info("Databricks client initialized with OAuth browser authentication")
+                # MLflow doesn't support external-browser OAuth natively.
+                # Extract the bearer token from the authenticated SDK
+                # client and set it as DATABRICKS_TOKEN so MLflow and
+                # other tools can authenticate via standard env vars.
+                os.environ["DATABRICKS_HOST"] = host
+                try:
+                    headers = _system_client.config.authenticate()
+                    bearer = headers.get("Authorization", "")
+                    if bearer.startswith("Bearer "):
+                        os.environ["DATABRICKS_TOKEN"] = bearer[7:]
+                        logger.info(
+                            "Set DATABRICKS_TOKEN from OAuth for MLflow"
+                        )
+                except Exception as e:
+                    logger.warning(f"Could not extract OAuth token: {e}")
+                logger.info(
+                    "Databricks client initialized with OAuth browser auth"
+                )
             else:
                 # Traditional authentication via environment variables
                 logger.info(
@@ -222,7 +264,8 @@ def get_system_client(force_new: bool = False) -> WorkspaceClient:
                     product_version=version,
                 )
 
-            # Skip verification in development/test mode - allows local dev and tests without valid token
+            # Skip verification in dev/test mode
+            # Allows local dev and tests without valid token
             if os.getenv("ENVIRONMENT") in ("development", "test"):
                 logger.info("Dev/test mode: skipping Databricks connection verification")
                 return _system_client
@@ -511,7 +554,6 @@ def ensure_workspace_folder(folder_path: str) -> None:
     Raises:
         DatabricksClientError: If folder creation fails
     """
-    from databricks.sdk.service.workspace import ImportFormat
 
     try:
         client = get_system_client()

--- a/src/core/databricks_client.py
+++ b/src/core/databricks_client.py
@@ -10,6 +10,8 @@ The user client is set per-request via middleware and stored in a ContextVar.
 Both client types set product tracking headers for API call attribution:
 - System client: product="tellr-app-system", product_version from package
 - User client: product="tellr-app-{hashed_user_id}"
+
+For Homebrew installations, supports OAuth browser authentication via config file.
 """
 
 import hashlib
@@ -17,8 +19,10 @@ import logging
 import os
 import threading
 from contextvars import ContextVar
+from pathlib import Path
 from typing import Optional
 
+import yaml
 from databricks.sdk import WorkspaceClient
 
 logger = logging.getLogger(__name__)
@@ -78,6 +82,71 @@ def _hash_username(username: str) -> str:
     local_part = username.split("@")[0] if "@" in username else username
     return hashlib.sha256(local_part.encode()).hexdigest()[:12]
 
+
+# =============================================================================
+# Tellr Config File Support (for Homebrew installations)
+# =============================================================================
+
+TELLR_CONFIG_PATH = Path.home() / ".tellr" / "config.yaml"
+
+
+def get_tellr_config() -> Optional[dict]:
+    """
+    Load tellr config from ~/.tellr/config.yaml if it exists.
+    
+    This config is created by the Homebrew formula or when user configures
+    their workspace URL through the UI.
+    
+    Returns:
+        Config dict or None if no config file exists
+    """
+    if not TELLR_CONFIG_PATH.exists():
+        return None
+    
+    try:
+        with open(TELLR_CONFIG_PATH) as f:
+            config = yaml.safe_load(f)
+            logger.info(f"Loaded tellr config from {TELLR_CONFIG_PATH}")
+            return config
+    except Exception as e:
+        logger.warning(f"Failed to load tellr config: {e}")
+        return None
+
+
+def save_tellr_config(host: str, auth_type: str = "external-browser") -> None:
+    """
+    Save tellr config to ~/.tellr/config.yaml.
+    
+    Called when user configures their workspace URL through the UI.
+    
+    Args:
+        host: Databricks workspace URL (e.g., https://mycompany.cloud.databricks.com)
+        auth_type: Authentication type (default: external-browser for OAuth SSO)
+    """
+    TELLR_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    
+    config = {
+        "databricks": {
+            "host": host,
+            "auth_type": auth_type,
+        }
+    }
+    
+    with open(TELLR_CONFIG_PATH, "w") as f:
+        yaml.dump(config, f, default_flow_style=False)
+    
+    logger.info(f"Saved tellr config to {TELLR_CONFIG_PATH}")
+
+
+def is_tellr_configured() -> bool:
+    """Check if tellr has been configured with a workspace URL."""
+    config = get_tellr_config()
+    if not config:
+        return False
+    
+    databricks_config = config.get("databricks", {})
+    return bool(databricks_config.get("host"))
+
 # =============================================================================
 # System Client (Singleton - Service Principal)
 # =============================================================================
@@ -98,7 +167,11 @@ def get_system_client(force_new: bool = False) -> WorkspaceClient:
     Get the system-level WorkspaceClient (service principal).
 
     Used for system operations like loading settings, health checks,
-    and database operations. Uses environment variables for authentication.
+    and database operations. 
+    
+    Authentication priority:
+    1. Tellr config file (~/.tellr/config.yaml) - for Homebrew/OAuth installations
+    2. Environment variables - for traditional local development or production
 
     Args:
         force_new: If True, create a new client instance (useful for testing)
@@ -123,14 +196,31 @@ def get_system_client(force_new: bool = False) -> WorkspaceClient:
 
         try:
             version = _get_package_version()
-            logger.info(
-                "Initializing system Databricks client from environment",
-                extra={"product": PRODUCT_NAME_SYSTEM, "product_version": version},
-            )
-            _system_client = WorkspaceClient(
-                product=PRODUCT_NAME_SYSTEM,
-                product_version=version,
-            )
+
+            # Check for tellr config file first (Homebrew/OAuth installations)
+            tellr_config = get_tellr_config()
+            
+            if tellr_config and tellr_config.get("databricks", {}).get("auth_type") == "external-browser":
+                # OAuth browser authentication - opens browser for SSO
+                host = tellr_config["databricks"]["host"]
+                logger.info(f"Initializing Databricks client with OAuth browser auth for {host}")
+                _system_client = WorkspaceClient(
+                    host=host,
+                    auth_type="external-browser",
+                    product=PRODUCT_NAME_SYSTEM,
+                    product_version=version,
+                )
+                logger.info("Databricks client initialized with OAuth browser authentication")
+            else:
+                # Traditional authentication via environment variables
+                logger.info(
+                    "Initializing system Databricks client from environment",
+                    extra={"product": PRODUCT_NAME_SYSTEM, "product_version": version},
+                )
+                _system_client = WorkspaceClient(
+                    product=PRODUCT_NAME_SYSTEM,
+                    product_version=version,
+                )
 
             # Skip verification in development/test mode - allows local dev and tests without valid token
             if os.getenv("ENVIRONMENT") in ("development", "test"):
@@ -140,11 +230,12 @@ def get_system_client(force_new: bool = False) -> WorkspaceClient:
             # Verify connection (production/staging only)
             try:
                 current_user = _system_client.current_user.me()
+                auth_method = "oauth_browser" if tellr_config else "service_principal"
                 logger.info(
                     "System Databricks client initialized",
                     extra={
                         "user": current_user.user_name,
-                        "auth_method": "service_principal",
+                        "auth_method": auth_method,
                     },
                 )
             except Exception as e:

--- a/start_app.sh
+++ b/start_app.sh
@@ -9,6 +9,7 @@ echo "🚀 Starting AI Slide Generator..."
 echo ""
 
 # Color codes for output
+RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
@@ -18,7 +19,10 @@ NC='\033[0m' # No Color
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
 
-# Load environment variables from .env file
+# Tellr config file path (for Homebrew/OAuth installations)
+TELLR_CONFIG="$HOME/.tellr/config.yaml"
+
+# Load environment variables from .env file (if exists)
 if [ -f .env ]; then
     echo -e "${BLUE}🔧 Loading environment variables from .env...${NC}"
     # Export variables safely (handles values with spaces) - macOS compatible
@@ -26,25 +30,29 @@ if [ -f .env ]; then
     source .env
     set +a  # disable automatic export
     echo -e "${GREEN}✅ Environment variables loaded${NC}"
+    AUTH_MODE="env"
+elif [ -f "$TELLR_CONFIG" ]; then
+    # Homebrew installation with OAuth config
+    echo -e "${BLUE}🔧 Using tellr config for OAuth authentication...${NC}"
+    echo -e "${GREEN}✅ Tellr config found at $TELLR_CONFIG${NC}"
+    AUTH_MODE="oauth"
 else
-    echo -e "${RED}❌ .env file not found${NC}"
-    echo ""
-    echo "Please create .env file:"
-    echo -e "  ${BLUE}cp .env.example .env${NC}"
-    echo -e "  ${BLUE}nano .env${NC}  # Set DATABRICKS_HOST and DATABRICKS_TOKEN"
-    echo ""
-    exit 1
+    # Fresh install - welcome screen will handle setup
+    echo -e "${YELLOW}📝 No configuration found - welcome screen will guide setup${NC}"
+    AUTH_MODE="setup"
 fi
 
-# Validate required environment variables
-if [ -z "$DATABRICKS_HOST" ] || [ -z "$DATABRICKS_TOKEN" ]; then
-    echo -e "${RED}❌ Missing required environment variables${NC}"
-    echo ""
-    echo "Please ensure .env file contains:"
-    echo "  - DATABRICKS_HOST=https://your-workspace.cloud.databricks.com"
-    echo "  - DATABRICKS_TOKEN=your-token-here"
-    echo ""
-    exit 1
+# Validate required environment variables (only for .env mode)
+if [ "$AUTH_MODE" = "env" ]; then
+    if [ -z "$DATABRICKS_HOST" ] || [ -z "$DATABRICKS_TOKEN" ]; then
+        echo -e "${RED}❌ Missing required environment variables${NC}"
+        echo ""
+        echo "Please ensure .env file contains:"
+        echo "  - DATABRICKS_HOST=https://your-workspace.cloud.databricks.com"
+        echo "  - DATABRICKS_TOKEN=your-token-here"
+        echo ""
+        exit 1
+    fi
 fi
 
 # Check if .venv exists

--- a/tests/unit/test_local_version.py
+++ b/tests/unit/test_local_version.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for local/Homebrew version check endpoint.
+
+Tests the /api/version/local-check endpoint that checks GitHub releases
+for newer versions (separate from the PyPI version check).
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.routes.local_version import (
+    _get_local_version,
+    _is_update_available,
+    _parse_version_tag,
+    router,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def local_version_app():
+    """Create a minimal FastAPI app with only the local_version router."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(local_version_app):
+    """Provide a TestClient for the local_version router."""
+    with TestClient(local_version_app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def clear_github_cache():
+    """Reset GitHub cache between tests."""
+    from src.api.routes import local_version
+
+    local_version._github_cache = {"version": None, "timestamp": 0}
+    yield
+    local_version._github_cache = {"version": None, "timestamp": 0}
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseVersionTag:
+    """Tests for git tag to version parsing."""
+
+    def test_parse_version_tag_valid_scenarios(self):
+        """Test parsing valid version tags in various formats."""
+        assert _parse_version_tag("v1.0.0") == "1.0.0"
+        assert _parse_version_tag("1.2.3") == "1.2.3"
+        assert _parse_version_tag("  v2.0.0  ") == "2.0.0"
+
+    def test_parse_version_tag_error_handling(self):
+        """Test parsing invalid and empty tags returns None."""
+        assert _parse_version_tag("not-a-version") is None
+        assert _parse_version_tag("") is None
+
+
+class TestIsUpdateAvailable:
+    """Tests for version comparison logic."""
+
+    def test_is_update_available_valid_scenarios(self):
+        """Test update detection for newer versions."""
+        assert _is_update_available("0.1.0", "0.2.0") is True
+        assert _is_update_available("1.0.0", "1.0.1") is True
+
+    def test_is_update_available_edge_cases(self):
+        """Test no update for same, older, or invalid versions."""
+        assert _is_update_available("1.0.0", "1.0.0") is False
+        assert _is_update_available("2.0.0", "1.0.0") is False
+        assert _is_update_available("invalid", "1.0.0") is False
+
+
+class TestGetLocalVersion:
+    """Tests for local version detection."""
+
+    def test_get_local_version_valid_scenarios(self):
+        """Returns the version string from src.__version__."""
+        version = _get_local_version()
+        assert isinstance(version, str)
+        assert version != ""
+        assert version != "unknown"
+
+    def test_get_local_version_error_handling(self):
+        """Returns 'unknown' when src.__version__ is unavailable."""
+        import src
+
+        original = getattr(src, "__version__", None)
+        try:
+            delattr(src, "__version__")
+            assert _get_local_version() == "unknown"
+        finally:
+            if original is not None:
+                src.__version__ = original
+
+
+# ---------------------------------------------------------------------------
+# GET /api/version/local-check
+# ---------------------------------------------------------------------------
+
+
+class TestLocalVersionCheckEndpoint:
+    """Tests for the local version check API endpoint."""
+
+    def test_local_check_valid_scenarios(self, client):
+        """Test update detection and no-update when current."""
+        # Update available when newer release exists
+        with patch(
+            "src.api.routes.local_version._get_latest_github_release",
+            return_value={
+                "tag_name": "v1.0.0",
+                "html_url": "https://github.com/repo/releases/v1.0.0",
+            },
+        ):
+            with patch(
+                "src.api.routes.local_version._get_local_version",
+                return_value="0.1.0",
+            ):
+                response = client.get("/api/version/local-check")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["update_available"] is True
+                assert data["latest_version"] == "1.0.0"
+                assert data["update_command"] == "brew upgrade tellr"
+                assert data["release_url"] == "https://github.com/repo/releases/v1.0.0"
+
+        # No update when already on latest
+        with patch(
+            "src.api.routes.local_version._get_latest_github_release",
+            return_value={
+                "tag_name": "v0.1.0",
+                "html_url": "https://github.com/repo/releases/v0.1.0",
+            },
+        ):
+            with patch(
+                "src.api.routes.local_version._get_local_version",
+                return_value="0.1.0",
+            ):
+                response = client.get("/api/version/local-check")
+                assert response.status_code == 200
+                assert response.json()["update_available"] is False
+
+    def test_local_check_error_handling(self, client):
+        """Test graceful handling when GitHub or local version unavailable."""
+        # No GitHub release available
+        with patch(
+            "src.api.routes.local_version._get_latest_github_release",
+            return_value=None,
+        ):
+            with patch(
+                "src.api.routes.local_version._get_local_version",
+                return_value="0.1.0",
+            ):
+                response = client.get("/api/version/local-check")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["update_available"] is False
+                assert data["installed_version"] == "0.1.0"
+                assert data["latest_version"] is None
+
+        # Unknown local version
+        with patch(
+            "src.api.routes.local_version._get_latest_github_release",
+            return_value={
+                "tag_name": "v1.0.0",
+                "html_url": "https://github.com/repo/releases/v1.0.0",
+            },
+        ):
+            with patch(
+                "src.api.routes.local_version._get_local_version",
+                return_value="unknown",
+            ):
+                response = client.get("/api/version/local-check")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["update_available"] is False
+                assert data["installed_version"] == "unknown"

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1,0 +1,245 @@
+"""
+Unit tests for setup API routes (first-time configuration).
+
+Tests the /api/setup/* endpoints that handle workspace configuration
+for local/Homebrew installations.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.routes.setup import (
+    ConfigureWorkspaceRequest,
+    router,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def setup_app():
+    """Create a minimal FastAPI app with only the setup router for testing."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(setup_app):
+    """Provide a TestClient for the setup router."""
+    with TestClient(setup_app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /api/setup/status
+# ---------------------------------------------------------------------------
+
+
+class TestGetSetupStatus:
+    """Tests for the setup status endpoint."""
+
+    def test_status_valid_scenarios(self, client):
+        """Test status returns configured=True via tellr config and env var."""
+        # Configured via ~/.tellr/config.yaml
+        with patch("src.api.routes.setup.is_tellr_configured", return_value=True):
+            with patch(
+                "src.api.routes.setup.get_tellr_config",
+                return_value={"databricks": {"host": "https://my.cloud.databricks.com"}},
+            ):
+                response = client.get("/api/setup/status")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["configured"] is True
+                assert data["host"] == "https://my.cloud.databricks.com"
+
+        # Configured via DATABRICKS_HOST env var
+        with patch("src.api.routes.setup.is_tellr_configured", return_value=False):
+            with patch.dict(
+                "os.environ",
+                {"DATABRICKS_HOST": "https://env.cloud.databricks.com"},
+                clear=False,
+            ):
+                response = client.get("/api/setup/status")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["configured"] is True
+                assert data["host"] == "https://env.cloud.databricks.com"
+
+    def test_status_not_configured(self, client):
+        """Test status returns configured=False when no config exists."""
+        with patch("src.api.routes.setup.is_tellr_configured", return_value=False):
+            with patch.dict("os.environ", {}, clear=True):
+                import os
+
+                os.environ.pop("DATABRICKS_HOST", None)
+                response = client.get("/api/setup/status")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["configured"] is False
+                assert data["host"] is None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/setup/configure
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureWorkspace:
+    """Tests for the workspace configuration endpoint."""
+
+    def test_configure_valid_scenarios(self, client):
+        """Test configure with various valid inputs (AWS, Azure, GCP, normalisation)."""
+        with patch("src.api.routes.setup.save_tellr_config") as mock_save:
+            with patch("src.api.routes.setup.reset_client"):
+                # AWS URL
+                response = client.post(
+                    "/api/setup/configure",
+                    json={"host": "https://mycompany.cloud.databricks.com"},
+                )
+                assert response.status_code == 200
+                assert response.json()["success"] is True
+                assert response.json()["host"] == "https://mycompany.cloud.databricks.com"
+                mock_save.assert_called_with(
+                    host="https://mycompany.cloud.databricks.com",
+                    auth_type="external-browser",
+                )
+
+                # Azure URL
+                response = client.post(
+                    "/api/setup/configure",
+                    json={"host": "https://adb-1234567890.18.azuredatabricks.net"},
+                )
+                assert response.status_code == 200
+                assert response.json()["success"] is True
+
+                # GCP URL
+                response = client.post(
+                    "/api/setup/configure",
+                    json={"host": "https://myworkspace.gcp.databricks.com"},
+                )
+                assert response.status_code == 200
+                assert response.json()["success"] is True
+
+                # Auto-adds https:// prefix
+                response = client.post(
+                    "/api/setup/configure",
+                    json={"host": "mycompany.cloud.databricks.com"},
+                )
+                assert response.status_code == 200
+                assert response.json()["host"] == "https://mycompany.cloud.databricks.com"
+
+                # Strips trailing slash
+                response = client.post(
+                    "/api/setup/configure",
+                    json={"host": "https://mycompany.cloud.databricks.com/"},
+                )
+                assert response.status_code == 200
+                assert response.json()["host"] == "https://mycompany.cloud.databricks.com"
+
+    def test_configure_error_handling(self, client):
+        """Test configure rejects invalid input and handles save failures."""
+        # Invalid non-Databricks URL
+        response = client.post(
+            "/api/setup/configure",
+            json={"host": "https://example.com"},
+        )
+        assert response.status_code == 422
+
+        # Empty host
+        response = client.post(
+            "/api/setup/configure",
+            json={"host": ""},
+        )
+        assert response.status_code == 422
+
+        # Save failure returns 500
+        with patch(
+            "src.api.routes.setup.save_tellr_config",
+            side_effect=IOError("Permission denied"),
+        ):
+            with patch("src.api.routes.setup.reset_client"):
+                response = client.post(
+                    "/api/setup/configure",
+                    json={"host": "https://mycompany.cloud.databricks.com"},
+                )
+                assert response.status_code == 500
+                assert "Failed to save" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/setup/test-connection
+# ---------------------------------------------------------------------------
+
+
+class TestTestConnection:
+    """Tests for the connection test endpoint."""
+
+    def test_connection_valid_scenarios(self, client):
+        """Test successful connection returns user info."""
+        mock_user = MagicMock()
+        mock_user.user_name = "testuser@company.com"
+        mock_user.display_name = "Test User"
+
+        mock_client = MagicMock()
+        mock_client.current_user.me.return_value = mock_user
+
+        with patch(
+            "src.core.databricks_client.get_system_client",
+            return_value=mock_client,
+        ):
+            response = client.post("/api/setup/test-connection")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["user"]["username"] == "testuser@company.com"
+            assert data["user"]["display_name"] == "Test User"
+
+    def test_connection_error_handling(self, client):
+        """Test connection failure returns 400."""
+        with patch(
+            "src.core.databricks_client.get_system_client",
+            side_effect=Exception("Authentication failed"),
+        ):
+            response = client.post("/api/setup/test-connection")
+            assert response.status_code == 400
+            assert "Connection failed" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# URL Validation
+# ---------------------------------------------------------------------------
+
+
+class TestUrlValidation:
+    """Tests for workspace URL validation logic."""
+
+    def test_valid_urls(self):
+        """Accepts various valid Databricks URL formats."""
+        valid_urls = [
+            "https://company.cloud.databricks.com",
+            "https://adb-1234567890123456.14.azuredatabricks.net",
+            "https://workspace.gcp.databricks.com",
+            "company.cloud.databricks.com",  # auto-adds https://
+            "https://my-workspace.cloud.databricks.com",
+        ]
+        for url in valid_urls:
+            req = ConfigureWorkspaceRequest(host=url)
+            assert req.host.startswith("https://"), f"Failed for {url}"
+
+    def test_invalid_urls(self):
+        """Rejects invalid URL formats."""
+        invalid_urls = [
+            "https://google.com",
+            "https://not-databricks.com",
+            "ftp://company.cloud.databricks.com",
+        ]
+        for url in invalid_urls:
+            with pytest.raises(Exception):
+                ConfigureWorkspaceRequest(host=url)


### PR DESCRIPTION
## Summary

Simplifies local development by adding a UI-based authentication flow. Developers can now run the app and authenticate via browser SSO — no `.env` file or PAT token required. The existing `.env`/PAT method continues to work unchanged.

## What's New

- **Welcome Setup screen** — on first run, the app shows a setup screen where users enter their workspace URL and sign in via browser SSO
- **OAuth token bridge for MLflow** — extracts the bearer token from the Databricks SDK and sets it as `DATABRICKS_TOKEN` so MLflow can authenticate (MLflow doesn't support `external-browser` auth natively)
- **Auto token refresh** — silently refreshes the OAuth token on each client access so long-running sessions never hit expiry
- **Local version check** — new `/api/version/local-check` endpoint that checks GitHub releases and shows an update banner with the appropriate upgrade command (detects Homebrew vs git-clone)
- **Config persistence** — workspace config saved to `~/.tellr/config.yaml`, survives app restarts

## Authentication Priority

| Priority | Source | Method |
|----------|--------|--------|
| 1 | `~/.tellr/config.yaml` | Browser SSO (new) |
| 2 | `.env` file | PAT token (existing, unchanged) |
| 3 | Neither | Shows Welcome Setup screen |

## Files Changed

- `src/core/databricks_client.py` — OAuth token extraction + refresh for MLflow
- `src/api/routes/setup.py` — Setup API endpoints (status, configure, test-connection)
- `src/api/routes/local_version.py` — Local version check endpoint (new)
- `frontend/src/App.tsx` — Setup screen routing
- `frontend/src/components/Setup/` — WelcomeSetup component (new)
- `frontend/src/components/Layout/AppLayout.tsx` — Local update banner
- `quickstart/*.md` — Updated with both auth options
- `docs/**/local-development.md` — Updated with auth options table
- `tests/unit/test_setup.py`, `test_local_version.py`, `test_client.py` — Unit tests

## Test Plan

- [x] Fresh setup: `rm ~/.tellr/config.yaml` → app shows setup screen → enter workspace URL → SSO login → slides generate → verification works
- [x] `.env` path: app loads directly, no setup screen, existing behaviour unchanged
- [x] Browser refresh: app stays authenticated, no re-login
- [x] Token refresh: SDK handles expiry transparently, no browser popup
- [x] Unit tests: 447 passed, 0 failed