### PR TITLE
Fix save point versioning: prevent stale UI overwrites and harden backend

### DIFF
--- a/frontend/src/components/SlidePanel/SlidePanel.tsx
+++ b/frontend/src/components/SlidePanel/SlidePanel.tsx
@@ -67,7 +67,15 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({ slideDeck, rawHtml, onSl
   // Auto-verification state
   const [isAutoVerifying, setIsAutoVerifying] = useState(false);
   const [verifyingSlides, setVerifyingSlides] = useState<Set<number>>(new Set());
-  const autoVerifyTriggeredRef = useRef<Set<string>>(new Set()); // Track which content hashes we've tried to verify
+  const autoVerifyTriggeredRef = useRef<Set<string>>(new Set());
+
+  // Deck edit counter: incremented on every user-initiated mutation (edit, delete,
+  // reorder).  Async callbacks (auto-verify, delayed getSlides) capture the counter
+  // at start and skip onSlideChange if it has since changed, preventing stale
+  // server responses from overwriting newer user edits.
+  const deckEditCounterRef = useRef(0);
+  const slideDeckRef = useRef(slideDeck);
+  slideDeckRef.current = slideDeck;
   
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -97,14 +105,14 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({ slideDeck, rawHtml, onSl
       }
 
       setIsReordering(true);
+      const editId = ++deckEditCounterRef.current;
       try {
         const newOrder = newSlides.map((_, idx) => 
           slideDeck.slides.findIndex(s => s.slide_id === newSlides[idx].slide_id)
         );
         await api.reorderSlides(newOrder, sessionId);
-        // Fetch full deck to get verification merged from verification_map
         const result = await api.getSlides(sessionId);
-        if (result.slide_deck) {
+        if (result.slide_deck && deckEditCounterRef.current === editId) {
           onSlideChange?.(result.slide_deck);
         }
         clearSelection();
@@ -124,11 +132,11 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({ slideDeck, rawHtml, onSl
     
     if (!confirm(`Delete slide ${index + 1}?`)) return;
 
+    const editId = ++deckEditCounterRef.current;
     try {
       await api.deleteSlide(index, sessionId);
-      // Fetch full deck to get verification merged from verification_map
       const result = await api.getSlides(sessionId);
-      if (result.slide_deck) {
+      if (result.slide_deck && deckEditCounterRef.current === editId) {
         onSlideChange?.(result.slide_deck);
       }
       clearSelection();
@@ -141,11 +149,11 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({ slideDeck, rawHtml, onSl
   const handleUpdateSlide = async (index: number, html: string) => {
     if (!slideDeck || !sessionId || readOnly || !onSlideChange) return;
 
+    const editId = ++deckEditCounterRef.current;
     try {
       await api.updateSlide(index, html, sessionId);
-      // Fetch updated deck
       const result = await api.getSlides(sessionId);
-      if (result.slide_deck) {
+      if (result.slide_deck && deckEditCounterRef.current === editId) {
         onSlideChange?.(result.slide_deck);
       }
       clearSelection();
@@ -159,17 +167,22 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({ slideDeck, rawHtml, onSl
     if (!slideDeck || !sessionId) return;
 
     try {
-      // Save verification to backend but DON'T replace the whole deck
-      // This prevents overwriting other slide data (like charts)
       await api.updateSlideVerification(index, sessionId, verification);
-      
-      // Update only the verification field locally
-      const updatedSlides = [...slideDeck.slides];
-      updatedSlides[index] = { ...updatedSlides[index], verification: verification || undefined };
-      onSlideChange?.({ ...slideDeck, slides: updatedSlides });
+
+      // Only update the global deck state when SETTING verification (not clearing).
+      // When clearing (verification === null), this is typically called right after
+      // handleUpdateSlide's onSlideChange.  Because React hasn't re-rendered yet,
+      // slideDeck still holds the pre-edit value -- calling onSlideChange here would
+      // overwrite the edit with stale data.  SlideTile already handles the cleared
+      // badge locally via setVerificationResult(undefined).
+      if (verification !== null && onSlideChange) {
+        const currentDeck = slideDeckRef.current || slideDeck;
+        const updatedSlides = [...currentDeck.slides];
+        updatedSlides[index] = { ...updatedSlides[index], verification };
+        onSlideChange({ ...currentDeck, slides: updatedSlides });
+      }
     } catch (error) {
       console.error('Failed to update verification:', error);
-      // Don't throw - verification persistence is non-critical
     }
   };
 
@@ -387,6 +400,7 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({ slideDeck, rawHtml, onSl
   const runAutoVerification = useCallback(async (slidesToVerify: Array<{ index: number; contentHash: string }>) => {
     if (!sessionId || slidesToVerify.length === 0 || isAutoVerifying) return;
 
+    const editIdAtStart = deckEditCounterRef.current;
     setIsAutoVerifying(true);
     console.log(`[Auto-verify] Starting verification for ${slidesToVerify.length} slides`);
 
@@ -411,21 +425,37 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({ slideDeck, rawHtml, onSl
 
     await Promise.all(verificationPromises);
 
-    // Refresh slides to get updated verification results (merged from verification_map)
+    // Merge only verification metadata into the CURRENT slideDeck (via ref to
+    // avoid stale closures).  We never replace the full deck here -- a stale
+    // getSlides response would overwrite user edits that landed while
+    // verification was running.
+    // Additionally, if the user mutated the deck (edit / delete / reorder)
+    // since we started, skip entirely -- the next auto-verify cycle will pick
+    // up the verification data after the user operation's own getSlides.
     try {
       const result = await api.getSlides(sessionId);
-      if (result.slide_deck) {
-        onSlideChange?.(result.slide_deck);
+      const currentDeck = slideDeckRef.current;
+      if (result.slide_deck && currentDeck && deckEditCounterRef.current === editIdAtStart) {
+        const serverSlides = result.slide_deck.slides || [];
+        const mergedSlides = currentDeck.slides.map((localSlide) => {
+          const match = serverSlides.find(
+            (s: { content_hash?: string }) => s.content_hash && s.content_hash === localSlide.content_hash
+          );
+          if (match?.verification) {
+            return { ...localSlide, verification: match.verification };
+          }
+          return localSlide;
+        });
+        onSlideChange?.({ ...currentDeck, slides: mergedSlides });
       }
     } catch (error) {
-      console.error('[Auto-verify] Failed to refresh slides:', error);
+      console.error('[Auto-verify] Failed to refresh verification:', error);
     }
 
     setVerifyingSlides(new Set());
     setIsAutoVerifying(false);
     console.log('[Auto-verify] Completed');
 
-    // Notify parent that verification is complete (refresh version list)
     onVerificationComplete?.();
   }, [sessionId, isAutoVerifying, onSlideChange, onVerificationComplete]);
 

--- a/frontend/tests/e2e/save-points-versioning.spec.ts
+++ b/frontend/tests/e2e/save-points-versioning.spec.ts
@@ -129,10 +129,10 @@ async function setupSavePointMocks(
     route.fulfill({ status: 200, contentType: 'text/event-stream', body: createStreamingResponseWithDeck(mockSlideDeck) });
   });
 
-  await page.route(/http:\/\/127.0.0.1:8000\/api\/slides\/\d+$/, (route, request) => {
+  await page.route(/http:\/\/127.0.0.1:8000\/api\/slides\/\d+(\?|$)/, (route, request) => {
     if (request.method() === 'DELETE') {
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'deleted' }) });
-    } else if (request.method() === 'PUT') {
+    } else if (request.method() === 'PATCH') {
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockSlides[0]) });
     } else {
       route.continue();

--- a/frontend/tests/e2e/save-points-versioning.spec.ts
+++ b/frontend/tests/e2e/save-points-versioning.spec.ts
@@ -948,6 +948,242 @@ test.describe('User Journey - Genie: verification scores in save points', () => 
   });
 });
 
+// ============================================
+// Race Condition Prevention Tests
+//
+// Validates the deck-edit-counter fix: when auto-verify's getSlides response
+// arrives after a subsequent user edit, it must NOT overwrite the newer state.
+// ============================================
+
+/**
+ * Helper: set up ALL mocks manually with stateful getSlides/updateSlide/delete.
+ * Does NOT use setupSavePointMocks (Playwright routes are FIFO, first-registered
+ * fulfills first -- later overrides would be ignored).
+ */
+async function setupStatefulMocks(
+  page: Page,
+  state: {
+    currentDeck: typeof mockSlideDeck;
+    updateSlideCallCount: { value: number };
+    getSlidesCalls: { value: number };
+    verifyDelayMs?: number;
+  },
+) {
+  const { currentDeck, updateSlideCallCount, getSlidesCalls, verifyDelayMs = 3000 } = state;
+
+  // Profiles
+  await page.route('http://127.0.0.1:8000/api/settings/profiles', (route, request) => {
+    if (request.method() === 'GET') {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockProfiles) });
+    } else { route.continue(); }
+  });
+  await page.route(/http:\/\/127.0.0.1:8000\/api\/settings\/profiles\/\d+$/, (route, request) => {
+    if (request.method() === 'GET') {
+      const id = parseInt(request.url().split('/').pop() || '1');
+      const profile = mockProfiles.find(p => p.id === id) || mockProfiles[0];
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(profile) });
+    } else { route.continue(); }
+  });
+  await page.route('http://127.0.0.1:8000/api/settings/deck-prompts', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockDeckPrompts) }));
+  await page.route('http://127.0.0.1:8000/api/settings/slide-styles', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockSlideStyles) }));
+  await page.route('**/api/version**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ version: '0.1.21', latest: '0.1.21' }) }));
+  await page.route('http://127.0.0.1:8000/api/genie/spaces', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ spaces: [], total: 0 }) }));
+  await page.route(/http:\/\/127.0.0.1:8000\/api\/genie\/.*\/link/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ url: 'https://example.com/genie', message: null }) }));
+  await page.route('http://127.0.0.1:8000/api/slides/reorder**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) }));
+
+  // Versions (static)
+  const v1 = makeVersionListItem(1, 'Generated 3 slide(s)');
+  await page.route('**/api/slides/versions?**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ versions: [v1], current_version: 1 }) }));
+  await page.route('**/api/slides/versions/current?**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ current_version: 1 }) }));
+  await page.route('**/api/slides/versions/create', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(v1) }));
+  await page.route('**/api/slides/versions/sync-verification', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ version_number: 1, verification_entries: 0 }) }));
+
+  // Chat
+  await page.route('http://127.0.0.1:8000/api/chat/stream', r =>
+    r.fulfill({ status: 200, contentType: 'text/event-stream', body: createStreamingResponseWithDeck(mockSlideDeck) }));
+
+  // --- STATEFUL: updateSlide (PATCH), deleteSlide (DELETE) ---
+  // Note: updateSlide sends PATCH with body {html, session_id}
+  //       deleteSlide sends DELETE with ?session_id= query param
+  await page.route(/http:\/\/127.0.0.1:8000\/api\/slides\/\d+(\?|$)/, async (route, request) => {
+    const urlPath = new URL(request.url()).pathname;
+    const slideIndex = parseInt(urlPath.split('/').pop() || '0');
+    if (request.method() === 'DELETE') {
+      state.currentDeck = {
+        ...state.currentDeck,
+        slide_count: state.currentDeck.slides.length - 1,
+        slides: state.currentDeck.slides.filter((_, i) => i !== slideIndex),
+      };
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'deleted' }) });
+      return;
+    }
+    if (request.method() === 'PATCH') {
+      updateSlideCallCount.value++;
+      const body = request.postDataJSON();
+      if (body.html && slideIndex < state.currentDeck.slides.length) {
+        state.currentDeck = {
+          ...state.currentDeck,
+          slides: state.currentDeck.slides.map((s, i) =>
+            i === slideIndex ? { ...s, html: body.html, content_hash: `edit_${slideIndex}_${updateSlideCallCount.value}` } : s
+          ),
+        };
+      }
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ index: slideIndex, slide_id: `slide-${slideIndex}`, html: body.html }) });
+      return;
+    }
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+  });
+
+  // --- STATEFUL: sessions (getSlides reads currentDeck) ---
+  await page.route('http://127.0.0.1:8000/api/sessions**', (route, request) => {
+    const url = request.url();
+    const method = request.method();
+    if (method === 'POST' || method === 'DELETE') {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ session_id: 'mock', title: 'New', user_id: null, created_at: '2026-01-01T00:00:00Z' }) });
+      return;
+    }
+    if (url.includes('limit=')) {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockSessions) });
+    } else if (url.includes('/slides')) {
+      getSlidesCalls.value++;
+      const snap = JSON.parse(JSON.stringify(state.currentDeck));
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ session_id: 'test-session-id', slide_deck: snap }) });
+    } else {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ session_id: 'test-session-id', messages: [] }) });
+    }
+  });
+
+  // --- Verification: DELAYED to create race window ---
+  await page.route(/http:\/\/127.0.0.1:8000\/api\/slides\/\d+\/verification/, async (route) => {
+    await new Promise(resolve => setTimeout(resolve, verifyDelayMs));
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'unable_to_verify', message: 'No Genie room linked' }) });
+  });
+  await page.route(/http:\/\/127.0.0.1:8000\/api\/verification/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ score: 0, rating: 'grey', explanation: 'No Genie', issues: [], duration_ms: 50, error: false }) }));
+}
+
+/**
+ * Helper: open edit modal for slide at given 0-based index, change the first
+ * editable text to `newText`, and save.  Returns after the modal closes.
+ */
+async function editSlideText(page: Page, slideIndex: number, newText: string) {
+  const slideHeaders = page.locator('.bg-gray-100.border-b');
+  const editButton = slideHeaders.nth(slideIndex).locator('button.text-blue-600').first();
+  await editButton.click();
+  await expect(page.getByRole('heading', { name: 'Edit Slide' })).toBeVisible({ timeout: 5000 });
+
+  // Click the first editable text node (the span with cursor-pointer that shows quoted text)
+  const editableText = page.locator('span.truncate.cursor-pointer').first();
+  await editableText.click({ timeout: 3000 });
+
+  // The inline TextEditor should appear as an <input> or <textarea>
+  const textInput = page.getByRole('textbox').last();
+  await textInput.fill(newText);
+  await textInput.press('Enter');
+
+  // Save and wait for modal to close
+  await page.getByRole('button', { name: 'Save Changes' }).click();
+  await expect(page.getByRole('heading', { name: 'Edit Slide' })).not.toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Race Condition Prevention - rapid sequential edits', () => {
+
+  test('edit slide 1 then edit slide 2 -- slide 1 edit must not revert (auto-verify race)', async ({ page }) => {
+    // Scenario from user report:
+    //   "you edit slide 1, then edit slide 2 - slide 1 reverts"
+    //
+    // Root cause: auto-verify starts after edit 1, its getSlides response
+    // (pre-edit-2) arrives and overwrites the frontend state.
+    // The deckEditCounterRef fix discards stale responses.
+
+    const state = {
+      currentDeck: JSON.parse(JSON.stringify(mockSlideDeck)),
+      updateSlideCallCount: { value: 0 },
+      getSlidesCalls: { value: 0 },
+    };
+
+    await setupStatefulMocks(page, state);
+
+    await goToGenerator(page);
+    await generateSlides(page);
+    await page.waitForTimeout(500);
+
+    // --- Edit slide 1 ---
+    await editSlideText(page, 0, 'EDITED_SLIDE_1_TEXT');
+
+    // Auto-verify triggers (3s delay on verifySlide).
+    // Quickly edit slide 2 BEFORE auto-verify completes.
+    await page.waitForTimeout(200);
+
+    // --- Edit slide 2 ---
+    await editSlideText(page, 1, 'EDITED_SLIDE_2_TEXT');
+
+    // Wait for auto-verify to complete (3s delay) and all getSlides to resolve
+    await page.waitForTimeout(5000);
+
+    // --- Assertions ---
+    expect(state.updateSlideCallCount.value).toBe(2);
+
+    // The stateful mock deck must have both edits applied
+    expect(state.currentDeck.slides[0].html).toContain('EDITED_SLIDE_1_TEXT');
+    expect(state.currentDeck.slides[1].html).toContain('EDITED_SLIDE_2_TEXT');
+
+    // The frontend should still show 3 slides (none lost)
+    await expect(page.locator('.bg-gray-100.border-b')).toHaveCount(3);
+  });
+
+  test('delete slide then rapid edit -- edit must persist through auto-verify race', async ({ page }) => {
+    // Scenario: "after deleting 1 slide it starts getting messy"
+
+    const state = {
+      currentDeck: JSON.parse(JSON.stringify(mockSlideDeck)),
+      updateSlideCallCount: { value: 0 },
+      getSlidesCalls: { value: 0 },
+    };
+
+    await setupStatefulMocks(page, state);
+
+    await goToGenerator(page);
+    await generateSlides(page);
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('.bg-gray-100.border-b')).toHaveCount(3);
+
+    // Accept the confirm dialog for delete
+    page.on('dialog', dialog => dialog.accept());
+
+    // Delete slide 3 (index 2)
+    const deleteButton = page.locator('.bg-gray-100.border-b').nth(2).locator('button.text-red-600');
+    await deleteButton.click();
+
+    // Wait for delete + getSlides cycle
+    await page.waitForTimeout(1500);
+    await expect(page.locator('.bg-gray-100.border-b')).toHaveCount(2, { timeout: 5000 });
+
+    // Quickly edit slide 1 before auto-verify completes
+    await editSlideText(page, 0, 'POST_DELETE_EDIT');
+
+    // Wait for auto-verify to complete
+    await page.waitForTimeout(5000);
+
+    // Assertions
+    await expect(page.locator('.bg-gray-100.border-b')).toHaveCount(2);
+    expect(state.currentDeck.slides.length).toBe(2);
+    expect(state.currentDeck.slides[0].html).toContain('POST_DELETE_EDIT');
+    expect(state.updateSlideCallCount.value).toBe(1);
+  });
+});
+
 test.describe('User Journey - Edge Cases', () => {
 
   test('back-to-back preview switches between different versions correctly', async ({ page }) => {

--- a/frontend/tests/e2e/slide-operations-ui.spec.ts
+++ b/frontend/tests/e2e/slide-operations-ui.spec.ts
@@ -164,15 +164,15 @@ async function setupWithSlides(page: Page) {
     });
   });
 
-  // Mock slide operations (DELETE, PUT)
-  await page.route(/http:\/\/127.0.0.1:8000\/api\/slides\/\d+$/, (route, request) => {
+  // Mock slide operations (DELETE, PUT/PATCH)
+  await page.route(/http:\/\/127.0.0.1:8000\/api\/slides\/\d+(\?|$)/, (route, request) => {
     if (request.method() === 'DELETE') {
       route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({ status: 'deleted' }),
       });
-    } else if (request.method() === 'PUT') {
+    } else if (request.method() === 'PATCH') {
       route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -2364,11 +2364,14 @@ class ChatService:
         )
 
         # Create save point
-        self.create_save_point(
-            session_id=session_id,
-            description=f"Reordered slides",
-            deck=current_deck,
-        )
+        try:
+            self.create_save_point(
+                session_id=session_id,
+                description=f"Reordered slides",
+                deck=current_deck,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to create save point (reorder_slides): {e}")
 
         logger.info(
             "Reordered slides",
@@ -2485,11 +2488,14 @@ class ChatService:
         )
 
         # Create save point
-        self.create_save_point(
-            session_id=session_id,
-            description=f"Duplicated slide {index + 1}",
-            deck=current_deck,
-        )
+        try:
+            self.create_save_point(
+                session_id=session_id,
+                description=f"Duplicated slide {index + 1}",
+                deck=current_deck,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to create save point (duplicate_slide): {e}")
 
         logger.info(
             "Duplicated slide",
@@ -2546,11 +2552,14 @@ class ChatService:
         )
 
         # Create save point
-        self.create_save_point(
-            session_id=session_id,
-            description=f"Deleted slide {index + 1}",
-            deck=current_deck,
-        )
+        try:
+            self.create_save_point(
+                session_id=session_id,
+                description=f"Deleted slide {index + 1}",
+                deck=current_deck,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to create save point (delete_slide): {e}")
 
         logger.info(
             "Deleted slide",

--- a/tests/integration/test_savepoint_e2e.py
+++ b/tests/integration/test_savepoint_e2e.py
@@ -512,3 +512,188 @@ class TestLargerDeck:
             assert "data-marker" not in v_slides[idx]["html"], (
                 f"Slide {idx} should NOT have been edited"
             )
+
+
+class TestDeleteSlideRegressions:
+    """Targeted tests for the reported 'delete slide then things go messy' bug.
+
+    Scenarios:
+    - Delete a slide, then rapidly edit multiple remaining slides
+    - Delete middle slide, edit first and last, verify save points are cumulative
+    - Delete + edit + delete + edit chain
+    - Verify getSlides returns correct state between operations
+    """
+
+    @patch("src.api.services.chat_service.create_agent")
+    def test_delete_middle_then_edit_first_and_last(self, mock_agent, client, mock_user):
+        """Delete slide 3 (index 2) from 5-slide deck, then edit slides 1 and 4.
+        Each save point must reflect ALL prior changes cumulatively.
+        """
+        session_id = _create_session(client)
+        deck = _seed_deck(session_id, html=load_6_slide_deck())
+        original_count = len(deck.slides)
+        assert original_count == 6
+
+        # Delete slide 3 (index 2)
+        resp = client.delete("/api/slides/2", params={"session_id": session_id})
+        assert resp.status_code == 200, f"delete failed: {resp.text}"
+
+        # Verify deck state via getSlides
+        slides_after = _get_slides(client, session_id)
+        assert len(slides_after.get("slides", [])) == 5, "Should be 5 slides after delete"
+
+        # Edit slide 1 (index 0) -- now with 5 slides
+        edit_1 = _marker("post-delete-slide1")
+        _edit_slide(client, session_id, 0, edit_1)
+
+        # Verify intermediate state via getSlides
+        intermediate = _get_slides(client, session_id)
+        assert intermediate["slides"][0]["html"] == edit_1, "getSlides should show edit on slide 1"
+
+        # Edit last slide (index 4 in 5-slide deck)
+        edit_last = _marker("post-delete-last")
+        _edit_slide(client, session_id, 4, edit_last)
+
+        # Get the latest version from version list
+        versions = _list_versions(client, session_id)
+        latest_v = versions["versions"][0]["version_number"]
+        latest_data = _preview_version(client, session_id, latest_v)
+        latest_slides = _get_version_slides(latest_data)
+
+        assert len(latest_slides) == 5, "Latest save point should have 5 slides"
+        assert latest_slides[0]["html"] == edit_1, "Slide 1 edit MUST be in latest save point"
+        assert latest_slides[4]["html"] == edit_last, "Last slide edit MUST be in latest save point"
+
+    @patch("src.api.services.chat_service.create_agent")
+    def test_delete_edit_delete_edit_chain(self, mock_agent, client, mock_user):
+        """Delete-edit-delete-edit chain: each operation's save point must be correct."""
+        session_id = _create_session(client)
+        deck = _seed_deck(session_id, html=load_6_slide_deck())
+        assert len(deck.slides) == 6
+
+        # Step 1: Delete slide 2 (index 1) → 5 slides
+        resp = client.delete("/api/slides/1", params={"session_id": session_id})
+        assert resp.status_code == 200
+
+        # Step 2: Edit slide 1 (index 0)
+        edit_a = _marker("chain-edit-a")
+        _edit_slide(client, session_id, 0, edit_a)
+
+        # Step 3: Delete slide 3 (index 2 in 5-slide deck) → 4 slides
+        resp = client.delete("/api/slides/2", params={"session_id": session_id})
+        assert resp.status_code == 200
+
+        # Step 4: Edit slide 2 (index 1 in 4-slide deck)
+        edit_b = _marker("chain-edit-b")
+        _edit_slide(client, session_id, 1, edit_b)
+
+        # Verify final state
+        final = _get_slides(client, session_id)
+        final_slides = final.get("slides", [])
+        assert len(final_slides) == 4, f"Should be 4 slides, got {len(final_slides)}"
+        assert final_slides[0]["html"] == edit_a, "Slide 1 edit-a must persist through chain"
+        assert final_slides[1]["html"] == edit_b, "Slide 2 edit-b must be present"
+
+        # Verify the latest save point matches
+        versions = _list_versions(client, session_id)
+        latest_v = versions["versions"][0]["version_number"]
+        latest_data = _preview_version(client, session_id, latest_v)
+        latest_slides = _get_version_slides(latest_data)
+
+        assert len(latest_slides) == 4, "Save point should have 4 slides"
+        assert latest_slides[0]["html"] == edit_a, "Save point must have edit-a on slide 1"
+        assert latest_slides[1]["html"] == edit_b, "Save point must have edit-b on slide 2"
+
+    @patch("src.api.services.chat_service.create_agent")
+    def test_rapid_edits_after_delete_no_gaps(self, mock_agent, client, mock_user):
+        """Delete a slide then rapidly edit every remaining slide.
+        No save point should lose a prior edit.
+        """
+        session_id = _create_session(client)
+        deck = _seed_deck(session_id, html=load_6_slide_deck())
+        assert len(deck.slides) == 6
+
+        # Delete slide 4 (index 3) → 5 slides
+        resp = client.delete("/api/slides/3", params={"session_id": session_id})
+        assert resp.status_code == 200
+
+        # Rapidly edit all 5 remaining slides
+        edits = {}
+        for i in range(5):
+            tag = f"rapid-post-delete-{i}"
+            _edit_slide(client, session_id, i, _marker(tag))
+            edits[i] = tag
+
+        # Every edit should be in the latest save point
+        versions = _list_versions(client, session_id)
+        latest_v = versions["versions"][0]["version_number"]
+        latest_data = _preview_version(client, session_id, latest_v)
+        latest_slides = _get_version_slides(latest_data)
+
+        assert len(latest_slides) == 5, f"Expected 5 slides, got {len(latest_slides)}"
+        for idx, tag in edits.items():
+            assert tag in latest_slides[idx]["html"], (
+                f"Slide {idx} missing edit '{tag}' in latest save point. "
+                f"Got: {latest_slides[idx]['html'][:80]}"
+            )
+
+    @patch("src.api.services.chat_service.create_agent")
+    def test_getslides_consistent_between_operations(self, mock_agent, client, mock_user):
+        """After each operation, getSlides must return the cumulative state.
+        This catches the auto-verify race where getSlides could return stale data.
+        """
+        session_id = _create_session(client)
+        deck = _seed_deck(session_id)
+        assert len(deck.slides) == 3
+
+        # Edit slide 1
+        edit_1 = _marker("consistency-s1")
+        _edit_slide(client, session_id, 0, edit_1)
+        state_1 = _get_slides(client, session_id)
+        assert state_1["slides"][0]["html"] == edit_1, "getSlides after edit 1 must show edit"
+
+        # Edit slide 2
+        edit_2 = _marker("consistency-s2")
+        _edit_slide(client, session_id, 1, edit_2)
+        state_2 = _get_slides(client, session_id)
+        assert state_2["slides"][0]["html"] == edit_1, "getSlides after edit 2 must STILL show edit 1"
+        assert state_2["slides"][1]["html"] == edit_2, "getSlides after edit 2 must show edit 2"
+
+        # Delete slide 3
+        resp = client.delete("/api/slides/2", params={"session_id": session_id})
+        assert resp.status_code == 200
+        state_3 = _get_slides(client, session_id)
+        assert len(state_3["slides"]) == 2, "getSlides after delete must show 2 slides"
+        assert state_3["slides"][0]["html"] == edit_1, "Edit 1 must survive deletion of slide 3"
+        assert state_3["slides"][1]["html"] == edit_2, "Edit 2 must survive deletion of slide 3"
+
+        # Edit remaining slide 1 again
+        edit_1b = _marker("consistency-s1-v2")
+        _edit_slide(client, session_id, 0, edit_1b)
+        state_4 = _get_slides(client, session_id)
+        assert state_4["slides"][0]["html"] == edit_1b, "Re-edit of slide 1 must be reflected"
+        assert state_4["slides"][1]["html"] == edit_2, "Edit 2 must persist across re-edit of slide 1"
+
+    @patch("src.api.services.chat_service.create_agent")
+    def test_save_point_version_numbers_after_delete_chain(self, mock_agent, client, mock_user):
+        """Verify version numbers increment correctly through a delete+edit chain.
+        Backend auto-creates save points for each operation.
+        """
+        session_id = _create_session(client)
+        _seed_deck(session_id)
+
+        # Each operation auto-creates a save point on the backend
+        _edit_slide(client, session_id, 0, _marker("v-check-1"))
+        _edit_slide(client, session_id, 1, _marker("v-check-2"))
+        client.delete("/api/slides/2", params={"session_id": session_id})
+        _edit_slide(client, session_id, 0, _marker("v-check-3"))
+
+        versions = _list_versions(client, session_id)
+        v_numbers = [v["version_number"] for v in versions["versions"]]
+
+        # Should have at least 4 auto-created save points (one per operation)
+        assert len(v_numbers) >= 4, f"Expected >=4 versions, got {len(v_numbers)}: {v_numbers}"
+        # Version numbers should be strictly increasing (newest first in list)
+        assert v_numbers == sorted(v_numbers, reverse=True), (
+            f"Version numbers should be strictly decreasing in newest-first list: {v_numbers}"
+        )


### PR DESCRIPTION
## Summary

- **Frontend race condition fix**: After editing a slide (especially via the HTML editor), `handleVerificationUpdate(null)` was called to clear the verification badge. Because React hadn't re-rendered yet, it read the stale (pre-edit) `slideDeck` from its closure and called `onSlideChange` with the old data — overwriting the edit. The fix skips `onSlideChange` when clearing verification (`null`), since the SlideTile already handles the badge locally.
- **Auto-verification merge fix**: `runAutoVerification` previously replaced the entire `slideDeck` state with the `getSlides` response. If a user made an edit while auto-verify was in flight, the stale response would overwrite it. Now it merges only verification metadata into the current deck, guarded by a `deckEditCounterRef` that tracks user-initiated mutations.
- **Backend hardening**: `create_save_point()` calls in `reorder_slides`, `duplicate_slide`, and `delete_slide` were unprotected. If the save point failed after the deck mutation already committed, the route returned 500 — even though the change was persisted. Now wrapped in try-catch to log a warning instead of crashing.

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/components/SlidePanel/SlidePanel.tsx` | deckEditCounterRef + slideDeckRef guards, verification merge, skip onSlideChange on null |
| `src/api/services/chat_service.py` | try-catch around 3 unprotected create_save_point calls |
| `frontend/tests/e2e/save-points-versioning.spec.ts` | 2 new Playwright tests for race condition scenarios |
| `tests/integration/test_savepoint_e2e.py` | 5 new backend integration tests for delete+edit regressions |

## Test plan

- [x] All 20 Playwright save-point E2E tests pass
- [x] All 38 backend save-point unit/integration tests pass
- [x] Full Playwright suite (333 pass, 4 pre-existing failures unrelated to this PR)
- [x] Manual testing: HTML editor edits now reflect immediately without refresh
- [x] Manual testing: save points correctly capture all edits, including after delete/reorder/ etc. (up to 25 savepoints)