### PR TITLE
Add agent generation cancel + Genie graceful failure handling

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -21,6 +21,24 @@ environments:
       schema: "tellr_app_data_dev"
       capacity: "CU_1"  # Options: CU_1, CU_2, CU_4, CU_8
 
+  jss-sandbox:
+    app_name: "ai-slide-generator"
+    description: "AI Slide Generator - jss-sandbox"
+    workspace_path: "/Workspace/Users/jack.sandom@databricks.com/.apps/dev/tellr"
+    permissions:
+      - user_name: "jack.sandom@databricks.com"
+        permission_level: "CAN_MANAGE"
+    compute_size: "MEDIUM"
+    env_vars:
+      ENVIRONMENT: "development"
+      LOG_LEVEL: "DEBUG"
+      LAKEBASE_INSTANCE: "db-tellr"
+      LAKEBASE_SCHEMA: "app_data_jss"
+    lakebase:
+      database_name: "db-tellr"
+      schema: "tellr_app_data_jss"
+      capacity: "CU_1"
+
   production:
     app_name: "db-tellr-prod"
     description: "Databricks tellr AI Slide Generator - Production"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,6 +82,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -359,6 +360,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1582,6 +1584,7 @@
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1599,6 +1602,7 @@
       "integrity": "sha512-k5dJVszUiNr1DSe8Cs+knKR6IrqhqdhpUwzqhkS8ecQTSf3THNtbfIp/umqHMpX2bv+9dkx3fwDv/86LcSfvSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1659,6 +1663,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -1911,6 +1916,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2142,6 +2148,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2440,8 +2447,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2535,6 +2541,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3157,6 +3164,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3335,7 +3343,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3728,6 +3735,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3927,6 +3935,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3936,6 +3945,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4519,6 +4529,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4584,6 +4595,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4686,6 +4698,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4779,6 +4792,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/src/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel/ChatPanel.tsx
@@ -72,16 +72,19 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(({
       try {
         const session = await api.getSession(sessionId);
         if (session.messages && session.messages.length > 0) {
-          // Convert database messages to UI Message format
-          const uiMessages: Message[] = session.messages.map(msg => ({
-            role: msg.role as 'user' | 'assistant' | 'tool',
-            content: msg.content,
-            timestamp: msg.created_at,
-            tool_call: msg.metadata?.tool_name ? {
-              name: msg.metadata.tool_name,
-              arguments: msg.metadata.tool_input || {},
-            } : undefined,
-          }));
+          // Convert database messages to UI Message format, skipping
+          // AI/tool messages from cancelled generations
+          const uiMessages: Message[] = session.messages
+            .filter(msg => !msg.metadata?.cancelled)
+            .map(msg => ({
+              role: msg.role as 'user' | 'assistant' | 'tool',
+              content: msg.content,
+              timestamp: msg.created_at,
+              tool_call: msg.metadata?.tool_name ? {
+                name: msg.metadata.tool_name,
+                arguments: msg.metadata.tool_input || {},
+              } : undefined,
+            }));
           setMessages(uiMessages);
         } else {
           setMessages([]);
@@ -224,6 +227,23 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(({
           setIsGenerating(false);
           break;
 
+        case 'cancelled':
+          stopLoadingMessages();
+          setIsLoading(false);
+          setIsGenerating(false);
+          setMessages(prev => [
+            ...prev,
+            {
+              role: 'assistant',
+              content: 'Generation was cancelled.',
+              timestamp: new Date().toISOString(),
+            },
+          ]);
+          if (event.slides) {
+            onSlidesGenerated(event.slides, rawHtml);
+          }
+          break;
+
         case 'complete':
           stopLoadingMessages();
           setIsLoading(false);
@@ -259,7 +279,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(({
       }
     };
 
-    // Start streaming (automatically uses SSE or polling based on environment)
+    // Start chat (automatically uses SSE or polling based on environment)
     cancelStreamRef.current = api.sendChatMessage(
       sessionId,
       trimmedContent,
@@ -274,6 +294,29 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(({
       },
       imageIds,
     );
+  };
+
+  const handleCancel = () => {
+    if (!sessionId) return;
+    // Stop client-side SSE/polling immediately
+    if (cancelStreamRef.current) {
+      cancelStreamRef.current();
+      cancelStreamRef.current = null;
+    }
+    stopLoadingMessages();
+    setIsLoading(false);
+    setIsGenerating(false);
+    setMessages(prev => [
+      ...prev,
+      {
+        role: 'assistant',
+        content: 'Generation was cancelled.',
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+    // Fire-and-forget: tell backend to stop the agent and release the lock.
+    // The API layer retries on 409 if the lock hasn't released yet.
+    api.cancelGeneration(sessionId).catch(() => {});
   };
 
   // Expose sendMessage method to parent components via ref
@@ -318,7 +361,9 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(({
         <ErrorDisplay error={error} onDismiss={() => setError(null)} />
       )}
 
-      {loadingMessage && <LoadingIndicator message={loadingMessage} />}
+      {loadingMessage && (
+        <LoadingIndicator message={loadingMessage} onCancel={handleCancel} />
+      )}
 
       <ChatInput
         onSend={handleSendMessage}

--- a/frontend/src/components/ChatPanel/LoadingIndicator.tsx
+++ b/frontend/src/components/ChatPanel/LoadingIndicator.tsx
@@ -2,28 +2,40 @@ import React from 'react';
 
 interface LoadingIndicatorProps {
   message?: string;
+  onCancel?: () => void;
 }
 
 export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
   message = 'Processing slide edits...',
+  onCancel,
 }) => (
   <div className="px-4 py-3 bg-blue-50 border-t border-blue-200">
-    <div className="flex items-center space-x-3 text-blue-800 text-sm">
-      <div className="flex space-x-1" aria-hidden="true">
-        <div
-          className="w-2 h-2 bg-blue-600 rounded-full animate-bounce"
-          style={{ animationDelay: '0ms' }}
-        ></div>
-        <div
-          className="w-2 h-2 bg-blue-600 rounded-full animate-bounce"
-          style={{ animationDelay: '150ms' }}
-        ></div>
-        <div
-          className="w-2 h-2 bg-blue-600 rounded-full animate-bounce"
-          style={{ animationDelay: '300ms' }}
-        ></div>
+    <div className="flex items-center justify-between text-blue-800 text-sm">
+      <div className="flex items-center space-x-3">
+        <div className="flex space-x-1" aria-hidden="true">
+          <div
+            className="w-2 h-2 bg-blue-600 rounded-full animate-bounce"
+            style={{ animationDelay: '0ms' }}
+          ></div>
+          <div
+            className="w-2 h-2 bg-blue-600 rounded-full animate-bounce"
+            style={{ animationDelay: '150ms' }}
+          ></div>
+          <div
+            className="w-2 h-2 bg-blue-600 rounded-full animate-bounce"
+            style={{ animationDelay: '300ms' }}
+          ></div>
+        </div>
+        <span className="font-medium italic">{message}</span>
       </div>
-      <span className="font-medium italic">{message}</span>
+      {onCancel && (
+        <button
+          onClick={onCancel}
+          className="ml-3 px-3 py-1 text-xs font-medium text-red-600 bg-red-50 border border-red-200 rounded hover:bg-red-100 transition-colors"
+        >
+          Stop
+        </button>
+      )}
     </div>
   </div>
 );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -58,7 +58,7 @@ const isPollingMode = (): boolean => {
 };
 
 // Streaming event types matching backend StreamEventType
-export type StreamEventType = 'assistant' | 'tool_call' | 'tool_result' | 'error' | 'complete' | 'session_title';
+export type StreamEventType = 'assistant' | 'tool_call' | 'tool_result' | 'error' | 'complete' | 'cancelled' | 'session_title';
 
 export interface StreamEvent {
   type: StreamEventType;
@@ -366,6 +366,15 @@ export const api = {
     return response.json();
   },
 
+  /**
+   * Cancel an in-progress generation for a session
+   */
+  async cancelGeneration(sessionId: string): Promise<void> {
+    await fetch(`${API_BASE_URL}/api/chat/${sessionId}/cancel`, {
+      method: 'POST',
+    });
+  },
+
   async healthCheck(): Promise<{ status: string }> {
     const response = await fetch(`${API_BASE_URL}/api/health`);
     if (!response.ok) {
@@ -670,6 +679,9 @@ export const api = {
 
           try {
             const response = await this.pollChat(request_id, lastMessageId);
+
+            // Drop in-flight response if cancelled while the fetch was in-flight
+            if (cancelled) return;
 
             // Process new events
             for (const event of response.events) {

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -24,6 +24,7 @@ from src.api.services.chat_service import get_chat_service
 from src.api.services.job_queue import enqueue_job
 from src.api.services.session_manager import SessionNotFoundError, get_session_manager
 from src.core.context_utils import run_in_thread_with_context
+from src.services.cancellation import CancellationRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -200,11 +201,14 @@ async def send_message_streaming(request: ChatRequest) -> StreamingResponse:
                 yield error_event.to_sse()
 
         finally:
-            # Always release the lock
-            await asyncio.to_thread(
-                session_manager.release_session_lock,
-                request.session_id,
-            )
+            # Release lock only if not cancelled — cancel endpoint already released it
+            if not CancellationRegistry.is_cancelled(request.session_id):
+                await asyncio.to_thread(
+                    session_manager.release_session_lock,
+                    request.session_id,
+                )
+            else:
+                CancellationRegistry.reset(request.session_id)
 
     return StreamingResponse(
         generate_events(),
@@ -292,6 +296,11 @@ async def submit_chat_async(request: ChatRequest):
         )
         is_first_message = session_data.get("message_count", 0) == 0
 
+        # Record the current save-point version so we can revert on cancel
+        pre_gen_version = await asyncio.to_thread(
+            session_manager.get_current_version_number, request.session_id
+        )
+
         # Persist user message
         await asyncio.to_thread(
             session_manager.add_message,
@@ -313,6 +322,7 @@ async def submit_chat_async(request: ChatRequest):
                 ),
                 "is_first_message": is_first_message,
                 "image_ids": request.image_ids,
+                "pre_gen_version": pre_gen_version,
             },
         )
 
@@ -369,3 +379,29 @@ async def poll_chat(
         "result": chat_request.get("result") if chat_request["status"] == "completed" else None,
         "error": chat_request.get("error_message") if chat_request["status"] == "error" else None,
     }
+
+
+@router.post("/chat/{session_id}/cancel")
+async def cancel_generation(session_id: str):
+    """Cancel an in-progress slide generation for a session.
+
+    Sets the cancellation flag so the agent stops after the current step completes.
+    Also releases the session lock so a new generation can start immediately.
+
+    Args:
+        session_id: Session ID to cancel
+
+    Returns:
+        Dictionary with cancellation status
+    """
+    logger.info("Cancel requested", extra={"session_id": session_id})
+    CancellationRegistry.cancel(session_id)
+
+    # Release session lock so user can start a new generation immediately
+    session_manager = get_session_manager()
+    try:
+        await asyncio.to_thread(session_manager.release_session_lock, session_id)
+    except Exception:
+        pass  # Lock may already be released
+
+    return {"status": "cancelled", "session_id": session_id}

--- a/src/api/schemas/streaming.py
+++ b/src/api/schemas/streaming.py
@@ -18,6 +18,7 @@ class StreamEventType(str, Enum):
     TOOL_RESULT = "tool_result"  # Tool returned result
     ERROR = "error"  # Error occurred
     COMPLETE = "complete"  # Generation finished
+    CANCELLED = "cancelled"  # Generation cancelled by user
     SESSION_TITLE = "session_title"  # Auto-generated session title
 
 

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -29,6 +29,7 @@ from src.core.databricks_client import (
 from src.domain.slide import Slide
 from src.domain.slide_deck import SlideDeck
 from src.services.agent import create_agent
+from src.services.cancellation import CancellationRegistry
 from src.services.streaming_callback import StreamingCallbackHandler
 from src.utils.html_utils import (
     extract_canvas_ids_from_html,
@@ -932,6 +933,22 @@ class ChatService:
         # Check for errors
         if "error" in error_container:
             raise error_container["error"]
+
+        # Check if generation was cancelled by the user
+        if CancellationRegistry.is_cancelled(session_id):
+            CancellationRegistry.reset(session_id)
+            logger.info("Generation cancelled, returning partial results", extra={"session_id": session_id})
+            # Return existing deck (partial results already streamed via events)
+            existing_deck = self._get_or_load_deck(session_id)
+            deck_dict = existing_deck.to_dict() if existing_deck else None
+            if deck_dict:
+                deck_dict, _ = self._substitute_images_for_response(deck_dict)
+            yield StreamEvent(
+                type=StreamEventType.CANCELLED,
+                slides=deck_dict,
+                content="Generation was cancelled.",
+            )
+            return
 
         # Process final result
         result = result_container.get("result")

--- a/src/api/services/job_queue.py
+++ b/src/api/services/job_queue.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 from src.api.schemas.streaming import StreamEventType
+from src.services.cancellation import CancellationRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,7 @@ async def process_chat_request(request_id: str, payload: dict) -> None:
     slide_context = payload.get("slide_context")
     is_first_message = payload.get("is_first_message", False)
     image_ids = payload.get("image_ids")
+    pre_gen_version = payload.get("pre_gen_version")  # version to restore on cancel
 
     chat_service = get_chat_service()
     session_manager = get_session_manager()
@@ -153,8 +155,16 @@ async def process_chat_request(request_id: str, payload: dict) -> None:
         raise
 
     finally:
-        # Always release session lock
-        session_manager.release_session_lock(session_id)
+        if CancellationRegistry.is_cancelled(session_id):
+            # Revert slides only — preserve chat messages so history stays intact
+            try:
+                session_manager.revert_slides_on_cancel(session_id, pre_gen_version, request_id)
+            except Exception as e:
+                logger.warning(f"Failed to revert slides on cancel: {e}")
+            CancellationRegistry.reset(session_id)
+            # Lock was already released by the cancel endpoint
+        else:
+            session_manager.release_session_lock(session_id)
         # Clean up in-memory tracking
         jobs.pop(request_id, None)
 

--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
 
 from src.core.database import get_db_session
+from src.services.cancellation import CancellationRegistry
 from src.database.models.session import (
     ChatRequest,
     SessionMessage,
@@ -937,6 +938,83 @@ class SessionManager:
                 "chat_history": chat_history,
             }
 
+    def revert_slides_on_cancel(
+        self, session_id: str, pre_gen_version: Optional[int], request_id: Optional[str] = None
+    ) -> None:
+        """Revert slide deck to pre-generation state after a cancel.
+
+        Unlike restore_version(), this does NOT delete messages — it only
+        restores the slide content. AI/tool messages from the cancelled request
+        are flagged with cancelled=true in their metadata so the frontend can
+        hide them, while the user's own message is preserved.
+
+        Args:
+            session_id: Session to revert
+            pre_gen_version: Version to restore slides from, or None to clear slides
+            request_id: The cancelled request's ID, used to flag its AI/tool messages
+        """
+        with get_db_session() as db:
+            session = (
+                db.query(UserSession)
+                .filter(UserSession.session_id == session_id)
+                .first()
+            )
+            if not session:
+                return
+
+            if pre_gen_version is not None:
+                version = (
+                    db.query(SlideDeckVersion)
+                    .filter(
+                        SlideDeckVersion.session_id == session.id,
+                        SlideDeckVersion.version_number == pre_gen_version,
+                    )
+                    .first()
+                )
+                if version and session.slide_deck:
+                    session.slide_deck.deck_json = version.deck_json
+                    session.slide_deck.verification_map = version.verification_map_json
+                    deck_dict = json.loads(version.deck_json) if version.deck_json else {}
+                    session.slide_deck.title = deck_dict.get("title")
+                    session.slide_deck.slide_count = len(deck_dict.get("slides", []))
+                    session.slide_deck.updated_at = datetime.utcnow()
+                # Delete save points created during the cancelled generation
+                db.query(SlideDeckVersion).filter(
+                    SlideDeckVersion.session_id == session.id,
+                    SlideDeckVersion.version_number > pre_gen_version,
+                ).delete()
+            else:
+                # No slides existed before — clear what the cancelled run created
+                if session.slide_deck:
+                    session.slide_deck.deck_json = None
+                    session.slide_deck.slide_count = 0
+                    session.slide_deck.title = None
+                db.query(SlideDeckVersion).filter(
+                    SlideDeckVersion.session_id == session.id
+                ).delete()
+
+            # Flag AI/tool messages from the cancelled request so the frontend
+            # can hide them, while preserving the user's own prompt
+            if request_id:
+                cancelled_messages = (
+                    db.query(SessionMessage)
+                    .filter(
+                        SessionMessage.session_id == session.id,
+                        SessionMessage.request_id == request_id,
+                        SessionMessage.role != "user",
+                    )
+                    .all()
+                )
+                for msg in cancelled_messages:
+                    existing = json.loads(msg.metadata_json) if msg.metadata_json else {}
+                    existing["cancelled"] = True
+                    msg.metadata_json = json.dumps(existing)
+
+            logger.info(
+                "Reverted slides on cancel",
+                extra={"session_id": session_id, "pre_gen_version": pre_gen_version},
+            )
+
     def restore_version(self, session_id: str, version_number: int) -> Dict[str, Any]:
         """Restore deck to a specific version and delete all newer versions.
 
@@ -1059,6 +1137,37 @@ class SessionManager:
 
             return max_version[0] if max_version else None
 
+    def clear_slide_deck(self, session_id: str) -> None:
+        """Clear the slide deck and any save points for a session.
+
+        Used when cancelling a generation that started with no slides,
+        to revert the session back to its empty state.
+
+        Args:
+            session_id: Session whose slides should be cleared
+        """
+        with get_db_session() as db:
+            session = (
+                db.query(UserSession)
+                .filter(UserSession.session_id == session_id)
+                .first()
+            )
+            if not session:
+                return
+
+            # Remove all save points
+            db.query(SlideDeckVersion).filter(
+                SlideDeckVersion.session_id == session.id
+            ).delete()
+
+            # Clear the live slide deck
+            if session.slide_deck:
+                session.slide_deck.deck_json = None
+                session.slide_deck.slide_count = 0
+                session.slide_deck.title = None
+
+            logger.info("Cleared slide deck on cancel", extra={"session_id": session_id})
+
     # Session locking for concurrent request handling
     def acquire_session_lock(self, session_id: str, timeout_seconds: int = 300) -> bool:
         """Try to acquire processing lock for a session.
@@ -1088,8 +1197,18 @@ class SessionManager:
                 return True
 
             if session.is_processing:
+                # Allow stealing the lock if the current generation was cancelled.
+                # The cancel endpoint may have already released the DB lock, but if
+                # it failed silently or the old worker hasn't finished yet, this
+                # guarantees the new request can always proceed after a cancel.
+                if CancellationRegistry.is_cancelled(session_id):
+                    logger.info(
+                        "Stealing lock from cancelled generation",
+                        extra={"session_id": session_id},
+                    )
+                    # fall through to acquire
                 # Check if lock is stale (held too long)
-                if session.processing_started_at:
+                elif session.processing_started_at:
                     age = (datetime.utcnow() - session.processing_started_at).total_seconds()
                     if age < timeout_seconds:
                         return False  # Legitimately locked

--- a/src/services/agent.py
+++ b/src/services/agent.py
@@ -16,12 +16,14 @@ import mlflow
 from bs4 import BeautifulSoup
 from databricks_langchain import ChatDatabricks
 from langchain_classic.agents import AgentExecutor, create_tool_calling_agent
+
+from src.services.cancellation import CancellationRegistry
 from langchain_community.chat_message_histories import ChatMessageHistory
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.tools import StructuredTool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from src.core.databricks_client import (
     get_current_username,
@@ -56,6 +58,30 @@ class ToolExecutionError(AgentError):
     """Raised when tool execution fails."""
 
     pass
+
+
+class CancellableAgentExecutor(AgentExecutor):
+    """AgentExecutor that checks a cancellation flag between iterations.
+
+    When a user cancels generation, CancellationRegistry is set for the session.
+    This executor checks the flag in _should_continue() so the agent loop
+    exits cleanly after the current step finishes.
+
+    We use a PrivateAttr for session_id to bypass Pydantic's field storage
+    (AgentExecutor has extra='ignore' which silently drops model fields from
+    subclasses). PrivateAttr is stored separately and not subject to extras.
+    """
+
+    _session_id: str = PrivateAttr(default="")
+
+    def _should_continue(self, iterations: int, time_elapsed: float) -> bool:
+        if CancellationRegistry.is_cancelled(self._session_id):
+            logger.info(
+                "Agent cancelled by user",
+                extra={"session_id": self._session_id, "iterations": iterations},
+            )
+            return False
+        return super()._should_continue(iterations, time_elapsed)
 
 
 class GenieQueryInput(BaseModel):
@@ -116,12 +142,11 @@ class SlideGeneratorAgent:
             mlflow.set_tracking_uri(tracking_uri)
             logger.info("MLflow tracking configured", extra={"tracking_uri": tracking_uri})
 
-            # Enable LangChain autologging
-            try:
-                mlflow.langchain.autolog()
-                logger.info("MLflow LangChain autologging enabled")
-            except Exception as e:
-                logger.warning(f"Failed to enable MLflow LangChain autologging: {e}")
+            # LangChain autologging is intentionally disabled: mlflow.langchain.autolog()
+            # patches invoke() on AgentExecutor instances, replacing it with a wrapper
+            # that calls the base AgentExecutor._call — bypassing our
+            # CancellableAgentExecutor._should_continue override. Explicit MLflow spans
+            # (mlflow.start_span) are used for tracing instead.
         except Exception as e:
             logger.warning(f"Failed to configure MLflow tracking: {e}")
 
@@ -523,7 +548,9 @@ class SlideGeneratorAgent:
         )
         return prompt
 
-    def _create_agent_executor(self, tools: list[StructuredTool]) -> AgentExecutor:
+    def _create_agent_executor(
+        self, tools: list[StructuredTool], session_id: str = ""
+    ) -> CancellableAgentExecutor:
         """
         Create agent executor with model, tools, and fresh prompt content.
 
@@ -532,9 +559,10 @@ class SlideGeneratorAgent:
 
         Args:
             tools: List of tools to bind to this executor
+            session_id: Session ID for cancellation support
 
         Returns:
-            Configured AgentExecutor
+            Configured CancellableAgentExecutor
         """
         try:
             model = self._create_model()
@@ -543,8 +571,8 @@ class SlideGeneratorAgent:
             prompt = self._create_prompt(prompts)
             agent = create_tool_calling_agent(model, tools, prompt)
 
-            # Create executor with intermediate steps enabled
-            agent_executor = AgentExecutor(
+            # Create executor with intermediate steps enabled and cancellation support
+            agent_executor = CancellableAgentExecutor(
                 agent=agent,
                 tools=tools,
                 return_intermediate_steps=True,
@@ -552,6 +580,8 @@ class SlideGeneratorAgent:
                 max_iterations=1000,
                 max_execution_time=self.settings.llm.timeout,
             )
+            # Set session_id via PrivateAttr to bypass Pydantic's extra='ignore'
+            agent_executor._session_id = session_id
 
             logger.info("Agent executor created")
             return agent_executor
@@ -1163,9 +1193,13 @@ class SlideGeneratorAgent:
         session = self.get_session(session_id)
         chat_history = session["chat_history"]
 
+        # NOTE: Do NOT reset the cancel flag here. The cancel endpoint may have
+        # set it before this job started processing (job was queued). The flag is
+        # reset in process_chat_request.finally after the agent exits.
+
         # Create tools with session_id bound via closure (thread-safe)
         tools = self._create_tools_for_session(session_id)
-        agent_executor = self._create_agent_executor(tools)
+        agent_executor = self._create_agent_executor(tools, session_id=session_id)
 
         editing_mode = slide_context is not None
         is_add_operation = False
@@ -1384,12 +1418,16 @@ class SlideGeneratorAgent:
         session = self.get_session(session_id)
         chat_history = session["chat_history"]
 
+        # NOTE: Do NOT reset the cancel flag here. The cancel endpoint may have
+        # set it before this job started processing (job was queued). The flag is
+        # reset in process_chat_request.finally after the agent exits.
+
         # Create tools with session_id bound via closure (thread-safe)
         tools = self._create_tools_for_session(session_id)
 
-        # Create agent executor with callback handler
+        # Create agent executor with callback handler and cancellation support
         agent_executor = self._create_agent_executor_with_callbacks(
-            tools, [callback_handler]
+            tools, [callback_handler], session_id=session_id
         )
 
         editing_mode = slide_context is not None
@@ -1566,7 +1604,8 @@ class SlideGeneratorAgent:
         self,
         tools: list[StructuredTool],
         callbacks: list[BaseCallbackHandler],
-    ) -> AgentExecutor:
+        session_id: str = "",
+    ) -> CancellableAgentExecutor:
         """
         Create agent executor with callback handlers for streaming.
 
@@ -1576,9 +1615,10 @@ class SlideGeneratorAgent:
         Args:
             tools: List of tools to bind to this executor
             callbacks: List of callback handlers for event streaming
+            session_id: Session ID for cancellation support
 
         Returns:
-            Configured AgentExecutor with callbacks
+            Configured CancellableAgentExecutor with callbacks
         """
         try:
             model = self._create_model()
@@ -1587,7 +1627,7 @@ class SlideGeneratorAgent:
             prompt = self._create_prompt(prompts)
             agent = create_tool_calling_agent(model, tools, prompt)
 
-            agent_executor = AgentExecutor(
+            agent_executor = CancellableAgentExecutor(
                 agent=agent,
                 tools=tools,
                 callbacks=callbacks,
@@ -1596,6 +1636,8 @@ class SlideGeneratorAgent:
                 max_iterations=1000,
                 max_execution_time=self.settings.llm.timeout,
             )
+            # Set session_id via PrivateAttr to bypass Pydantic's extra='ignore'
+            agent_executor._session_id = session_id
 
             logger.info("Agent executor created with streaming callbacks")
             return agent_executor

--- a/src/services/agent.py
+++ b/src/services/agent.py
@@ -33,7 +33,7 @@ from src.core.databricks_client import (
 from src.core.settings_db import fetch_prompt_content, get_settings
 from src.domain.slide import Slide
 from src.services.image_tools import SearchImagesInput, search_images
-from src.services.tools import initialize_genie_conversation, query_genie_space
+from src.services.tools import GenieToolError, initialize_genie_conversation, query_genie_space
 from src.utils.html_utils import extract_canvas_ids_from_script, split_script_by_canvas
 from src.utils.js_validator import validate_and_fix_javascript
 
@@ -367,7 +367,20 @@ class SlideGeneratorAgent:
                     raise ToolExecutionError(f"Failed to initialize Genie conversation: {e}") from e
 
             # Query Genie with automatic conversation_id
-            result = query_genie_space(query, conversation_id)
+            try:
+                result = query_genie_space(query, conversation_id)
+            except GenieToolError as e:
+                logger.warning(
+                    f"Genie query failed gracefully: {e}",
+                    extra={"session_id": session_id, "query": query[:100]},
+                )
+                return (
+                    f"GENIE QUERY FAILED: Could not retrieve data for query: \"{query}\"\n"
+                    f"Error: {e}\n\n"
+                    "INSTRUCTION: Do NOT retry this query. Instead, generate a placeholder slide for this data. "
+                    "Use a clear visual indicator (e.g. a muted/greyed-out box) showing that the data could not "
+                    "be loaded, and display the original query that was attempted so the user knows what is missing."
+                )
 
             # Format response for LLM (no conversation_id exposed)
             response_parts = []
@@ -379,7 +392,11 @@ class SlideGeneratorAgent:
                 response_parts.append(f"Data retrieved:\n\n{result['data']}")
 
             if not response_parts:
-                return "Query completed but no data or message was returned."
+                return (
+                    f"Genie query completed but returned no data for: \"{query}\"\n\n"
+                    "INSTRUCTION: Generate a placeholder slide noting that no data was available for this query. "
+                    "Use a clear visual indicator showing the data was unavailable and display the original query."
+                )
 
             return "\n\n".join(response_parts)
 

--- a/src/services/cancellation.py
+++ b/src/services/cancellation.py
@@ -1,0 +1,36 @@
+"""Thread-safe cancellation registry for agent generation interruption."""
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+class CancellationRegistry:
+    """Thread-safe registry for tracking cancelled generations.
+
+    Maps session_id → cancelled boolean. Used by CancellableAgentExecutor
+    to check between agent iterations whether the user has requested cancellation.
+    """
+
+    _cancelled: dict[str, bool] = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    def cancel(cls, session_id: str) -> None:
+        """Mark a session's generation as cancelled."""
+        with cls._lock:
+            cls._cancelled[session_id] = True
+        logger.info("Generation cancelled", extra={"session_id": session_id})
+
+    @classmethod
+    def is_cancelled(cls, session_id: str) -> bool:
+        """Check if a session's generation has been cancelled."""
+        with cls._lock:
+            return cls._cancelled.get(session_id, False)
+
+    @classmethod
+    def reset(cls, session_id: str) -> None:
+        """Clear cancellation state for a session (call at start of each generation)."""
+        with cls._lock:
+            cls._cancelled.pop(session_id, None)

--- a/src/services/tools.py
+++ b/src/services/tools.py
@@ -181,11 +181,18 @@ def query_genie_space(
                     )
                     # Extract data and columns from response
                     response_dict = attachment_response.as_dict()["statement_response"]
-                    columns = [_["name"] for _ in response_dict["manifest"]["schema"]["columns"]]
-                    data_array = response_dict["result"]["data_array"]
-                    # Create DataFrame and convert to records
-                    df = pd.DataFrame(data_array, columns=columns)
-                    data = df.to_csv(index=False)
+                    result_block = response_dict.get("result")
+                    data_array = result_block.get("data_array") if result_block else None
+
+                    if data_array is not None:
+                        columns = [_["name"] for _ in response_dict["manifest"]["schema"]["columns"]]
+                        df = pd.DataFrame(data_array, columns=columns)
+                        data = df.to_csv(index=False)
+                    else:
+                        logger.warning(
+                            "Genie returned no data (missing result or data_array)",
+                            extra={"query": query[:100], "conversation_id": conversation_id},
+                        )
                 if attachment.text:
                     message_content = attachment.text
 

--- a/tests/unit/test_cancellation.py
+++ b/tests/unit/test_cancellation.py
@@ -1,0 +1,59 @@
+"""Tests for the cancellation registry and CancellableAgentExecutor."""
+
+import threading
+
+from src.services.cancellation import CancellationRegistry
+
+
+class TestCancellationRegistry:
+    """Tests for CancellationRegistry thread-safe operations."""
+
+    def setup_method(self):
+        """Reset registry state before each test."""
+        CancellationRegistry._cancelled.clear()
+
+    def test_cancel_sets_flag(self):
+        CancellationRegistry.cancel("session-1")
+        assert CancellationRegistry.is_cancelled("session-1") is True
+
+    def test_is_cancelled_default_false(self):
+        assert CancellationRegistry.is_cancelled("nonexistent") is False
+
+    def test_reset_clears_flag(self):
+        CancellationRegistry.cancel("session-1")
+        CancellationRegistry.reset("session-1")
+        assert CancellationRegistry.is_cancelled("session-1") is False
+
+    def test_reset_nonexistent_is_noop(self):
+        CancellationRegistry.reset("nonexistent")  # should not raise
+
+    def test_cancel_is_idempotent(self):
+        CancellationRegistry.cancel("session-1")
+        CancellationRegistry.cancel("session-1")
+        assert CancellationRegistry.is_cancelled("session-1") is True
+
+    def test_independent_sessions(self):
+        CancellationRegistry.cancel("session-1")
+        assert CancellationRegistry.is_cancelled("session-1") is True
+        assert CancellationRegistry.is_cancelled("session-2") is False
+
+    def test_thread_safety(self):
+        """Concurrent cancel/check/reset should not raise."""
+        errors = []
+
+        def worker(session_id):
+            try:
+                for _ in range(100):
+                    CancellationRegistry.cancel(session_id)
+                    CancellationRegistry.is_cancelled(session_id)
+                    CancellationRegistry.reset(session_id)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(f"s-{i}",)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []

--- a/tests/unit/test_error_recovery.py
+++ b/tests/unit/test_error_recovery.py
@@ -909,10 +909,10 @@ class TestGracefulDegradation:
             assert agent is not None
             assert agent.settings == mock_settings
 
-    def test_genie_failure_in_tool_propagates_error(
+    def test_genie_failure_in_tool_returns_placeholder_instructions(
         self, mock_settings, mock_client, mock_mlflow, mock_langchain_components
     ):
-        """Genie failure in tool propagates as GenieToolError."""
+        """Genie failure in tool returns placeholder instructions instead of raising."""
         with patch("src.services.agent.get_settings") as mock_get_settings, patch(
             "src.services.agent.get_databricks_client"
         ) as mock_get_client, patch(
@@ -946,13 +946,13 @@ class TestGracefulDegradation:
             tools = agent._create_tools_for_session(session_id)
             assert len(tools) == 2
 
-            # The tool wrapper propagates GenieToolError directly
-            # (not converted to ToolExecutionError)
+            # The tool wrapper catches GenieToolError and returns placeholder instructions
             genie_tool = next(t for t in tools if t.name == "query_genie_space")
-            with pytest.raises(GenieToolError) as exc_info:
-                genie_tool.func("test query")
+            result = genie_tool.func("test query")
 
-            assert "genie" in str(exc_info.value).lower() or "unavailable" in str(exc_info.value).lower()
+            assert "GENIE QUERY FAILED" in result
+            assert "test query" in result
+            assert "placeholder" in result.lower()
 
 
 # =============================================================================

--- a/tests/unit/test_error_recovery.py
+++ b/tests/unit/test_error_recovery.py
@@ -106,7 +106,7 @@ def mock_langchain_components():
     with patch("src.services.agent.ChatDatabricks") as mock_chat, patch(
         "src.services.agent.create_tool_calling_agent"
     ) as mock_create_agent, patch(
-        "src.services.agent.AgentExecutor"
+        "src.services.agent.CancellableAgentExecutor"
     ) as mock_executor_class:
         # Create a mock executor instance
         mock_executor_instance = Mock()

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -231,6 +231,57 @@ def test_query_genie_space_empty_data(mock_databricks_client, mock_settings):
     assert "col1" in lines[0]
 
 
+def test_query_genie_space_null_result_block(mock_databricks_client, mock_settings):
+    """Test Genie query where result is null but query 'succeeded'.
+
+    Reproduces real Genie behavior where statement_response has
+    status=SUCCEEDED and manifest with columns, but result is None.
+    This previously caused: KeyError: 'data_array'
+    """
+    conversation_response = Mock()
+    conversation_response.conversation_id = "conv-null"
+    conversation_response.message_id = "msg-null"
+
+    attachment = Mock()
+    attachment.attachment_id = "attach-null"
+    attachment.query = True
+    attachment.text = "No data was returned for this query"
+    conversation_response.attachments = [attachment]
+
+    mock_databricks_client.genie.start_conversation_and_wait.return_value = conversation_response
+
+    # Real Genie response: result is None despite status=SUCCEEDED
+    attachment_result = Mock()
+    attachment_result.as_dict.return_value = {
+        "statement_response": {
+            "manifest": {
+                "format": "JSON_ARRAY",
+                "schema": {
+                    "column_count": 3,
+                    "columns": [
+                        {"name": "media_partners", "position": 0, "type_name": "STRING"},
+                        {"name": "reach_1plus", "position": 1, "type_name": "FLOAT"},
+                        {"name": "mmr_rate", "position": 2, "type_name": "FLOAT"},
+                    ]
+                }
+            },
+            "result": None,
+            "statement_id": "test-stmt-id",
+            "status": {"state": "SUCCEEDED"},
+        }
+    }
+
+    mock_databricks_client.genie.get_message_attachment_query_result.return_value = attachment_result
+
+    # Should NOT raise - previously this caused KeyError: 'data_array'
+    response = query_genie_space(query="Show me reach metrics")
+
+    assert response["conversation_id"] == "conv-null"
+    assert response["message"] == "No data was returned for this query"
+    # data should be empty string (no data extracted)
+    assert response["data"] == ''
+
+
 def test_query_genie_space_error(mock_databricks_client, mock_settings):
     """Test Genie query with error."""
     # Setup mock to raise exception


### PR DESCRIPTION
## Summary

- **Stop button**: users can now cancel a slide generation mid-run instead of waiting up to 10 minutes for it to complete or timeout
- **Genie graceful failure**: when Genie returns no data, the agent now generates an informative "no data found" slide instead of crashing

### Genie graceful failure fix

Previously, if Genie returned a null/empty result block, the agent would throw an unhandled exception. Now:
- `tools.py`: safe `.get()` extraction on Genie result data
- `agent.py`: catches `GenieToolError` in the query wrapper and returns a structured "no data" response, allowing the agent to generate a slide that explains what data was unavailable

### Agent interrupt / cancel feature

Users can click **Stop** in the loading indicator to cancel an in-progress generation.

**Backend:**
- `src/services/cancellation.py` — thread-safe `CancellationRegistry` mapping `session_id → cancelled bool`
- `src/services/agent.py` — `CancellableAgentExecutor` subclass that checks the cancel flag in `_should_continue()` between agent iterations. Uses `PrivateAttr` to store `session_id` (bypasses `AgentExecutor`'s `extra='ignore'` Pydantic config). `mlflow.langchain.autolog()` is disabled — it monkey-patches `invoke()` and was silently bypassing the `_should_continue` override
- `POST /api/chat/{session_id}/cancel` — sets the cancellation flag and immediately releases the session lock so the next request can start
- On cancel: `revert_slides_on_cancel()` restores the slide deck to its pre-generation state and flags AI/tool messages from the cancelled run with `metadata.cancelled=true`
- `acquire_session_lock` can steal a lock from a cancelled session to prevent spurious 409 errors

**Frontend:**
- Red **Stop** button in the loading indicator bar
- Drops in-flight poll responses after cancel (prevents a completed-but-already-cancelled generation from updating the slide viewer)
- Filters `metadata.cancelled=true` messages when loading session history from DB

**Notable root causes found during implementation:**
1. `AgentExecutor.model_config = {'extra': 'ignore'}` silently dropped subclass fields — fixed with `PrivateAttr`
2. `mlflow.langchain.autolog()` patched `invoke()` on executor instances, replacing it with a wrapper that called base `AgentExecutor._call` directly, bypassing our `_should_continue` override
3. `CancellationRegistry.reset()` was called at the start of each generation, wiping cancels that arrived before the queued job started processing — removed; reset now only happens in the `finally` block

### Test plan
- [X] Start a generation and click **Stop** mid-run — verify "Generation was cancelled." appears and no slides are generated
- [X] Immediately send a new message after cancelling — verify no 409 "already processing" error
- [x] Refresh the page after cancelling — verify no slides, tool call messages from cancelled run hidden
- [x] Let a generation complete normally — verify cancel feature doesn't affect normal flow
- [x] Unit tests: `pytest tests/unit/test_cancellation.py tests/unit/test_tools.py tests/unit/test_error_recovery.py tests/unit/test_agent.py`