### PR TITLE
fix: profile capture race condition, mention scoping, and deck-only view

### DIFF
--- a/frontend/src/components/History/SessionHistory.tsx
+++ b/frontend/src/components/History/SessionHistory.tsx
@@ -50,7 +50,7 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
     return () => clearInterval(timer);
   }, [refreshKey]);
 
-  const sessions = mySessions;
+  const sessions = mySessions.filter(s => s.has_slide_deck);
 
   const handleOpenPresentation = async (presentation: SharedPresentation) => {
     try {
@@ -133,7 +133,7 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
             >
               My Sessions
               <span className="ml-2 py-0.5 px-2 rounded-full text-xs bg-gray-100 text-gray-600">
-                {mySessions.length}
+                {sessions.length}
               </span>
             </button>
             <button
@@ -176,11 +176,10 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
             <table className="w-full divide-y divide-gray-200 table-fixed">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="w-[13%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Profile</th>
-                  <th className="w-[28%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Session Name</th>
-                  <th className="w-[12%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
-                  <th className="w-[12%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Activity</th>
-                  <th className="w-[8%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Slides</th>
+                  <th className="w-[15%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Profile</th>
+                  <th className="w-[32%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Session Name</th>
+                  <th className="w-[14%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                  <th className="w-[14%] px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Activity</th>
                   <th className="w-[18%] px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                 </tr>
               </thead>
@@ -219,18 +218,9 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
                     </td>
                     <td className="px-3 py-3 text-xs text-gray-500">{formatDate(session.created_at)}</td>
                     <td className="px-3 py-3 text-xs text-gray-500">{session.last_activity ? formatDate(session.last_activity) : '-'}</td>
-                    <td className="px-3 py-3 text-xs text-gray-500">
-                      {session.has_slide_deck ? (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Yes</span>
-                      ) : (
-                        <span className="text-gray-400">No</span>
-                      )}
-                    </td>
                     <td className="px-3 py-3 text-center text-sm font-medium">
                       <div className="flex items-center justify-center gap-2">
-                        {session.has_slide_deck && (
-                          <button onClick={() => handleRestore(session.session_id)} className="text-blue-600 hover:text-blue-900 text-xs">Open</button>
-                        )}
+                        <button onClick={() => handleRestore(session.session_id)} className="text-blue-600 hover:text-blue-900 text-xs">Open</button>
                         <button
                           onClick={() => { setEditingId(session.session_id); setEditTitle(session.title); }}
                           className="text-gray-600 hover:text-gray-900 text-xs"

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -341,17 +341,18 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ initialView = 'help', view
     const newId = createNewSession();
     setViewMode('main');
     try {
+      const profile = currentProfileRef.current;
       await api.createSession({
         sessionId: newId,
-        profileId: currentProfile?.id,
-        profileName: currentProfile?.name,
+        profileId: profile?.id,
+        profileName: profile?.name,
       });
       setSessionsRefreshKey(prev => prev + 1);
       navigate(`/sessions/${newId}/edit`);
     } catch (err) {
       console.error('Failed to create session:', err);
     }
-  }, [createNewSession, navigate, currentProfile]);
+  }, [createNewSession, navigate]);
 
   const handleSaveAs = useCallback(async (title: string) => {
     try {

--- a/frontend/src/contexts/ProfileContext.tsx
+++ b/frontend/src/contexts/ProfileContext.tsx
@@ -216,39 +216,35 @@ export const ProfileProvider: React.FC<React.PropsWithChildren> = ({ children })
    * Load a profile and hot-reload the application configuration
    */
   const loadProfile = useCallback(async (id: number): Promise<void> => {
-    try {
-      setError(null);
-      
-      // Call load profile endpoint (triggers hot-reload on backend)
-      await configApi.loadProfile(id);
-      
-      // Profile loaded successfully
-      
-      // Track this as the loaded profile
-      setLoadedProfileId(id);
-      
-      // Update current profile
-      const profile = profiles.find(p => p.id === id);
-      if (profile) {
-        setCurrentProfile(profile);
-      } else {
-        // Reload profiles to ensure we have the latest
-        await loadProfiles();
+    setError(null);
+
+    // Update ref + state IMMEDIATELY so the UI (sidebar, header,
+    // handleNewSession) reflects the new profile without waiting for the
+    // backend hot-reload.
+    loadedProfileIdRef.current = id;
+    setLoadedProfileId(id);
+    const profile = profiles.find(p => p.id === id);
+    if (profile) {
+      setCurrentProfile(profile);
+    }
+
+    // Fire backend hot-reload in the background — don't block the UI.
+    // Errors are handled silently; the next chat message will trigger
+    // a reload if needed.
+    configApi.loadProfile(id).then(() => {
+      if (!profile) {
+        loadProfiles(true);
       }
-    } catch (err) {
-      // Profile was deleted: clear stored id, fall back to default, show friendly message
+    }).catch((err) => {
       if (err instanceof ConfigApiError && err.status === 404 && err.message.includes('deleted')) {
+        loadedProfileIdRef.current = null;
         setLoadedProfileId(null);
-        await loadProfiles();
+        loadProfiles();
         setError('That profile was deleted. Switched to default profile.');
         return;
       }
-      const message = err instanceof ConfigApiError 
-        ? err.message 
-        : 'Failed to load profile';
-      setError(message);
-      throw err;
-    }
+      console.error('Background profile reload failed:', err);
+    });
   }, [profiles, loadProfiles]);
 
   const value: ProfileContextValue = {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -130,6 +130,8 @@ interface SendMessageParams {
   sessionId: string;
   slideContext?: SlideContext;
   imageIds?: number[];
+  profileId?: number;
+  profileName?: string;
 }
 
 /**
@@ -431,6 +433,8 @@ export const api = {
     sessionId,
     slideContext,
     imageIds,
+    profileId,
+    profileName,
   }: SendMessageParams): Promise<ChatResponse> {
     const response = await fetch(`${API_BASE_URL}/api/chat`, {
       method: 'POST',
@@ -442,6 +446,8 @@ export const api = {
         message,
         slide_context: slideContext,
         image_ids: imageIds,
+        profile_id: profileId,
+        profile_name: profileName,
       }),
     });
 

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -155,6 +155,8 @@ async def send_message(
             request.message,
             request.slide_context.model_dump() if request.slide_context else None,
             request.image_ids,
+            request.profile_id,
+            request.profile_name,
         )
 
         return ChatResponse(**result)
@@ -367,11 +369,15 @@ async def submit_chat_async(
         )
 
     try:
-        # Get current profile info for session association
-        from src.core.settings_db import get_settings
-        settings = get_settings()
-        profile_id = getattr(settings, 'profile_id', None)
-        profile_name = getattr(settings, 'profile_name', None)
+        # Prefer profile info from the frontend request (always up-to-date),
+        # fall back to server-side cached settings only when not provided.
+        profile_id = request.profile_id
+        profile_name = request.profile_name
+        if profile_id is None:
+            from src.core.settings_db import get_settings
+            settings = get_settings()
+            profile_id = getattr(settings, 'profile_id', None)
+            profile_name = getattr(settings, 'profile_name', None)
 
         # Create request record with profile info
         request_id = await asyncio.to_thread(

--- a/src/api/schemas/requests.py
+++ b/src/api/schemas/requests.py
@@ -71,6 +71,14 @@ class ChatRequest(BaseModel):
         default=None,
         description="IDs of images attached to this message (from upload or paste)",
     )
+    profile_id: Optional[int] = Field(
+        default=None,
+        description="Active profile ID (passed by frontend for accurate session association)",
+    )
+    profile_name: Optional[str] = Field(
+        default=None,
+        description="Active profile name (cached for display)",
+    )
 
     @field_validator("message")
     @classmethod

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -192,6 +192,8 @@ class ChatService:
         message: str,
         slide_context: Optional[Dict[str, Any]] = None,
         image_ids: Optional[List[int]] = None,
+        profile_id: Optional[int] = None,
+        profile_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Send a message to the agent and get response.
 
@@ -200,6 +202,8 @@ class ChatService:
             message: User's message
             slide_context: Optional context for slide editing
             image_ids: Optional list of image IDs attached to this message
+            profile_id: Active profile ID (from frontend request)
+            profile_name: Active profile name (from frontend request)
 
         Returns:
             Dictionary containing:
@@ -227,13 +231,15 @@ class ChatService:
 
         # Get or create session in database (auto-create on first message)
         session_manager = get_session_manager()
-        
-        # Get current profile info for session association
-        from src.core.settings_db import get_settings
-        settings = get_settings()
-        profile_id = getattr(settings, 'profile_id', None)
-        profile_name = getattr(settings, 'profile_name', None)
-        
+
+        # Prefer profile info passed from the frontend; fall back to
+        # server-side settings only when not provided.
+        if profile_id is None:
+            from src.core.settings_db import get_settings
+            settings = get_settings()
+            profile_id = getattr(settings, 'profile_id', None)
+            profile_name = getattr(settings, 'profile_name', None)
+
         try:
             db_session = session_manager.get_session(session_id)
             # Update profile for existing session without one
@@ -602,6 +608,8 @@ class ChatService:
         request_id: Optional[str] = None,
         image_ids: Optional[List[int]] = None,
         is_first_message_override: Optional[bool] = None,
+        profile_id: Optional[int] = None,
+        profile_name: Optional[str] = None,
     ) -> Generator[StreamEvent, None, None]:
         """Send a message and yield streaming events.
 
@@ -619,6 +627,8 @@ class ChatService:
             is_first_message_override: If set, overrides the DB-based first-message
                 detection. Used by the async path where the user message is
                 persisted before the job runs.
+            profile_id: Active profile ID (from frontend request)
+            profile_name: Active profile name (from frontend request)
 
         Yields:
             StreamEvent objects for real-time display
@@ -642,16 +652,15 @@ class ChatService:
 
         # Get or create session in database
         session_manager = get_session_manager()
-        
-        # Get current profile info for session association
-        from src.core.settings_db import get_settings
-        settings = get_settings()
-        profile_id = getattr(settings, 'profile_id', None)
-        profile_name = getattr(settings, 'profile_name', None)
-        
+
+        if profile_id is None:
+            from src.core.settings_db import get_settings
+            settings = get_settings()
+            profile_id = getattr(settings, 'profile_id', None)
+            profile_name = getattr(settings, 'profile_name', None)
+
         try:
             db_session = session_manager.get_session(session_id)
-            # Update profile for existing session without one
             if db_session.get("profile_id") is None and profile_id is not None:
                 session_manager.set_session_profile(session_id, profile_id, profile_name)
                 db_session["profile_id"] = profile_id


### PR DESCRIPTION
- Fix profile name race condition: update loadedProfileIdRef synchronously in loadProfile so background polling never overwrites with stale value.
- Make profile switch non-blocking: fire backend hot-reload in background so the UI updates instantly when switching profiles.
- Use currentProfileRef in handleNewSession to always read latest profile.
- Pass profile_id/profile_name in ChatRequest so chat endpoints don't rely on stale server-side get_settings() cache.
- Scope mention notifications to current deck via session_id query param.
- Filter "View All Decks" to only show sessions with slide decks.