### PR TITLE
Restore Save as HTML export option

### DIFF
--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -463,6 +463,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ initialView = 'help', view
     slidePanelRef.current?.exportPDF();
   }, []);
 
+  const handleExportHTML = useCallback(() => {
+    slidePanelRef.current?.exportHTML();
+  }, []);
+
   const handleExportGoogleSlides = useCallback(async () => {
     if (!sessionId || !slideDeck) return;
     try {
@@ -530,6 +534,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ initialView = 'help', view
                 onCopyLink={!viewOnly && sessionId ? handleCopyLink : undefined}
                 onExportPPTX={slideDeck ? handleExportPPTX : undefined}
                 onExportPDF={slideDeck ? handleExportPDF : undefined}
+                onExportHTML={slideDeck ? handleExportHTML : undefined}
                 onExportGoogleSlides={slideDeck ? handleExportGoogleSlides : undefined}
                 onPresent={slideDeck ? handlePresent : undefined}
                 isGenerating={isGenerating}

--- a/frontend/src/components/Layout/page-header.tsx
+++ b/frontend/src/components/Layout/page-header.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, type ReactNode } from "react"
-import { Save, Download, Play, Share2, Link, ChevronDown, FileDown, FileText, Presentation } from "lucide-react"
+import { Save, Download, Play, Share2, Link, ChevronDown, FileDown, FileText, Presentation, Code } from "lucide-react"
 import { Button } from "@/ui/button"
 import { SidebarTrigger } from "@/ui/sidebar"
 import { Separator } from "@/ui/separator"
@@ -20,6 +20,7 @@ interface PageHeaderProps {
   onExport?: () => void
   onExportPPTX?: () => void
   onExportPDF?: () => void
+  onExportHTML?: () => void
   onExportGoogleSlides?: () => void
   onPresent?: () => void
   onTitleChange?: (newTitle: string) => void
@@ -40,6 +41,7 @@ export function PageHeader({
   onExport,
   onExportPPTX,
   onExportPDF,
+  onExportHTML,
   onExportGoogleSlides,
   onPresent,
   onTitleChange,
@@ -48,7 +50,7 @@ export function PageHeader({
   isGenerating = false,
   viewOnly = false,
 }: PageHeaderProps) {
-  const hasExportMenu = !viewOnly && (onExportPPTX ?? onExportPDF ?? onExportGoogleSlides)
+  const hasExportMenu = !viewOnly && (onExportPPTX ?? onExportPDF ?? onExportHTML ?? onExportGoogleSlides)
   const [isEditing, setIsEditing] = useState(false)
   const [editedTitle, setEditedTitle] = useState(title)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -169,6 +171,12 @@ export function PageHeader({
                   <DropdownMenuItem onClick={onExportPDF} disabled={isGenerating}>
                     <FileText className="size-3.5 mr-2" />
                     Download PDF
+                  </DropdownMenuItem>
+                )}
+                {onExportHTML && (
+                  <DropdownMenuItem onClick={onExportHTML} disabled={isGenerating}>
+                    <Code className="size-3.5 mr-2" />
+                    Save as HTML
                   </DropdownMenuItem>
                 )}
                 {onExportGoogleSlides && (

--- a/frontend/src/components/SlidePanel/SlidePanel.tsx
+++ b/frontend/src/components/SlidePanel/SlidePanel.tsx
@@ -45,6 +45,7 @@ interface SlidePanelProps {
 export interface SlidePanelHandle {
   exportPDF: () => void;
   exportPPTX: () => void;
+  exportHTML: () => void;
   openPresentationMode: () => void;
 }
 
@@ -344,9 +345,139 @@ function SlidePanelComponent(props: SlidePanelProps, ref: React.Ref<SlidePanelHa
     }
   };
 
+  const handleSaveAsHTML = () => {
+    if (!slideDeck) return;
+
+    const slidesHtml = slideDeck.slides
+      .map((slide, index) => {
+        const slideScripts = slide.scripts || '';
+        return `
+    <div class="slide-wrapper" data-slide-index="${index}">
+      <div class="slide-container">
+        ${slide.html}
+      </div>
+      ${slideScripts ? `<script>
+        (function() {
+          ${slideScripts}
+        })();
+      </script>` : ''}
+    </div>`;
+      })
+      .join('\n');
+
+    const externalScriptsHtml = slideDeck.external_scripts
+      .map((src: string) => `<script src="${src}"></script>`)
+      .join('\n');
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${slideDeck.title || 'Presentation'}</title>
+  ${externalScriptsHtml}
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    html, body {
+      width: 100%;
+      height: 100%;
+      overflow: auto;
+      background: #f9fafb;
+    }
+    body {
+      padding: 40px 20px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 40px;
+    }
+    .slide-wrapper {
+      width: 100%;
+      max-width: 1280px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      page-break-after: always;
+    }
+    .slide-container {
+      width: 1280px;
+      height: 720px;
+      max-width: 100%;
+      max-height: calc(100vh - 80px);
+      position: relative;
+      background: #ffffff;
+      overflow: auto;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      border-radius: 8px;
+    }
+    .slide-container > * {
+      width: 100%;
+      min-height: 100%;
+    }
+    canvas {
+      max-width: 100%;
+      height: auto;
+    }
+    ${slideDeck.css}
+  </style>
+</head>
+<body>
+  ${slidesHtml}
+  <script>
+    function waitForChartJs(callback, maxAttempts = 50) {
+      let attempts = 0;
+      const check = () => {
+        attempts++;
+        if (typeof Chart !== 'undefined') {
+          callback();
+        } else if (attempts < maxAttempts) {
+          setTimeout(check, 100);
+        } else {
+          console.error('Chart.js failed to load');
+        }
+      };
+      check();
+    }
+
+    function initializeCharts() {
+      try {
+        ${slideDeck.scripts || ''}
+      } catch (err) {
+        console.error('Chart initialization error:', err);
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => {
+        waitForChartJs(initializeCharts);
+      });
+    } else {
+      waitForChartJs(initializeCharts);
+    }
+  </script>
+</body>
+</html>`;
+
+    const blob = new Blob([html], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${(slideDeck.title || 'presentation').replace(/[^a-z0-9]/gi, '-').toLowerCase()}.html`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
   useImperativeHandle(ref, () => ({
     exportPDF: handleExportPDF,
     exportPPTX: handleExportPPTX,
+    exportHTML: handleSaveAsHTML,
     openPresentationMode: () => setIsPresentationMode(true),
   }));
 


### PR DESCRIPTION
## Summary
- Re-adds the "Save as HTML" export option that was removed during the frontend refresh
- Client-side only — builds a standalone HTML presentation file from the slide deck (CSS, scripts, Chart.js) and triggers a browser download
- Adds menu item to the export dropdown between PDF and Google Slides

## Test plan
- [ ] Open a session with slides, click Export dropdown, verify "Save as HTML" option appears
- [ ] Click "Save as HTML" and confirm an `.html` file downloads
- [ ] Open the downloaded HTML in a browser and verify slides render correctly with charts

This pull request was AI-assisted by Isaac.