### PR TITLE
test: add regression tests for Google OAuth re-auth flow

### DIFF
--- a/docs/superpowers/plans/2026-03-27-google-oauth-reauth-tests.md
+++ b/docs/superpowers/plans/2026-03-27-google-oauth-reauth-tests.md
@@ -1,0 +1,212 @@
+# Google OAuth Re-Auth Regression Tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two tests that would have caught the Google OAuth re-auth regression — one backend, one frontend E2E.
+
+**Architecture:** Backend test goes in the existing admin routes test module using the same SQLite/TestClient fixtures. Frontend test goes in the existing export E2E suite using Playwright route interception to mock auth endpoints and capture the OAuth popup trigger.
+
+**Tech Stack:** pytest + FastAPI TestClient (backend), Playwright (frontend)
+
+**Spec:** `docs/superpowers/specs/2026-03-27-google-oauth-reauth-tests-design.md`
+
+---
+
+### Task 1: Backend — test that credential upload clears user tokens
+
+**Files:**
+- Modify: `tests/unit/config/test_admin_routes.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test at the end of `tests/unit/config/test_admin_routes.py`. It uses the existing `test_client`, `session_factory` fixtures and `VALID_CREDENTIALS` constant. Import `GoogleOAuthToken` and `encrypt_data` at the top of the file.
+
+Add to imports (top of file):
+
+```python
+from src.database.models.google_oauth_token import GoogleOAuthToken
+from src.core.encryption import encrypt_data
+```
+
+Add the test:
+
+```python
+def test_upload_credentials_clears_existing_user_tokens(test_client, session_factory):
+    """Uploading new credentials invalidates all existing user OAuth tokens."""
+    # Seed a user token
+    db = session_factory()
+    db.add(GoogleOAuthToken(
+        user_identity="user@example.com",
+        token_encrypted=encrypt_data('{"access_token": "old"}'),
+    ))
+    db.commit()
+    assert db.query(GoogleOAuthToken).count() == 1
+    db.close()
+
+    # Upload new credentials
+    resp = test_client.post(
+        "/api/admin/google-credentials",
+        files={"file": ("credentials.json", VALID_CREDENTIALS, "application/json")},
+    )
+    assert resp.status_code == 200
+
+    # All user tokens should be gone
+    db = session_factory()
+    assert db.query(GoogleOAuthToken).count() == 0
+    db.close()
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator
+python -m pytest tests/unit/config/test_admin_routes.py::test_upload_credentials_clears_existing_user_tokens -v
+```
+
+Expected: PASS — the fix is already on `main`.
+
+- [ ] **Step 3: Verify the test catches the regression**
+
+Temporarily comment out the token deletion lines in `src/api/routes/admin.py` (lines 65-66):
+
+```python
+    # deleted = db.query(GoogleOAuthToken).delete()
+```
+
+Re-run the test:
+
+```bash
+python -m pytest tests/unit/config/test_admin_routes.py::test_upload_credentials_clears_existing_user_tokens -v
+```
+
+Expected: FAIL — `assert db.query(GoogleOAuthToken).count() == 0` fails because the token was not deleted.
+
+**Restore the commented-out line immediately after confirming the failure.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/config/test_admin_routes.py
+git commit -m "test: verify credential upload clears existing user OAuth tokens"
+```
+
+---
+
+### Task 2: Frontend E2E — test that export triggers OAuth popup when unauthorized
+
+**Files:**
+- Modify: `frontend/tests/e2e/export-ui.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+Add a new `test.describe` block at the end of `frontend/tests/e2e/export-ui.spec.ts`, before the final closing of the file. This test uses the existing `setupMocks`, `setupStreamMock`, `goToGenerator`, and `generateSlides` helpers already defined in the file.
+
+```typescript
+// ============================================
+// Google Slides OAuth Flow Tests
+// ============================================
+
+test.describe('GoogleSlidesOAuth', () => {
+  test('triggers OAuth flow when user is not authorized', async ({ page }) => {
+    await setupMocks(page);
+    await setupStreamMock(page);
+
+    // Mock auth status: user is NOT authorized
+    await page.route('**/api/export/google-slides/auth/status', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ authorized: false }),
+      });
+    });
+
+    // Mock auth URL endpoint — track whether it gets called
+    let authUrlRequested = false;
+    await page.route('**/api/export/google-slides/auth/url', (route) => {
+      authUrlRequested = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ url: 'https://accounts.google.com/o/oauth2/auth?fake=true' }),
+      });
+    });
+
+    // Stub window.open so the popup doesn't actually open
+    await page.addInitScript(() => {
+      window.open = () => null;
+    });
+
+    await goToGenerator(page);
+    await generateSlides(page);
+
+    // Open export dropdown and click Google Slides
+    await page.getByRole('button', { name: 'Export' }).click();
+    await page.getByText('Export to Google Slides').click();
+
+    // The app should have requested the auth URL to start the OAuth flow
+    await expect(() => {
+      if (!authUrlRequested) throw new Error('auth/url was not requested');
+    }).toPass({ timeout: 5000 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator/frontend
+npx playwright test tests/e2e/export-ui.spec.ts -g "triggers OAuth flow" --headed
+```
+
+Expected: PASS — the fix is already on `main`.
+
+- [ ] **Step 3: Verify the test catches the regression**
+
+Temporarily revert the auth check in `frontend/src/components/Layout/AppLayout.tsx` by commenting out lines 475-485 (the `checkGoogleSlidesAuth` + `openOAuthPopup` block).
+
+Re-run:
+
+```bash
+npx playwright test tests/e2e/export-ui.spec.ts -g "triggers OAuth flow"
+```
+
+Expected: FAIL — `authUrlRequested` stays `false` because the export goes straight to the export endpoint without checking auth.
+
+**Restore the commented-out lines immediately after confirming the failure.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator
+git add frontend/tests/e2e/export-ui.spec.ts
+git commit -m "test(e2e): verify Google Slides export triggers OAuth when unauthorized"
+```
+
+---
+
+### Task 3: Final — run full test suites and push
+
+- [ ] **Step 1: Run backend admin tests**
+
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator
+python -m pytest tests/unit/config/test_admin_routes.py -v
+```
+
+Expected: All tests pass (existing + new).
+
+- [ ] **Step 2: Run frontend export E2E tests**
+
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator/frontend
+npx playwright test tests/e2e/export-ui.spec.ts
+```
+
+Expected: All tests pass (existing + new).
+
+- [ ] **Step 3: Push branch**
+
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator
+git push -u origin test/google-oauth-reauth-regression
+```

--- a/docs/superpowers/specs/2026-03-27-google-oauth-reauth-tests-design.md
+++ b/docs/superpowers/specs/2026-03-27-google-oauth-reauth-tests-design.md
@@ -1,0 +1,42 @@
+# Google OAuth Re-Auth Regression Tests
+
+## Problem
+
+Commit `c3942b6` moved export buttons from `SlidePanel` to `PageHeader` but dropped the auth-check-before-export flow. Users who lacked a valid token saw a generic error toast instead of the OAuth popup. The backend also had no mechanism to invalidate user tokens when admin credentials changed. Neither gap was caught by existing tests.
+
+## Tests to Add
+
+### 1. Backend: credential upload clears user tokens
+
+**File:** `tests/unit/config/test_admin_routes.py`
+
+Add one test to the existing module. Uses the same fixtures (`test_client`, `session_factory`, `_clean_data`).
+
+**Test:** `test_upload_credentials_clears_existing_user_tokens`
+
+Steps:
+1. Seed a `GoogleOAuthToken` row for a user (encrypted dummy token).
+2. `POST /api/admin/google-credentials` with valid credentials.
+3. Query `google_oauth_tokens` — assert zero rows remain.
+
+This directly validates the `db.query(GoogleOAuthToken).delete()` line added in the fix.
+
+### 2. Frontend: export triggers OAuth popup when unauthorized
+
+**File:** `frontend/tests/e2e/export-ui.spec.ts`
+
+Add one test to the existing export E2E suite. Uses the same mock setup patterns (route interception).
+
+**Test:** `triggers OAuth flow when user is not authorized for Google Slides`
+
+Steps:
+1. Mock `/api/export/google-slides/auth/status` → `{ authorized: false }`.
+2. Mock `/api/export/google-slides/auth/url` → `{ url: "https://accounts.google.com/fake" }`.
+3. Stub `window.open` via `page.addInitScript` to capture calls without opening a real popup.
+4. Open the export dropdown, click "Export to Google Slides".
+5. Assert that `/api/export/google-slides/auth/url` was requested (the OAuth flow was initiated, not a silent failure).
+
+### What these tests would have caught
+
+- **Backend test:** Would fail if credential upload doesn't clear `google_oauth_tokens` — the exact backend gap.
+- **Frontend test:** Would fail if the export handler calls the export endpoint directly without checking auth status first — the exact frontend regression from `c3942b6`.

--- a/frontend/tests/e2e/export-ui.spec.ts
+++ b/frontend/tests/e2e/export-ui.spec.ts
@@ -717,3 +717,48 @@ test.describe('SlidePanelHeader', () => {
     await expect(page.getByText(mockSlideDeck.title)).toBeVisible();
   });
 });
+
+// ============================================
+// Google Slides OAuth Flow Tests
+// ============================================
+
+test.describe('GoogleSlidesOAuth', () => {
+  test('triggers OAuth flow when user is not authorized', async ({ page }) => {
+    await setupMocks(page);
+    await setupStreamMock(page);
+
+    // Mock auth status: user is NOT authorized
+    await page.route('**/api/export/google-slides/auth/status', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ authorized: false }),
+      });
+    });
+
+    // Mock auth URL endpoint
+    await page.route('**/api/export/google-slides/auth/url', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ url: 'https://accounts.google.com/o/oauth2/auth?fake=true' }),
+      });
+    });
+
+    // Stub window.open so the popup doesn't actually open
+    await page.addInitScript(() => {
+      window.open = () => null;
+    });
+
+    await goToGenerator(page);
+    await generateSlides(page);
+
+    // Click Export to Google Slides and wait for the auth URL request
+    const authUrlRequestPromise = page.waitForRequest('**/api/export/google-slides/auth/url');
+    await page.getByRole('button', { name: 'Export' }).click();
+    await page.getByText('Export to Google Slides').click();
+
+    // The app should have requested the auth URL to start the OAuth flow
+    await authUrlRequestPromise;
+  });
+});

--- a/tests/unit/config/test_admin_routes.py
+++ b/tests/unit/config/test_admin_routes.py
@@ -10,6 +10,8 @@ from fastapi.testclient import TestClient
 
 from src.core.database import Base, get_db
 from src.database.models import GoogleGlobalCredentials
+from src.database.models.google_oauth_token import GoogleOAuthToken
+from src.core.encryption import encrypt_data
 
 VALID_CREDENTIALS = json.dumps({
     "installed": {
@@ -162,3 +164,28 @@ def test_upload_replaces_existing_credentials(test_client, session_factory):
     decrypted = decrypt_data(rows[0].credentials_encrypted)
     assert "v2" in decrypted
     assert "web" in decrypted
+
+
+def test_upload_credentials_clears_existing_user_tokens(test_client, session_factory):
+    """Uploading new credentials invalidates all existing user OAuth tokens."""
+    # Seed a user token
+    db = session_factory()
+    db.add(GoogleOAuthToken(
+        user_identity="user@example.com",
+        token_encrypted=encrypt_data('{"access_token": "old"}'),
+    ))
+    db.commit()
+    assert db.query(GoogleOAuthToken).count() == 1
+    db.close()
+
+    # Upload new credentials
+    resp = test_client.post(
+        "/api/admin/google-credentials",
+        files={"file": ("credentials.json", VALID_CREDENTIALS, "application/json")},
+    )
+    assert resp.status_code == 200
+
+    # All user tokens should be gone
+    db = session_factory()
+    assert db.query(GoogleOAuthToken).count() == 0
+    db.close()


### PR DESCRIPTION
## Summary
- **Backend test** (`test_admin_routes.py`): Verifies that uploading new Google credentials clears all existing user OAuth tokens, forcing re-authentication
- **Frontend E2E test** (`export-ui.spec.ts`): Verifies that clicking "Export to Google Slides" triggers the OAuth popup when the user is not authorized, rather than silently failing

Both tests target the regression introduced in `c3942b6` and fixed in #146.

## Test plan
- [x] Backend: `pytest tests/unit/config/test_admin_routes.py` — 8/8 pass
- [x] Frontend: `npx playwright test tests/e2e/export-ui.spec.ts -g "triggers OAuth flow"` — passes

This pull request was AI-assisted by Isaac.