### PR TITLE
fix: grant CAN_MANAGE to existing deck creators during migration

### DIFF
--- a/src/core/database.py
+++ b/src/core/database.py
@@ -866,6 +866,13 @@ def _migrate_deck_permissions_model(conn, inspector, schema, _qual, is_sqlite):
         ))
 
     # --- Grant CAN_MANAGE to deck creators who don't have a DeckContributor row ---
+    try:
+        inspector.get_columns("deck_contributors", schema=schema)
+    except Exception:
+        logger.info("Migration: deck_contributors table does not exist yet, skipping creator backfill")
+        logger.info("Migration: deck permissions model migration complete")
+        return
+
     qualified_deck_contribs = _qual("deck_contributors")
     conn.execute(text(
         f"INSERT INTO {qualified_deck_contribs} "

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -865,4 +865,19 @@ def _migrate_deck_permissions_model(conn, inspector, schema, _qual, is_sqlite):
             "WHERE global_permission = 'CAN_VIEW'"
         ))
 
+    # --- Grant CAN_MANAGE to deck creators who don't have a DeckContributor row ---
+    qualified_deck_contribs = _qual("deck_contributors")
+    conn.execute(text(
+        f"INSERT INTO {qualified_deck_contribs} "
+        "(user_session_id, identity_type, identity_id, identity_name, permission_level, created_by, created_at, updated_at) "
+        f"SELECT s.id, 'USER', s.created_by, s.created_by, 'CAN_MANAGE', 'migration', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP "
+        f"FROM {qualified_sessions} s "
+        f"WHERE s.created_by IS NOT NULL "
+        f"AND NOT EXISTS ("
+        f"  SELECT 1 FROM {qualified_deck_contribs} dc "
+        f"  WHERE dc.user_session_id = s.id AND dc.identity_id = s.created_by"
+        f")"
+    ))
+    logger.info("Migration: granted CAN_MANAGE to existing deck creators")
+
     logger.info("Migration: deck permissions model migration complete")

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -866,13 +866,6 @@ def _migrate_deck_permissions_model(conn, inspector, schema, _qual, is_sqlite):
         ))
 
     # --- Grant CAN_MANAGE to deck creators who don't have a DeckContributor row ---
-    try:
-        inspector.get_columns("deck_contributors", schema=schema)
-    except Exception:
-        logger.info("Migration: deck_contributors table does not exist yet, skipping creator backfill")
-        logger.info("Migration: deck permissions model migration complete")
-        return
-
     qualified_deck_contribs = _qual("deck_contributors")
     conn.execute(text(
         f"INSERT INTO {qualified_deck_contribs} "

--- a/tests/unit/test_database_migrations.py
+++ b/tests/unit/test_database_migrations.py
@@ -98,7 +98,12 @@ def test_migration_creates_google_global_credentials_table(sqlite_engine):
 
 def test_migration_copies_first_credentials_to_global(sqlite_engine):
     """Migration copies first non-null google_credentials_encrypted from config_profiles to global table."""
+    Base.metadata.create_all(bind=sqlite_engine)
     with sqlite_engine.connect() as conn:
+        # Drop and recreate with legacy schema (includes google_credentials_encrypted)
+        conn.execute(text("DROP TABLE IF EXISTS config_profiles"))
+        conn.execute(text("DROP TABLE IF EXISTS google_global_credentials"))
+        conn.commit()
         _create_old_config_profiles(conn, "config_profiles")
         _create_google_global_credentials(conn, "google_global_credentials")
         conn.execute(text("""
@@ -122,7 +127,11 @@ def test_migration_copies_first_credentials_to_global(sqlite_engine):
 
 def test_migration_nulls_all_profile_credentials(sqlite_engine):
     """Migration nulls out google_credentials_encrypted on all profile rows after copy."""
+    Base.metadata.create_all(bind=sqlite_engine)
     with sqlite_engine.connect() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS config_profiles"))
+        conn.execute(text("DROP TABLE IF EXISTS google_global_credentials"))
+        conn.commit()
         _create_old_config_profiles(conn, "config_profiles")
         _create_google_global_credentials(conn, "google_global_credentials")
         conn.execute(text("""
@@ -144,7 +153,11 @@ def test_migration_nulls_all_profile_credentials(sqlite_engine):
 
 def test_migration_is_idempotent(sqlite_engine):
     """Running migration twice is safe; no duplicate rows, no errors."""
+    Base.metadata.create_all(bind=sqlite_engine)
     with sqlite_engine.connect() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS config_profiles"))
+        conn.execute(text("DROP TABLE IF EXISTS google_global_credentials"))
+        conn.commit()
         _create_old_config_profiles(conn, "config_profiles")
         _create_google_global_credentials(conn, "google_global_credentials")
         conn.execute(text("""

--- a/tests/unit/test_deck_permissions_migration.py
+++ b/tests/unit/test_deck_permissions_migration.py
@@ -129,3 +129,64 @@ class TestDeckPermissionsMigration:
                 "SELECT permission_level FROM config_profile_contributors WHERE identity_id = 'user-2'"
             )).fetchone()
         assert result[0] == "CAN_EDIT"
+
+    def test_deck_creator_gets_can_manage(self, engine_with_legacy_columns):
+        """Existing decks should get a CAN_MANAGE DeckContributor row for their creator."""
+        with engine_with_legacy_columns.begin() as conn:
+            conn.execute(text(
+                "INSERT INTO user_sessions (session_id, created_by, is_processing, created_at, last_activity) "
+                "VALUES ('sess-1', 'alice@example.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ))
+            conn.execute(text(
+                "INSERT INTO user_sessions (session_id, created_by, is_processing, created_at, last_activity) "
+                "VALUES ('sess-2', 'bob@example.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ))
+        _run_migrations(engine_with_legacy_columns, schema=None)
+        with engine_with_legacy_columns.connect() as conn:
+            rows = conn.execute(text(
+                "SELECT dc.identity_id, dc.permission_level "
+                "FROM deck_contributors dc "
+                "WHERE dc.created_by = 'migration' "
+                "ORDER BY dc.identity_id"
+            )).fetchall()
+        assert len(rows) == 2
+        assert rows[0] == ("alice@example.com", "CAN_MANAGE")
+        assert rows[1] == ("bob@example.com", "CAN_MANAGE")
+
+    def test_deck_creator_manage_is_idempotent(self, engine_with_legacy_columns):
+        """Running migration twice should not duplicate CAN_MANAGE rows."""
+        with engine_with_legacy_columns.begin() as conn:
+            conn.execute(text(
+                "INSERT INTO user_sessions (session_id, created_by, is_processing, created_at, last_activity) "
+                "VALUES ('sess-idem', 'alice@example.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ))
+        _run_migrations(engine_with_legacy_columns, schema=None)
+        _run_migrations(engine_with_legacy_columns, schema=None)
+        with engine_with_legacy_columns.connect() as conn:
+            count = conn.execute(text(
+                "SELECT COUNT(*) FROM deck_contributors WHERE identity_id = 'alice@example.com'"
+            )).scalar()
+        assert count == 1
+
+    def test_deck_creator_skipped_when_already_has_contributor(self, engine_with_legacy_columns):
+        """If a creator already has a DeckContributor row, migration should not add another."""
+        with engine_with_legacy_columns.begin() as conn:
+            conn.execute(text(
+                "INSERT INTO user_sessions (session_id, created_by, is_processing, created_at, last_activity) "
+                "VALUES ('sess-existing', 'alice@example.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ))
+            # Manually add a CAN_EDIT contributor row (simulating pre-existing sharing)
+            session_id = conn.execute(text("SELECT id FROM user_sessions LIMIT 1")).scalar()
+            conn.execute(text(
+                "INSERT INTO deck_contributors "
+                "(user_session_id, identity_type, identity_id, identity_name, permission_level, created_at, updated_at) "
+                f"VALUES ({session_id}, 'USER', 'alice@example.com', 'alice@example.com', 'CAN_EDIT', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ))
+        _run_migrations(engine_with_legacy_columns, schema=None)
+        with engine_with_legacy_columns.connect() as conn:
+            rows = conn.execute(text(
+                "SELECT permission_level FROM deck_contributors WHERE identity_id = 'alice@example.com'"
+            )).fetchall()
+        # Should still be just the original row, not duplicated
+        assert len(rows) == 1
+        assert rows[0][0] == "CAN_EDIT"


### PR DESCRIPTION
## Summary
- Existing decks created before the deck-centric permissions migration had no `DeckContributor` row for their creator, so creators only got `CAN_EDIT` instead of `CAN_MANAGE`
- Adds an idempotent `INSERT...SELECT` step to `_migrate_deck_permissions_model` that backfills a `CAN_MANAGE` `DeckContributor` row for each session's `created_by` user
- Adds 3 tests: creator gets CAN_MANAGE, idempotency, and no-op when contributor already exists

## Test plan
- [x] All 9 deck permissions migration tests pass locally
- [ ] Deploy to existing environment and verify previously created decks show CAN_MANAGE

This pull request was AI-assisted by Isaac.