### PR TITLE
Add default profiles and deck prompts for new decks

### DIFF
--- a/docs/technical/frontend-overview.md
+++ b/docs/technical/frontend-overview.md
@@ -126,6 +126,16 @@ loadProfile(profileId)     // Load a profile's config into current session
 
 Used by: `AgentConfigBar`, `ChatPanel`.
 
+**Default resolution:** When no stored config exists (new session or first visit), the context resolves defaults for each config field using localStorage user preferences:
+
+| Config Field | localStorage Key | Priority |
+|---|---|---|
+| Profile | `userDefaultProfileId` | localStorage > server `is_my_default` > server `is_default` |
+| Slide Style | `userDefaultSlideStyleId` | localStorage > server `is_default` > server `is_system` |
+| Deck Prompt | `userDefaultDeckPromptId` | localStorage only (no server-side default) |
+
+Users set their defaults via the "Set as default" button on each settings page (`/profiles`, `/slide-styles`, `/deck-prompts`). The preference is per-browser, not synced to the backend.
+
 ### 4c. Profile Context (`src/contexts/ProfileContext.tsx`)
 
 Manages profile CRUD operations and the profile list. Wraps inside `AppLayout` (not app-level) because it's only needed by the profile management page.
@@ -201,6 +211,7 @@ interface DeckPrompt {
 2. Each session can select one prompt via `agent_config.deck_prompt_id`
 3. When generating slides, the selected prompt content is prepended to the system prompt
 4. User chat messages combine with the deck prompt for context-aware generation
+5. Users can set a personal default prompt via "Set as default" (stored in localStorage as `userDefaultDeckPromptId`); new sessions auto-select it
 
 ### 9. Save Points / Versioning (`src/components/SavePoints/`)
 
@@ -256,6 +267,7 @@ interface SlideStyle {
 2. Each session can select one style via `agent_config.slide_style_id`
 3. When generating slides, the selected style content is included in the system prompt
 4. Styles define typography (fonts, sizes), colors (brand palette, accents), and layout rules
+5. Users can set a personal default style via "Set as default" (stored in localStorage as `userDefaultSlideStyleId`); falls back to server `is_default` then `is_system`
 
 ---
 

--- a/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
+++ b/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
@@ -234,7 +234,6 @@ export const AgentConfigBar: React.FC = () => {
     setDeckPrompt,
     saveAsProfile,
     loadProfile,
-    isPreSession,
   } = useAgentConfig();
   const { sessionId } = useSession();
 
@@ -449,9 +448,8 @@ export const AgentConfigBar: React.FC = () => {
           <div className="flex items-center gap-2 pt-1">
             <button
               onClick={() => setSaveDialogOpen(true)}
-              disabled={isPreSession}
-              className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-600 hover:text-gray-800 border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              title={isPreSession ? 'Save requires an active session' : 'Save current config as a profile'}
+              className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-600 hover:text-gray-800 border border-gray-300 rounded hover:bg-gray-100 transition-colors"
+              title="Save current config as a profile"
               data-testid="save-profile-button"
             >
               <Save size={12} />

--- a/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
+++ b/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
@@ -200,9 +200,13 @@ const LoadProfileDialog: React.FC<{
               >
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-gray-800">{p.name}</span>
-                  {p.is_default && (
-                    <span className="text-[10px] uppercase text-gray-400 border border-gray-200 rounded px-1">default</span>
-                  )}
+                  {(() => {
+                    const userDefaultId = localStorage.getItem('userDefaultProfileId');
+                    const isDefault = userDefaultId ? p.id === Number(userDefaultId) : p.is_default;
+                    return isDefault ? (
+                      <span className="text-[10px] uppercase text-amber-700 bg-amber-500/10 border border-amber-200 rounded px-1">default</span>
+                    ) : null;
+                  })()}
                 </div>
                 {p.description && (
                   <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description}</p>

--- a/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
+++ b/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
@@ -9,7 +9,7 @@
  *  - "Save as Profile" / "Load Profile" actions
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Plus, X, Save, FolderOpen, Loader2, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
 import { useAgentConfig } from '../../contexts/AgentConfigContext';
 import { useSession } from '../../contexts/SessionContext';
@@ -148,6 +148,10 @@ const LoadProfileDialog: React.FC<{
   const [profiles, setProfiles] = useState<ProfileSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const userDefaultProfileId = useMemo(() => {
+    const stored = localStorage.getItem('userDefaultProfileId');
+    return stored ? Number(stored) : null;
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -200,13 +204,9 @@ const LoadProfileDialog: React.FC<{
               >
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-gray-800">{p.name}</span>
-                  {(() => {
-                    const userDefaultId = localStorage.getItem('userDefaultProfileId');
-                    const isDefault = userDefaultId ? p.id === Number(userDefaultId) : p.is_default;
-                    return isDefault ? (
-                      <span className="text-[10px] uppercase text-amber-700 bg-amber-500/10 border border-amber-200 rounded px-1">default</span>
-                    ) : null;
-                  })()}
+                  {(userDefaultProfileId != null ? p.id === userDefaultProfileId : p.is_default) && (
+                    <span className="text-[10px] uppercase text-amber-700 bg-amber-500/10 border border-amber-200 rounded px-1">default</span>
+                  )}
                 </div>
                 {p.description && (
                   <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description}</p>

--- a/frontend/src/components/config/DeckPromptList.tsx
+++ b/frontend/src/components/config/DeckPromptList.tsx
@@ -25,7 +25,11 @@ export const DeckPromptList: React.FC = () => {
   const [editingPrompt, setEditingPrompt] = useState<DeckPrompt | null>(null);
   const [actionLoading, setActionLoading] = useState<number | null>(null);
   const [expandedPromptId, setExpandedPromptId] = useState<number | null>(null);
-  
+  const [userDefaultDeckPromptId, setUserDefaultDeckPromptId] = useState<number | null>(() => {
+    const stored = localStorage.getItem('userDefaultDeckPromptId');
+    return stored ? Number(stored) : null;
+  });
+
   const [confirmDialog, setConfirmDialog] = useState<{
     isOpen: boolean;
     title: string;
@@ -55,6 +59,17 @@ export const DeckPromptList: React.FC = () => {
   useEffect(() => {
     loadPrompts();
   }, [loadPrompts]);
+
+  // Stale default cleanup: if stored default prompt no longer exists, clear it
+  useEffect(() => {
+    if (!loading && userDefaultDeckPromptId != null && prompts.length > 0) {
+      const exists = prompts.some(p => p.id === userDefaultDeckPromptId);
+      if (!exists) {
+        localStorage.removeItem('userDefaultDeckPromptId');
+        setUserDefaultDeckPromptId(null);
+      }
+    }
+  }, [prompts, loading, userDefaultDeckPromptId]);
 
   // Handle create
   const handleCreate = () => {
@@ -94,6 +109,11 @@ export const DeckPromptList: React.FC = () => {
         setActionLoading(prompt.id);
         try {
           await configApi.deleteDeckPrompt(prompt.id);
+          // Clear localStorage default if the deleted prompt was the default
+          if (userDefaultDeckPromptId === prompt.id) {
+            localStorage.removeItem('userDefaultDeckPromptId');
+            setUserDefaultDeckPromptId(null);
+          }
           await loadPrompts();
         } catch (err) {
           setError(err instanceof Error ? err.message : 'Failed to delete prompt');
@@ -185,6 +205,11 @@ export const DeckPromptList: React.FC = () => {
                             {prompt.category}
                           </Badge>
                         )}
+                        {prompt.id === userDefaultDeckPromptId && (
+                          <Badge className="text-xs bg-amber-500/10 text-amber-700 hover:bg-amber-500/20">
+                            Default
+                          </Badge>
+                        )}
                         {!prompt.is_active && (
                           <Badge variant="outline" className="text-xs">
                             Inactive
@@ -204,6 +229,20 @@ export const DeckPromptList: React.FC = () => {
 
                     {/* Actions */}
                     <div className="flex shrink-0 items-center gap-1">
+                      {prompt.id !== userDefaultDeckPromptId && prompt.is_active && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 px-2 text-xs text-muted-foreground"
+                          onClick={() => {
+                            localStorage.setItem('userDefaultDeckPromptId', String(prompt.id));
+                            setUserDefaultDeckPromptId(prompt.id);
+                          }}
+                          aria-label="Set as default"
+                        >
+                          Set as default
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="sm"

--- a/frontend/src/components/config/ProfileList.tsx
+++ b/frontend/src/components/config/ProfileList.tsx
@@ -6,7 +6,7 @@
  * - Delete profile
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { User, ChevronDown, Trash2, Pencil, Share2, MessageSquare, Palette, FileText, Wrench } from 'lucide-react';
 import { Button } from '@/ui/button';
 import { Badge } from '@/ui/badge';
@@ -159,6 +159,10 @@ export const ProfileList: React.FC = () => {
     const stored = localStorage.getItem('userDefaultProfileId');
     return stored ? Number(stored) : null;
   });
+  const isDefaultProfile = useCallback((profile: { id: number; is_my_default?: boolean }) =>
+    userDefaultProfileId != null ? profile.id === userDefaultProfileId : !!profile.is_my_default,
+    [userDefaultProfileId],
+  );
   const [nameLookups, setNameLookups] = useState<NameLookups>({
     slideStyles: new Map(),
     deckPrompts: new Map(),
@@ -330,7 +334,7 @@ export const ProfileList: React.FC = () => {
                         <h3 className="text-sm font-medium text-foreground">
                           {profile.name}
                         </h3>
-                        {(userDefaultProfileId != null ? profile.id === userDefaultProfileId : profile.is_my_default) && (
+                        {isDefaultProfile(profile) && (
                           <Badge className="text-xs bg-amber-500/10 text-amber-700 hover:bg-amber-500/20">
                             Default
                           </Badge>
@@ -343,7 +347,7 @@ export const ProfileList: React.FC = () => {
 
                     {/* Actions */}
                     <div className="flex shrink-0 items-center gap-1">
-                      {!(userDefaultProfileId != null ? profile.id === userDefaultProfileId : profile.is_my_default) && (
+                      {!isDefaultProfile(profile) && (
                         <Button
                           variant="ghost"
                           size="sm"

--- a/frontend/src/components/config/ProfileList.tsx
+++ b/frontend/src/components/config/ProfileList.tsx
@@ -155,6 +155,10 @@ export const ProfileList: React.FC = () => {
   const [actionLoading, setActionLoading] = useState<number | null>(null);
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [sharingProfileId, setSharingProfileId] = useState<number | null>(null);
+  const [userDefaultProfileId, setUserDefaultProfileId] = useState<number | null>(() => {
+    const stored = localStorage.getItem('userDefaultProfileId');
+    return stored ? Number(stored) : null;
+  });
   const [nameLookups, setNameLookups] = useState<NameLookups>({
     slideStyles: new Map(),
     deckPrompts: new Map(),
@@ -180,6 +184,17 @@ export const ProfileList: React.FC = () => {
     fetchLookups();
     return () => { cancelled = true; };
   }, []);
+  // Stale default cleanup: if stored default profile no longer exists, clear it
+  useEffect(() => {
+    if (!loading && userDefaultProfileId != null) {
+      const exists = profiles.some(p => p.id === userDefaultProfileId);
+      if (!exists) {
+        localStorage.removeItem('userDefaultProfileId');
+        setUserDefaultProfileId(null);
+      }
+    }
+  }, [profiles, loading, userDefaultProfileId]);
+
   const [renamingId, setRenamingId] = useState<number | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [renameError, setRenameError] = useState<string | null>(null);
@@ -201,6 +216,11 @@ export const ProfileList: React.FC = () => {
         setActionLoading(profile.id);
         try {
           await deleteProfile(profile.id);
+          // Clear localStorage default if the deleted profile was the default
+          if (userDefaultProfileId === profile.id) {
+            localStorage.removeItem('userDefaultProfileId');
+            setUserDefaultProfileId(null);
+          }
           setConfirmDialog(prev => ({ ...prev, isOpen: false, loading: false }));
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Failed to delete profile';
@@ -310,8 +330,8 @@ export const ProfileList: React.FC = () => {
                         <h3 className="text-sm font-medium text-foreground">
                           {profile.name}
                         </h3>
-                        {profile.is_my_default && (
-                          <Badge variant="secondary" className="text-xs">
+                        {(userDefaultProfileId != null ? profile.id === userDefaultProfileId : profile.is_my_default) && (
+                          <Badge className="text-xs bg-amber-500/10 text-amber-700 hover:bg-amber-500/20">
                             Default
                           </Badge>
                         )}
@@ -323,6 +343,20 @@ export const ProfileList: React.FC = () => {
 
                     {/* Actions */}
                     <div className="flex shrink-0 items-center gap-1">
+                      {!(userDefaultProfileId != null ? profile.id === userDefaultProfileId : profile.is_my_default) && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 px-2 text-xs text-muted-foreground"
+                          onClick={() => {
+                            localStorage.setItem('userDefaultProfileId', String(profile.id));
+                            setUserDefaultProfileId(profile.id);
+                          }}
+                          aria-label="Set as default"
+                        >
+                          Set as default
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="sm"

--- a/frontend/src/contexts/AgentConfigContext.tsx
+++ b/frontend/src/contexts/AgentConfigContext.tsx
@@ -324,17 +324,17 @@ export const AgentConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
   // ------------------------------------------------------------------
 
   const saveAsProfile = useCallback(async (name: string, description?: string) => {
-    if (isPreSession || !urlSessionId) {
-      showToast('Save as profile requires an active session', 'error');
-      return;
-    }
-
     try {
-      await api.saveAsProfile(urlSessionId, name, description, agentConfig);
+      if (isPreSession || !urlSessionId) {
+        await api.createProfile(name, description, agentConfig);
+      } else {
+        await api.saveAsProfile(urlSessionId, name, description, agentConfig);
+      }
       showToast(`Profile "${name}" saved`, 'success');
     } catch (err) {
       console.error('Failed to save as profile:', err);
-      showToast('Failed to save profile', 'error');
+      const message = err instanceof Error ? err.message : 'Failed to save profile';
+      showToast(message, 'error');
     }
   }, [isPreSession, urlSessionId, showToast, agentConfig]);
 

--- a/frontend/src/contexts/AgentConfigContext.tsx
+++ b/frontend/src/contexts/AgentConfigContext.tsx
@@ -197,14 +197,10 @@ export const AgentConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
       .then(async (config) => {
         if (cancelled) return;
 
-        // If the session has an empty/default config (new deck), load the default profile
-        const isEmpty = config.tools.length === 0
-          && config.slide_style_id == null
-          && config.deck_prompt_id == null
-          && config.system_prompt == null
-          && config.slide_editing_instructions == null;
+        // If the session has no explicitly-saved config, load the default profile
+        const isConfigured = (config as AgentConfig & { is_configured?: boolean }).is_configured ?? true;
 
-        if (isEmpty) {
+        if (!isConfigured) {
           try {
             const profiles = await api.listProfiles();
             const userProfileId = localStorage.getItem('userDefaultProfileId');

--- a/frontend/src/contexts/AgentConfigContext.tsx
+++ b/frontend/src/contexts/AgentConfigContext.tsx
@@ -77,6 +77,16 @@ async function resolveDefaultStyleId(): Promise<number | null> {
   }
 }
 
+/**
+ * Resolve the default deck prompt ID from user preference.
+ * Priority: user localStorage only (no server-side default for deck prompts).
+ */
+function resolveDefaultDeckPromptId(): number | null {
+  const userPromptId = localStorage.getItem('userDefaultDeckPromptId');
+  if (userPromptId) return Number(userPromptId);
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
@@ -96,11 +106,15 @@ export const AgentConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
     () => {
       const stored = readStoredConfig();
       if (stored) return stored;
-      // Apply user default style synchronously so the dropdown shows it immediately
+      // Apply user defaults synchronously so dropdowns show them immediately
       const config = { ...DEFAULT_AGENT_CONFIG };
       const userStyleId = localStorage.getItem('userDefaultSlideStyleId');
       if (userStyleId) {
         config.slide_style_id = Number(userStyleId);
+      }
+      const userDeckPromptId = resolveDefaultDeckPromptId();
+      if (userDeckPromptId) {
+        config.deck_prompt_id = userDeckPromptId;
       }
       return config;
     },
@@ -121,18 +135,37 @@ export const AgentConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
     const storedConfig = readStoredConfig();
 
-    // If we have a stored config with a style already set, use it as-is
-    if (storedConfig?.slide_style_id != null) return;
+    // If we have a stored config with tools already configured, it's a real
+    // user-modified config — keep it as-is and just fill in missing defaults.
+    if (storedConfig && storedConfig.tools.length > 0) {
+      if (storedConfig.slide_style_id == null || storedConfig.deck_prompt_id == null) {
+        resolveDefaultStyleId().then(styleId => {
+          const updated = { ...storedConfig };
+          if (updated.slide_style_id == null) updated.slide_style_id = styleId;
+          if (updated.deck_prompt_id == null) updated.deck_prompt_id = resolveDefaultDeckPromptId();
+          setAgentConfig(updated);
+        });
+      }
+      return;
+    }
 
-    // Otherwise, load profile config and apply default style
+    // Otherwise, load default profile config and apply defaults
     api.listProfiles()
       .then(async (profiles: ProfileSummary[]) => {
-        const defaultProfile = profiles.find(p => p.is_default);
-        const config = storedConfig
-          ?? (defaultProfile?.agent_config ? { ...defaultProfile.agent_config } : { ...DEFAULT_AGENT_CONFIG });
+        // Prefer user's localStorage profile default over server is_default
+        const userProfileId = localStorage.getItem('userDefaultProfileId');
+        const defaultProfile = userProfileId
+          ? profiles.find(p => p.id === Number(userProfileId)) ?? profiles.find(p => p.is_default)
+          : profiles.find(p => p.is_default);
+        const config = defaultProfile?.agent_config
+          ? { ...defaultProfile.agent_config }
+          : { ...DEFAULT_AGENT_CONFIG };
 
         if (config.slide_style_id == null) {
           config.slide_style_id = await resolveDefaultStyleId();
+        }
+        if (config.deck_prompt_id == null) {
+          config.deck_prompt_id = resolveDefaultDeckPromptId();
         }
 
         setAgentConfig(config);
@@ -140,6 +173,16 @@ export const AgentConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
       .catch(err => {
         console.error('Failed to load default profile for pre-session config:', err);
       });
+  }, [isPreSession]);
+
+  // ------------------------------------------------------------------
+  // Reset default-profile flag when entering an active session so
+  // clicking "New Deck" later will re-load the default profile.
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    if (!isPreSession) {
+      defaultProfileLoaded.current = false;
+    }
   }, [isPreSession]);
 
   // ------------------------------------------------------------------
@@ -153,8 +196,34 @@ export const AgentConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
     api.getAgentConfig(urlSessionId)
       .then(async (config) => {
         if (cancelled) return;
+
+        // If the session has an empty/default config (new deck), load the default profile
+        const isEmpty = config.tools.length === 0
+          && config.slide_style_id == null
+          && config.deck_prompt_id == null
+          && config.system_prompt == null
+          && config.slide_editing_instructions == null;
+
+        if (isEmpty) {
+          try {
+            const profiles = await api.listProfiles();
+            const userProfileId = localStorage.getItem('userDefaultProfileId');
+            const defaultProfile = userProfileId
+              ? profiles.find((p: ProfileSummary) => p.id === Number(userProfileId)) ?? profiles.find((p: ProfileSummary) => p.is_default)
+              : profiles.find((p: ProfileSummary) => p.is_default);
+            if (defaultProfile?.agent_config) {
+              config = { ...defaultProfile.agent_config };
+            }
+          } catch {
+            // Non-critical — continue with defaults
+          }
+        }
+
         if (config.slide_style_id == null) {
           config.slide_style_id = await resolveDefaultStyleId();
+        }
+        if (config.deck_prompt_id == null) {
+          config.deck_prompt_id = resolveDefaultDeckPromptId();
         }
         setAgentConfig(config);
       })
@@ -265,13 +334,13 @@ export const AgentConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
     }
 
     try {
-      await api.saveAsProfile(urlSessionId, name, description);
+      await api.saveAsProfile(urlSessionId, name, description, agentConfig);
       showToast(`Profile "${name}" saved`, 'success');
     } catch (err) {
       console.error('Failed to save as profile:', err);
       showToast('Failed to save profile', 'error');
     }
-  }, [isPreSession, urlSessionId, showToast]);
+  }, [isPreSession, urlSessionId, showToast, agentConfig]);
 
   const refreshConfig = useCallback(async () => {
     if (isPreSession || !urlSessionId) return;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1685,13 +1685,13 @@ export const api = {
   /**
    * Save the current session's agent config as a named profile.
    */
-  async saveAsProfile(sessionId: string, name: string, description?: string): Promise<ProfileSummary> {
+  async saveAsProfile(sessionId: string, name: string, description?: string, agentConfig?: AgentConfig): Promise<ProfileSummary> {
     const response = await fetch(
       `${API_BASE_URL}/api/profiles/save-from-session/${sessionId}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, description }),
+        body: JSON.stringify({ name, description, agent_config: agentConfig }),
       }
     );
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1704,6 +1704,27 @@ export const api = {
   },
 
   /**
+   * Create a profile directly from config (no session required).
+   */
+  async createProfile(name: string, description?: string, agentConfig?: AgentConfig): Promise<ProfileSummary> {
+    const response = await fetch(
+      `${API_BASE_URL}/api/profiles`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, description, agent_config: agentConfig }),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new ApiError(response.status, error.detail || 'Failed to create profile');
+    }
+
+    return response.json();
+  },
+
+  /**
    * Load a profile's agent config into a session.
    */
   async loadProfile(sessionId: string, profileId: number): Promise<{ status: string; agent_config: AgentConfig }> {

--- a/src/api/routes/agent_config.py
+++ b/src/api/routes/agent_config.py
@@ -89,8 +89,11 @@ async def get_agent_config(session_id: str):
     except SessionNotFoundError:
         raise HTTPException(status_code=404, detail=f"Session not found: {session_id}")
 
-    config = resolve_agent_config(session.get("agent_config"))
-    return config.model_dump()
+    raw = session.get("agent_config")
+    config = resolve_agent_config(raw)
+    result = config.model_dump()
+    result["is_configured"] = raw is not None
+    return result
 
 
 @router.put("")

--- a/src/api/routes/profiles.py
+++ b/src/api/routes/profiles.py
@@ -28,7 +28,7 @@ load_router = APIRouter(prefix="/api/sessions", tags=["profiles"])
 class SaveProfileRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     description: Optional[str] = None
-    agent_config: Optional[dict] = None  # Client-side config takes precedence over session
+    agent_config: Optional[AgentConfig] = None  # Client-side config takes precedence over session
 
 
 class UpdateProfileRequest(BaseModel):
@@ -129,8 +129,7 @@ async def save_from_session(session_id: str, body: SaveProfileRequest):
             )
 
     # Prefer client-side config (has resolved defaults) over session's stored config
-    raw_config = body.agent_config if body.agent_config else session.get("agent_config")
-    config = resolve_agent_config(raw_config)
+    config = body.agent_config if body.agent_config else resolve_agent_config(session.get("agent_config"))
 
     # Strip session-specific conversation_ids before persisting
     for tool in config.tools:

--- a/src/api/routes/profiles.py
+++ b/src/api/routes/profiles.py
@@ -28,6 +28,7 @@ load_router = APIRouter(prefix="/api/sessions", tags=["profiles"])
 class SaveProfileRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     description: Optional[str] = None
+    agent_config: Optional[dict] = None  # Client-side config takes precedence over session
 
 
 class UpdateProfileRequest(BaseModel):
@@ -127,7 +128,8 @@ async def save_from_session(session_id: str, body: SaveProfileRequest):
                 detail="You don't have permission to save a profile from this session",
             )
 
-    raw_config = session.get("agent_config")
+    # Prefer client-side config (has resolved defaults) over session's stored config
+    raw_config = body.agent_config if body.agent_config else session.get("agent_config")
     config = resolve_agent_config(raw_config)
 
     # Strip session-specific conversation_ids before persisting
@@ -138,24 +140,6 @@ async def save_from_session(session_id: str, body: SaveProfileRequest):
     config_dict = config.model_dump()
 
     with get_db_session() as db:
-        # Check for duplicate agent_config among non-deleted profiles
-        existing_profiles = (
-            db.query(ConfigProfile)
-            .filter(ConfigProfile.is_deleted == False)  # noqa: E712
-            .all()
-        )
-        for existing in existing_profiles:
-            existing_config = resolve_agent_config(existing.agent_config)
-            # Strip conversation_ids from existing for fair comparison
-            for tool in existing_config.tools:
-                if isinstance(tool, GenieTool):
-                    tool.conversation_id = None
-            if existing_config.model_dump() == config_dict:
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"A profile with this configuration already exists: '{existing.name}'",
-                )
-
         current_user = get_current_user()
         profile = ConfigProfile(
             name=body.name,

--- a/src/api/routes/profiles.py
+++ b/src/api/routes/profiles.py
@@ -31,6 +31,12 @@ class SaveProfileRequest(BaseModel):
     agent_config: Optional[AgentConfig] = None  # Client-side config takes precedence over session
 
 
+class CreateProfileRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = None
+    agent_config: AgentConfig
+
+
 class UpdateProfileRequest(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=100)
     description: Optional[str] = None
@@ -97,6 +103,50 @@ async def list_profiles():
         return [_profile_to_dict(p) for p in profiles]
 
 
+@router.post("", status_code=201)
+async def create_profile(body: CreateProfileRequest):
+    """Create a profile directly from a provided agent_config (no session required)."""
+    config = body.agent_config
+
+    # Strip session-specific conversation_ids before persisting
+    for tool in config.tools:
+        if isinstance(tool, GenieTool):
+            tool.conversation_id = None
+
+    config_dict = config.model_dump()
+
+    with get_db_session() as db:
+        # Check for duplicate agent_config among non-deleted profiles
+        existing_profiles = (
+            db.query(ConfigProfile)
+            .filter(ConfigProfile.is_deleted == False)  # noqa: E712
+            .all()
+        )
+        for existing in existing_profiles:
+            existing_config = resolve_agent_config(existing.agent_config)
+            for tool in existing_config.tools:
+                if isinstance(tool, GenieTool):
+                    tool.conversation_id = None
+            if existing_config.model_dump() == config_dict:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"A profile with this configuration already exists: '{existing.name}'",
+                )
+
+        current_user = get_current_user()
+        profile = ConfigProfile(
+            name=body.name,
+            description=body.description,
+            agent_config=config_dict,
+            created_by=current_user,
+        )
+        db.add(profile)
+        db.flush()
+        result = _profile_to_dict(profile)
+
+    return result
+
+
 @router.post("/save-from-session/{session_id}", status_code=201)
 async def save_from_session(session_id: str, body: SaveProfileRequest):
     """Snapshot a session's agent_config into a new named profile."""
@@ -139,6 +189,24 @@ async def save_from_session(session_id: str, body: SaveProfileRequest):
     config_dict = config.model_dump()
 
     with get_db_session() as db:
+        # Check for duplicate agent_config among non-deleted profiles
+        existing_profiles = (
+            db.query(ConfigProfile)
+            .filter(ConfigProfile.is_deleted == False)  # noqa: E712
+            .all()
+        )
+        for existing in existing_profiles:
+            existing_config = resolve_agent_config(existing.agent_config)
+            # Strip conversation_ids from existing for fair comparison
+            for tool in existing_config.tools:
+                if isinstance(tool, GenieTool):
+                    tool.conversation_id = None
+            if existing_config.model_dump() == config_dict:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"A profile with this configuration already exists: '{existing.name}'",
+                )
+
         current_user = get_current_user()
         profile = ConfigProfile(
             name=body.name,


### PR DESCRIPTION
## Add default profiles and deck prompts for new decks

### Summary
- Users can set a default **profile**, **deck prompt**, and **slide style** via "Set as default" on each settings page
- New decks automatically load the default profile's config (tools, style, prompt) — no manual setup required
- Defaults stored in localStorage per user (no database changes)
- "Save as Profile" now works from pre-session mode and sends the client-side config instead of reading stale backend data
- Duplicate profile detection prevents saving profiles with identical configs
- Error toasts now show detailed backend messages instead of generic "Failed to save"

### Files changed
**Frontend:**
- `AgentConfigBar.tsx` — Default label in Load Profile dialog, enabled Save as Profile in pre-session
- `AgentConfigContext.tsx` — Default profile/deck prompt resolution, pre-session save support, new session auto-load
- `ProfileList.tsx` — "Set as default" button + localStorage + amber badge
- `DeckPromptList.tsx` — "Set as default" button + localStorage + amber badge
- `api.ts` — `createProfile` endpoint, `saveAsProfile` sends client config

**Backend:**
- `profiles.py` — `POST /api/profiles` for session-free profile creation, `agent_config` in save request body, duplicate detection
- `agent_config.py` — `is_configured` flag for empty session detection

**Docs:**
- `frontend-overview.md` — Default resolution priority table

### Test plan
- [X] Set default deck prompt → amber badge appears, persists on refresh
- [X] Set default profile → amber badge appears, persists on refresh
- [X] Change default → badge moves to new item
- [X] Click "New Deck" from active session → default profile auto-loads (tools, style, prompt)
- [X] Open app fresh → default profile auto-loads
- [X] Save as Profile from pre-session → profile created with correct config
- [X] Save as Profile from active session → profile captures UI state including tools
- [X] Save duplicate config → 409 error with descriptive message
- [X] Load Profile dialog → shows "DEFAULT" label on correct profile
- [X] Delete default profile → badge disappears, localStorage cleared