### PR TITLE
fix: add PKCE support to Google OAuth flow

### DIFF
--- a/src/api/routes/google_slides.py
+++ b/src/api/routes/google_slides.py
@@ -180,12 +180,13 @@ async def auth_callback(
 
         auth = _get_auth(db)
         redirect_uri = _build_redirect_uri(request)
-        auth.authorize(code=code, redirect_uri=redirect_uri)
+        code_verifier = state_data.get("code_verifier")
+        auth.authorize(code=code, redirect_uri=redirect_uri, code_verifier=code_verifier)
         logger.info(
             "Google Slides OAuth callback successful",
             extra={"user": _get_user_identity()},
         )
-    except (GoogleSlidesAuthError, ValueError, json.JSONDecodeError) as exc:
+    except Exception as exc:
         logger.error("OAuth callback failed", exc_info=True)
         return HTMLResponse(
             content=f"""

--- a/src/services/google_slides_auth.py
+++ b/src/services/google_slides_auth.py
@@ -10,8 +10,11 @@ Supports two modes:
      from disk, same as the legacy behaviour.
 """
 
+import base64
+import hashlib
 import json
 import logging
+import secrets
 from pathlib import Path
 from typing import Optional
 
@@ -212,30 +215,62 @@ class GoogleSlidesAuth:
             )
         return creds
 
+    @staticmethod
+    def _generate_pkce() -> tuple[str, str]:
+        """Generate a PKCE code_verifier and code_challenge pair."""
+        verifier = secrets.token_urlsafe(64)
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        return verifier, challenge
+
     def get_auth_url(self, redirect_uri: str, state: str | None = None) -> str:
-        """Generate the OAuth2 consent URL.
+        """Generate the OAuth2 consent URL with PKCE.
+
+        A PKCE ``code_verifier`` is generated and embedded in the OAuth
+        ``state`` parameter so it round-trips through the callback and can
+        be passed to :pymeth:`authorize`.
 
         Args:
             redirect_uri: The registered OAuth callback URI (no query params).
-            state: Optional opaque string that Google will return unchanged on
-                   the callback.  Used to carry profile_id / user context.
+            state: Optional JSON string carrying caller context (e.g. user
+                identity).  A ``code_verifier`` key will be injected into it.
         """
         flow = self._build_flow(redirect_uri)
-        kwargs: dict = {
-            "access_type": "offline",
-            "include_granted_scopes": "true",
-            "prompt": "consent",
-        }
-        if state:
-            kwargs["state"] = state
-        auth_url, _ = flow.authorization_url(**kwargs)
+        verifier, challenge = self._generate_pkce()
+
+        # Inject code_verifier into the state payload
+        state_data = json.loads(state) if state else {}
+        state_data["code_verifier"] = verifier
+
+        auth_url, _ = flow.authorization_url(
+            access_type="offline",
+            include_granted_scopes="true",
+            prompt="consent",
+            state=json.dumps(state_data),
+            code_challenge=challenge,
+            code_challenge_method="S256",
+        )
         logger.info("Generated Google OAuth consent URL")
         return auth_url
 
-    def authorize(self, code: str, redirect_uri: str) -> Credentials:
-        """Exchange an authorization code for tokens and persist them."""
+    def authorize(
+        self,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str | None = None,
+    ) -> Credentials:
+        """Exchange an authorization code for tokens and persist them.
+
+        Args:
+            code: The authorization code from the OAuth callback.
+            redirect_uri: Must match the URI used for the consent URL.
+            code_verifier: The PKCE code verifier from the OAuth state.
+        """
         flow = self._build_flow(redirect_uri)
-        flow.fetch_token(code=code)
+        flow.fetch_token(code=code, code_verifier=code_verifier)
         creds = flow.credentials
         self._save_token(creds)
         logger.info("Google OAuth authorization successful, token saved")

--- a/tests/unit/test_google_slides_routes.py
+++ b/tests/unit/test_google_slides_routes.py
@@ -172,6 +172,51 @@ class TestAuthUrl:
 # Export endpoint
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Auth callback endpoint
+# ---------------------------------------------------------------------------
+
+class TestAuthCallback:
+
+    def test_callback_no_credentials_returns_failure_html(self, test_client):
+        """No global credentials → returns HTML failure page (not 500)."""
+        state = json.dumps({"user": "local_dev"})
+        resp = test_client.get(
+            "/api/export/google-slides/auth/callback",
+            params={"code": "fake-code", "state": state},
+        )
+        assert resp.status_code == 200
+        assert "Authorization Failed" in resp.text
+
+    def test_callback_invalid_code_returns_failure_html(self, test_client, session_factory):
+        """Valid credentials but invalid auth code → returns HTML failure page (not 500).
+
+        Regression test: previously, OAuth library exceptions (e.g. InvalidGrantError)
+        were not caught, causing a raw 500 Internal Server Error.
+        """
+        _seed_global_credentials(session_factory)
+        state = json.dumps({"user": "local_dev"})
+        resp = test_client.get(
+            "/api/export/google-slides/auth/callback",
+            params={"code": "invalid-code", "state": state},
+        )
+        assert resp.status_code == 200
+        assert "Authorization Failed" in resp.text
+
+    def test_callback_missing_user_in_state(self, test_client):
+        """State without user key → returns HTML failure page."""
+        resp = test_client.get(
+            "/api/export/google-slides/auth/callback",
+            params={"code": "fake-code", "state": "{}"},
+        )
+        assert resp.status_code == 200
+        assert "Authorization Failed" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Export endpoint
+# ---------------------------------------------------------------------------
+
 class TestExportEndpoint:
 
     def test_export_no_credentials_returns_400(self, test_client):


### PR DESCRIPTION
## Summary
- **PKCE support**: Google now enforces PKCE on OAuth token exchanges. Added `code_challenge`/`code_verifier` generation to the auth URL and token exchange. The verifier is round-tripped through the OAuth `state` parameter.
- **Broader error handling**: The OAuth callback previously only caught 3 specific exception types — OAuth library errors (e.g. `InvalidGrantError`) fell through as raw 500s. Now catches all exceptions and returns a proper error page.
- **Regression tests**: Added 3 tests for the callback endpoint covering missing credentials, invalid codes, and missing state.

## Test plan
- [x] Upload Google credentials on `/admin` page
- [x] Click "Export to Google Slides" → OAuth popup opens with PKCE challenge
- [x] Complete Google consent → callback exchanges code with verifier → authorization succeeds
- [x] Unit tests pass (`pytest tests/unit/test_google_slides_routes.py`)

This pull request was AI-assisted by Isaac.