### PR TITLE
Fix: handle missing default profile instead of raising ValueError

### DIFF
--- a/src/core/settings_db.py
+++ b/src/core/settings_db.py
@@ -194,7 +194,23 @@ def load_settings_from_database(profile_id: Optional[int] = None) -> AppSettings
                 # No profile specified and no active profile - use default
                 profile = db.query(ConfigProfile).filter_by(is_default=True).first()
                 if not profile:
-                    raise ValueError("No default profile found in database")
+                    # No default profile — return settings built from defaults
+                    logger.info("No default profile found in database, using built-in defaults")
+                    from src.core.defaults import DEFAULT_CONFIG
+                    llm_defaults = DEFAULT_CONFIG["llm"]
+                    return AppSettings(
+                        database_url=os.getenv("DATABASE_URL", ""),
+                        profile_id=0,
+                        profile_name="default",
+                        llm=LLMSettings(
+                            endpoint=llm_defaults["endpoint"],
+                            temperature=llm_defaults["temperature"],
+                            max_tokens=llm_defaults["max_tokens"],
+                        ),
+                        genie=None,
+                        prompts={},
+                        environment=os.getenv("ENVIRONMENT", "development"),
+                    )
             else:
                 # Specific profile requested
                 profile = db.query(ConfigProfile).filter_by(id=profile_id).first()

--- a/tests/unit/test_settings_db.py
+++ b/tests/unit/test_settings_db.py
@@ -136,7 +136,7 @@ def test_load_settings_specific_profile(test_db, test_profile, monkeypatch):
 
 
 def test_load_settings_no_default_profile(test_db, monkeypatch):
-    """Test error when no default profile exists."""
+    """Test fallback to built-in defaults when no default profile exists."""
     # Mock get_db_session
     def mock_get_db_session():
         class MockContextManager:
@@ -145,12 +145,15 @@ def test_load_settings_no_default_profile(test_db, monkeypatch):
             def __exit__(self, *args):
                 pass
         return MockContextManager()
-    
+
     monkeypatch.setattr("src.core.settings_db.get_db_session", mock_get_db_session)
-    
-    # Should raise ValueError
-    with pytest.raises(ValueError, match="No default profile found"):
-        load_settings_from_database()
+
+    # Should return default settings instead of raising
+    settings = load_settings_from_database()
+    assert settings.profile_id == 0
+    assert settings.profile_name == "default"
+    assert settings.genie is None
+    assert settings.prompts == {}
 
 
 def test_load_settings_profile_not_found(test_db, monkeypatch):


### PR DESCRIPTION
## Fix: handle missing default profile gracefully

### Summary
- App crashed with "No default profile found in database" when creating a deck with no profiles configured
- `load_settings_from_database()` now returns built-in defaults instead of raising `ValueError` when no default profile exists
- Profiles are fully optional — the app works with or without them

### Test plan
- [x] Delete all profiles → create new deck → send message → slide generates without error
- [x] Existing profile flows unaffected