### PR TITLE
fix: presentation mode closing after a few seconds

### DIFF
--- a/frontend/src/components/PresentationMode/PresentationMode.tsx
+++ b/frontend/src/components/PresentationMode/PresentationMode.tsx
@@ -18,6 +18,8 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const onExitRef = useRef(onExit);
+  onExitRef.current = onExit;
 
   // Generate HTML for current slide (no reveal.js)
   const currentSlideHTML = useMemo(() => {
@@ -219,7 +221,7 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
     return () => clearTimeout(timer);
   }, []);
 
-  // Handle fullscreen
+  // Handle fullscreen — runs once on mount only
   useEffect(() => {
     document.documentElement.requestFullscreen().catch(() => {
       // Fallback: still show presentation if fullscreen denied
@@ -227,7 +229,7 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
 
     const handleFullscreenChange = () => {
       if (!document.fullscreenElement) {
-        onExit();
+        onExitRef.current();
       } else {
         // Recalculate scale when entering fullscreen (viewport size may change)
         setTimeout(() => {
@@ -257,7 +259,7 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
         document.exitFullscreen();
       }
     };
-  }, [onExit]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle iframe load - refocus container to capture keyboard events
   const handleIframeLoad = () => {

--- a/frontend/tests/e2e/presentation-mode.spec.ts
+++ b/frontend/tests/e2e/presentation-mode.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, Page } from '@playwright/test';
+import { setupMocks } from '../helpers/setup-mocks';
+import { mockSessionWithSlides, TEST_SESSION_ID } from '../helpers/session-helpers';
+
+/**
+ * Presentation Mode UI Tests
+ *
+ * Tests that presentation mode stays open despite parent component re-renders.
+ * Regression test for: inline onExit callback + [onExit] useEffect dependency
+ * caused fullscreen to exit whenever SlidePanel re-rendered (e.g. from mentions polling).
+ *
+ * Run: cd frontend && npx playwright test tests/e2e/presentation-mode.spec.ts
+ */
+
+async function setupPresentationMocks(page: Page) {
+  await setupMocks(page);
+  await mockSessionWithSlides(page, TEST_SESSION_ID);
+
+  // Mock lock/user/mentions endpoints (SlidePanel polls mentions every 3s)
+  await page.route('**/api/user/current', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ username: 'test@test.com', display_name: 'Test User' }),
+    });
+  });
+  await page.route(/\/api\/sessions\/[^/]+\/lock$/, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ locked_by: 'test@test.com', locked_at: new Date().toISOString() }),
+    });
+  });
+  await page.route('**/api/comments/mentions**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ mentions: [], count: 0 }),
+    });
+  });
+  await page.route('**/api/comments/mentionable-users**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ users: [], is_global: false }),
+    });
+  });
+}
+
+/** Locator for the presentation overlay (portal rendered at document.body). */
+function presentationOverlay(page: Page) {
+  // The overlay is a fixed div with slide counter text like "1 / 3"
+  return page.locator('div[style*="position: fixed"][style*="z-index: 9999"]');
+}
+
+test.describe('Presentation Mode', () => {
+  test('stays open despite parent re-renders from polling', async ({ page }) => {
+    await setupPresentationMocks(page);
+
+    // Navigate to a session with slides
+    await page.goto(`/sessions/${TEST_SESSION_ID}/edit`);
+
+    // Wait for slides to render and Present button to appear
+    const presentButton = page.getByRole('button', { name: 'Present' });
+    await presentButton.waitFor({ state: 'visible', timeout: 15000 });
+
+    // Click Present to open presentation mode
+    await presentButton.click();
+
+    // Verify the presentation overlay appeared
+    const overlay = presentationOverlay(page);
+    await expect(overlay).toBeVisible({ timeout: 5000 });
+
+    // Verify slide counter is showing (confirms presentation is functional)
+    await expect(page.getByText(/1\s*\/\s*\d+/)).toBeVisible();
+
+    // Wait well beyond the 3s mentions polling interval.
+    // Before the fix, the first polling response would re-render SlidePanel,
+    // create a new onExit reference, trigger the fullscreen useEffect cleanup,
+    // and close presentation mode.
+    await page.waitForTimeout(7000);
+
+    // Presentation overlay must still be visible
+    await expect(overlay).toBeVisible();
+    await expect(page.getByText(/1\s*\/\s*\d+/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Presentation mode was closing ~3-5 seconds after opening because the fullscreen `useEffect` had `[onExit]` in its dependency array, and `onExit` was an inline arrow function from `SlidePanel` that got a new reference on every re-render
- The 3-second mentions polling (`setInterval(fetchMentions, 3_000)`) triggered `SlidePanel` re-renders, which recreated `onExit`, which triggered the effect cleanup calling `document.exitFullscreen()`
- Fixed by storing `onExit` in a ref so the fullscreen effect runs only once on mount
- Added e2e regression test that waits beyond the polling interval to verify presentation stays open

## Test plan
- [x] `npx playwright test tests/e2e/presentation-mode.spec.ts` passes with fix
- [x] Same test fails when fix is reverted (confirms it catches the bug)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Manual: click Present, verify it stays in presentation mode indefinitely

This pull request was AI-assisted by Isaac.