### PR TITLE
feat: use app service principal for LLM calls

### DIFF
--- a/docs/superpowers/plans/2026-03-31-llm-system-client.md
+++ b/docs/superpowers/plans/2026-03-31-llm-system-client.md
@@ -1,0 +1,248 @@
+# LLM System Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch LLM calls from the user workspace client to the app's service principal (system) workspace client so users without workspace-level permissions can use the app.
+
+**Architecture:** Replace `get_user_client()` with `get_system_client()` in both `_create_model()` functions (agent_factory.py and agent.py). Update docstrings to reflect the change. Tools remain on the user client.
+
+**Tech Stack:** Python, databricks-langchain, databricks-sdk
+
+**Spec:** `docs/superpowers/specs/2026-03-31-llm-system-client-design.md`
+
+---
+
+### Task 1: Update `_create_model()` in `agent_factory.py`
+
+**Files:**
+- Modify: `src/services/agent_factory.py:48-58`
+
+- [ ] **Step 1: Change import and client in `_create_model()`**
+
+Replace the user client with the system client:
+
+```python
+# Line 48: change import
+from src.core.databricks_client import get_system_client
+
+# Line 51: change client call
+system_client = get_system_client()
+
+# Line 58: change kwarg
+workspace_client=system_client,
+```
+
+The full function (lines 37-70) should read:
+
+```python
+def _create_model():
+    """Create LangChain Databricks model using backend defaults.
+
+    Uses the fixed LLM configuration from DEFAULT_CONFIG. LLM settings
+    are NOT user-configurable — they are backend infrastructure defaults.
+
+    Uses the system client (service principal) so that users do not need
+    workspace-level permissions on the model serving endpoint.
+
+    Returns:
+        ChatDatabricks model instance
+    """
+    from databricks_langchain import ChatDatabricks
+
+    from src.core.databricks_client import get_system_client
+
+    llm_config = DEFAULT_CONFIG["llm"]
+    system_client = get_system_client()
+
+    model = ChatDatabricks(
+        endpoint=llm_config["endpoint"],
+        temperature=llm_config["temperature"],
+        max_tokens=llm_config["max_tokens"],
+        top_p=0.95,
+        workspace_client=system_client,
+    )
+
+    logger.info(
+        "Agent factory: ChatDatabricks model created",
+        extra={
+            "endpoint": llm_config["endpoint"],
+            "temperature": llm_config["temperature"],
+            "max_tokens": llm_config["max_tokens"],
+        },
+    )
+
+    return model
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing breaks**
+
+Run: `python -m pytest tests/unit/test_agent_factory.py -v`
+Expected: All tests PASS (they mock `_create_model` at the factory level, so they don't see the internal change)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/agent_factory.py
+git commit -m "feat: use system client for LLM calls in agent factory"
+```
+
+---
+
+### Task 2: Update `_create_model()` in `agent.py`
+
+**Files:**
+- Modify: `src/services/agent.py:319-348`
+
+- [ ] **Step 1: Change client call in `SlideGeneratorAgent._create_model()`**
+
+The method at line 319 should change to use `get_system_client()` (already imported at line 31):
+
+```python
+def _create_model(self) -> ChatDatabricks:
+    """Create LangChain Databricks model with system client.
+
+    Creates a new ChatDatabricks instance per request using the
+    system WorkspaceClient (service principal). This ensures users
+    do not need workspace-level permissions on the serving endpoint.
+    """
+    try:
+        from src.core.defaults import DEFAULT_CONFIG
+        system_client = get_system_client()
+        llm_config = DEFAULT_CONFIG["llm"]
+
+        model = ChatDatabricks(
+            endpoint=llm_config["endpoint"],
+            temperature=llm_config["temperature"],
+            max_tokens=llm_config["max_tokens"],
+            top_p=llm_config["top_p"],
+            workspace_client=system_client,
+        )
+
+        logger.info(
+            "ChatDatabricks model created with system client",
+            extra={
+                "endpoint": llm_config["endpoint"],
+                "temperature": llm_config["temperature"],
+                "max_tokens": llm_config["max_tokens"],
+            },
+        )
+
+        return model
+    except Exception as e:
+        raise AgentError(f"Failed to create ChatDatabricks model: {e}") from e
+```
+
+- [ ] **Step 2: Remove unused `get_user_client` import**
+
+In `src/services/agent.py` line 32, remove `get_user_client` from the import block (it is no longer used anywhere in agent.py):
+
+```python
+# Before (lines 27-33)
+from src.core.databricks_client import (
+    ...
+    get_system_client,
+    get_user_client,
+    ...
+)
+
+# After — remove the get_user_client line
+from src.core.databricks_client import (
+    ...
+    get_system_client,
+    ...
+)
+```
+
+- [ ] **Step 3: Run existing tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_agent.py::TestSlideGeneratorAgent::test_create_model_valid -v`
+Expected: FAIL — test still mocks `get_user_client` which no longer exists in agent.py. We fix this next.
+
+- [ ] **Step 4: Update test mock to use `get_system_client`**
+
+In `tests/unit/test_agent.py` line 139, change:
+
+```python
+# Before
+with patch("src.services.agent.get_user_client") as mock_user_client:
+    mock_user_client.return_value = MagicMock()
+    model = agent_with_mocks._create_model()
+
+# After
+with patch("src.services.agent.get_system_client") as mock_system_client:
+    mock_system_client.return_value = MagicMock()
+    model = agent_with_mocks._create_model()
+```
+
+- [ ] **Step 5: Update test mock in `test_default_config_integration.py`**
+
+In `tests/unit/test_default_config_integration.py` lines 17-44, change:
+
+```python
+# Before (line 17)
+with patch("src.services.agent.get_user_client") as mock_user_client, \
+# ...
+    mock_user_client.return_value = MagicMock()
+# ...
+    workspace_client=mock_user_client.return_value,
+
+# After
+with patch("src.services.agent.get_system_client") as mock_system_client, \
+# ...
+    mock_system_client.return_value = MagicMock()
+# ...
+    workspace_client=mock_system_client.return_value,
+```
+
+- [ ] **Step 6: Run all affected tests**
+
+Run: `python -m pytest tests/unit/test_agent.py tests/unit/test_default_config_integration.py tests/unit/test_agent_factory.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/services/agent.py tests/unit/test_agent.py tests/unit/test_default_config_integration.py
+git commit -m "feat: use system client for LLM calls in SlideGeneratorAgent"
+```
+
+---
+
+### Task 3: Update docstrings in `databricks_client.py`
+
+**Files:**
+- Modify: `src/core/databricks_client.py:1-15,492-501`
+
+- [ ] **Step 1: Update module-level docstring**
+
+Change line 6 from:
+```python
+2. User Client (request-scoped): Uses forwarded user token for Genie/LLM/MLflow
+```
+to:
+```python
+2. User Client (request-scoped): Uses forwarded user token for Genie queries and tools
+```
+
+- [ ] **Step 2: Update `get_user_client()` docstring**
+
+Change line 494 from:
+```python
+Get the user-scoped WorkspaceClient for Genie/LLM/MLflow operations.
+```
+to:
+```python
+Get the user-scoped WorkspaceClient for Genie queries and tool operations.
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `python -m pytest tests/unit/ -v --tb=short`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/databricks_client.py
+git commit -m "docs: update client docstrings to reflect LLM using system client"
+```

--- a/docs/superpowers/specs/2026-03-31-llm-system-client-design.md
+++ b/docs/superpowers/specs/2026-03-31-llm-system-client-design.md
@@ -15,6 +15,7 @@ Switch `ChatDatabricks` model creation to use the app's system client (service p
 
 **Changes:**
 - `src/services/agent_factory.py` — `_create_model()`: replace `get_user_client()` with `get_system_client()`
+- `src/services/agent.py` — `SlideGeneratorAgent._create_model()`: same change, remove now-unused `get_user_client` import
 - `src/core/databricks_client.py` — update docstrings for `get_user_client()` and module-level docstring to remove LLM from user-client responsibilities
 
 **No changes to:**
@@ -48,5 +49,6 @@ model = ChatDatabricks(..., workspace_client=system_client)
 
 ## Testing
 
-- Existing unit tests mock `_create_model` at the factory level, so they never see which client is used internally — no test updates needed
+- `test_agent_factory.py` tests mock `_create_model` at the factory level — no updates needed
+- `test_agent.py` and `test_default_config_integration.py` mock `get_user_client` inside `SlideGeneratorAgent._create_model()` — update mocks to `get_system_client`
 - E2E tests should pass without change since the serving endpoint is accessible to the service principal

--- a/docs/superpowers/specs/2026-03-31-llm-system-client-design.md
+++ b/docs/superpowers/specs/2026-03-31-llm-system-client-design.md
@@ -1,0 +1,52 @@
+# Use App Service Principal for LLM Calls
+
+**Date:** 2026-03-31
+**Status:** Approved
+
+## Problem
+
+The app currently uses the user's workspace client (OBO token from `x-forwarded-access-token`) to make LLM calls via `ChatDatabricks`. This requires users to have workspace-level permissions on the model serving endpoint, which prevents consumers without those permissions from using the app.
+
+## Decision
+
+Switch `ChatDatabricks` model creation to use the app's system client (service principal) instead of the user's client. This is a targeted, single-function change.
+
+## Scope
+
+**Changes:**
+- `src/services/agent_factory.py` — `_create_model()`: replace `get_user_client()` with `get_system_client()`
+- `src/core/databricks_client.py` — update docstrings for `get_user_client()` and module-level docstring to remove LLM from user-client responsibilities
+
+**No changes to:**
+- Tools (Genie, Vector Search, Model Endpoint, MCP, Agent Bricks) — these remain on the user client for identity-based access
+- MLflow tracing — already authenticates via `DATABRICKS_TOKEN` env var (system client)
+- Experiment creation and permission grants — already use system client
+- Middleware — still sets up user client per-request (needed for tools)
+- Local development — `get_user_client()` already falls back to the system client when no user token is present, so local dev already uses the system client for LLM calls
+
+## Design
+
+In `_create_model()` (agent_factory.py), the workspace client passed to `ChatDatabricks` changes from the request-scoped user client to the singleton system client:
+
+```python
+# Before
+from src.core.databricks_client import get_user_client
+user_client = get_user_client()
+model = ChatDatabricks(..., workspace_client=user_client)
+
+# After
+from src.core.databricks_client import get_system_client
+system_client = get_system_client()
+model = ChatDatabricks(..., workspace_client=system_client)
+```
+
+## Consequences
+
+- LLM calls are attributed to the app's service principal, not the end user. Per-user attribution at the serving layer is lost (product tracking header changes from `tellr-app-{hashed_user_id}` to `tellr-app-system`). MLflow tracing still records which user triggered each call, so auditability is preserved there.
+- Users no longer need workspace-level model serving endpoint permissions to use the app
+- The service principal's quota/rate limits apply to all LLM calls (shared across all users). The Foundation Model API pay-per-token endpoints do not have per-principal rate limits that would be a concern here.
+
+## Testing
+
+- Existing unit tests mock `_create_model` at the factory level, so they never see which client is used internally — no test updates needed
+- E2E tests should pass without change since the serving endpoint is accessible to the service principal

--- a/src/core/databricks_client.py
+++ b/src/core/databricks_client.py
@@ -3,7 +3,7 @@ Databricks client management with dual-client architecture.
 
 This module provides two types of WorkspaceClient:
 1. System Client (singleton): Uses service principal credentials for system operations
-2. User Client (request-scoped): Uses forwarded user token for Genie/LLM/MLflow
+2. User Client (request-scoped): Uses forwarded user token for Genie queries and tools
 
 The user client is set per-request via middleware and stored in a ContextVar.
 
@@ -310,7 +310,7 @@ def get_databricks_client(force_new: bool = False) -> WorkspaceClient:
     """
     Alias for get_system_client() - maintains backward compatibility.
 
-    For user-scoped operations (Genie, LLM, MLflow), use get_user_client() instead.
+    For user-scoped operations (Genie queries and tools), use get_user_client() instead.
     """
     return get_system_client(force_new)
 
@@ -491,7 +491,7 @@ def set_user_client(client: Optional[WorkspaceClient]) -> None:
 
 def get_user_client() -> WorkspaceClient:
     """
-    Get the user-scoped WorkspaceClient for Genie/LLM/MLflow operations.
+    Get the user-scoped WorkspaceClient for Genie queries and tool operations.
 
     Returns the request-scoped user client if available (set by middleware),
     otherwise falls back to the system client (for local development).

--- a/src/services/agent.py
+++ b/src/services/agent.py
@@ -29,7 +29,6 @@ from src.core.databricks_client import (
     get_databricks_client,
     get_service_principal_folder,
     get_system_client,
-    get_user_client,
 )
 from src.core.settings_db import get_settings
 from src.domain.slide import Slide
@@ -317,15 +316,15 @@ class SlideGeneratorAgent:
             )
 
     def _create_model(self) -> ChatDatabricks:
-        """Create LangChain Databricks model with user context.
+        """Create LangChain Databricks model with system client.
 
         Creates a new ChatDatabricks instance per request using the
-        user-scoped WorkspaceClient. This ensures LLM calls are made
-        with the authenticated user's permissions.
+        system WorkspaceClient (service principal). This ensures users
+        do not need workspace-level permissions on the serving endpoint.
         """
         try:
             from src.core.defaults import DEFAULT_CONFIG
-            user_client = get_user_client()
+            system_client = get_system_client()
             llm_config = DEFAULT_CONFIG["llm"]
 
             model = ChatDatabricks(
@@ -333,11 +332,11 @@ class SlideGeneratorAgent:
                 temperature=llm_config["temperature"],
                 max_tokens=llm_config["max_tokens"],
                 top_p=llm_config["top_p"],
-                workspace_client=user_client,
+                workspace_client=system_client,
             )
 
             logger.info(
-                "ChatDatabricks model created with user context",
+                "ChatDatabricks model created with system client",
                 extra={
                     "endpoint": llm_config["endpoint"],
                     "temperature": llm_config["temperature"],

--- a/src/services/agent_factory.py
+++ b/src/services/agent_factory.py
@@ -40,22 +40,25 @@ def _create_model():
     Uses the fixed LLM configuration from DEFAULT_CONFIG. LLM settings
     are NOT user-configurable — they are backend infrastructure defaults.
 
+    Uses the system client (service principal) so that users do not need
+    workspace-level permissions on the model serving endpoint.
+
     Returns:
         ChatDatabricks model instance
     """
     from databricks_langchain import ChatDatabricks
 
-    from src.core.databricks_client import get_user_client
+    from src.core.databricks_client import get_system_client
 
     llm_config = DEFAULT_CONFIG["llm"]
-    user_client = get_user_client()
+    system_client = get_system_client()
 
     model = ChatDatabricks(
         endpoint=llm_config["endpoint"],
         temperature=llm_config["temperature"],
         max_tokens=llm_config["max_tokens"],
         top_p=0.95,
-        workspace_client=user_client,
+        workspace_client=system_client,
     )
 
     logger.info(

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -136,8 +136,8 @@ class TestSlideGeneratorAgent:
     def test_create_model_valid(self, agent_with_mocks):
         """Test model creation with valid settings."""
         # Model is now created per-request via _create_model()
-        with patch("src.services.agent.get_user_client") as mock_user_client:
-            mock_user_client.return_value = MagicMock()
+        with patch("src.services.agent.get_system_client") as mock_system_client:
+            mock_system_client.return_value = MagicMock()
             model = agent_with_mocks._create_model()
             assert model is not None
 

--- a/tests/unit/test_default_config_integration.py
+++ b/tests/unit/test_default_config_integration.py
@@ -14,12 +14,12 @@ from src.core.defaults import DEFAULT_CONFIG
 
 def test_agent_create_model_uses_default_config():
     """Verify agent._create_model() reads endpoint/temperature/etc from DEFAULT_CONFIG."""
-    with patch("src.services.agent.get_user_client") as mock_user_client, \
+    with patch("src.services.agent.get_system_client") as mock_system_client, \
          patch("src.services.agent.ChatDatabricks") as mock_chat, \
          patch("src.services.agent.get_settings") as mock_get_settings, \
          patch("src.services.agent.get_databricks_client") as mock_db_client, \
          patch("src.services.agent.mlflow"):
-        mock_user_client.return_value = MagicMock()
+        mock_system_client.return_value = MagicMock()
         mock_chat.return_value = MagicMock()
         mock_settings = MagicMock()
         mock_settings.prompts = {"system_prompt": "test", "slide_style": "test style", "slide_editing_instructions": "test"}
@@ -41,7 +41,7 @@ def test_agent_create_model_uses_default_config():
             temperature=llm_config["temperature"],
             max_tokens=llm_config["max_tokens"],
             top_p=llm_config["top_p"],
-            workspace_client=mock_user_client.return_value,
+            workspace_client=mock_system_client.return_value,
         )
 
 

--- a/tests/unit/test_error_recovery.py
+++ b/tests/unit/test_error_recovery.py
@@ -118,16 +118,13 @@ def agent_with_mocks(mock_settings, mock_client, mock_mlflow, mock_langchain_com
         "src.services.agent.get_service_principal_folder"
     ) as mock_get_sp_folder, patch(
         "src.services.agent.get_system_client"
-    ) as mock_get_system, patch(
-        "src.services.agent.get_user_client"
-    ) as mock_get_user:
+    ) as mock_get_system:
         mock_get_settings.return_value = mock_settings
         mock_get_client.return_value = mock_client
         mock_init_genie.return_value = "test-genie-conv-id"
         mock_get_username.return_value = "test-user@example.com"
         mock_get_sp_folder.return_value = None  # Local dev mode
         mock_get_system.return_value = mock_client
-        mock_get_user.return_value = mock_client
 
         agent = SlideGeneratorAgent()
         return agent
@@ -176,14 +173,14 @@ class TestLLMErrorHandling:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -217,14 +214,14 @@ class TestLLMErrorHandling:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -256,14 +253,14 @@ class TestLLMErrorHandling:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -301,14 +298,14 @@ class TestLLMErrorHandling:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -344,14 +341,14 @@ class TestLLMErrorHandling:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -382,14 +379,14 @@ class TestLLMErrorHandling:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -690,14 +687,14 @@ class TestStateRecovery:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -737,14 +734,14 @@ class TestStateRecovery:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings
             mock_get_client.return_value = mock_client
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             agent = SlideGeneratorAgent()
 
@@ -818,13 +815,13 @@ class TestGracefulDegradation:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             mock_get_settings.return_value = mock_settings_no_genie
             mock_get_client.return_value = mock_client
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             # Agent should initialize without Genie
             agent = SlideGeneratorAgent()
@@ -857,8 +854,8 @@ class TestGracefulDegradation:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user:
+            "src.services.agent.get_system_client"
+        ) as mock_get_system:
             # Mock MLflow to fail
             mock_mlflow_fail.set_tracking_uri.side_effect = Exception("MLflow unavailable")
             mock_mlflow_fail.langchain.autolog.side_effect = Exception("MLflow unavailable")
@@ -868,7 +865,7 @@ class TestGracefulDegradation:
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             # Agent should still initialize despite MLflow errors
             agent = SlideGeneratorAgent()
@@ -888,8 +885,8 @@ class TestGracefulDegradation:
         ) as mock_get_username, patch(
             "src.services.agent.get_service_principal_folder"
         ) as mock_get_sp_folder, patch(
-            "src.services.agent.get_user_client"
-        ) as mock_get_user, patch(
+            "src.services.agent.get_system_client"
+        ) as mock_get_system, patch(
             "src.services.agent.query_genie_space"
         ) as mock_query_genie:
             mock_get_settings.return_value = mock_settings
@@ -897,7 +894,7 @@ class TestGracefulDegradation:
             mock_init_genie.return_value = "test-genie-conv-id"
             mock_get_username.return_value = "test-user@example.com"
             mock_get_sp_folder.return_value = None
-            mock_get_user.return_value = mock_client
+            mock_get_system.return_value = mock_client
 
             # Mock Genie to fail
             mock_query_genie.side_effect = GenieToolError("Genie unavailable")


### PR DESCRIPTION
## Summary

- Switch `ChatDatabricks` model creation to use the app's system client (service principal) instead of the user's OBO token
- Users no longer need workspace-level permissions on the model serving endpoint to use the app
- Tools (Genie, Vector Search, Model Endpoint, MCP, Agent Bricks) remain on the user client for identity-based access
- MLflow tracing is unaffected (already uses system client token)

## Changes

- `src/services/agent_factory.py` — `_create_model()` uses `get_system_client()`
- `src/services/agent.py` — `SlideGeneratorAgent._create_model()` uses `get_system_client()`, removed unused `get_user_client` import
- `src/core/databricks_client.py` — Updated 3 docstrings to remove LLM from user-client responsibilities
- `tests/unit/test_agent.py`, `tests/unit/test_default_config_integration.py` — Updated mocks

## Test plan

- [x] All 29 affected unit tests pass
- [ ] Deploy to staging and verify LLM calls work for users without workspace-level endpoint permissions
- [ ] Verify tools (Genie, Vector Search) still work with user identity

This pull request was AI-assisted by Isaac.