### PR TITLE
fix: disable SCIM group fetching in all environments

### DIFF
--- a/frontend/src/components/DeckContributorsManager.tsx
+++ b/frontend/src/components/DeckContributorsManager.tsx
@@ -188,7 +188,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
       <div>
         <h3 className="text-lg font-medium text-gray-900">Share Deck</h3>
         <p className="text-sm text-gray-500 mt-1">
-          Add users or groups from your Databricks workspace who can access this deck.
+          Add users from your Databricks workspace who can access this deck.
         </p>
       </div>
 
@@ -220,7 +220,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search users or groups..."
+                placeholder="Search users..."
                 className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 disabled={addingContributor}
               />
@@ -274,7 +274,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
           {/* No results */}
           {searchQuery.length >= 2 && !searching && searchResults.length === 0 && (
             <p className="mt-2 text-sm text-gray-500 text-center py-2">
-              No users or groups found matching "{searchQuery}"
+              No users found matching "{searchQuery}"
             </p>
           )}
         </div>
@@ -293,7 +293,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
               No contributors yet. This deck is private to you.
             </p>
             <p className="text-xs text-blue-600 mt-1">
-              Search above to add users or groups.
+              Search above to add users.
             </p>
           </div>
         ) : (

--- a/frontend/src/components/config/ContributorsManager.tsx
+++ b/frontend/src/components/config/ContributorsManager.tsx
@@ -185,7 +185,7 @@ export const ContributorsManager: React.FC<ContributorsManagerProps> = ({
       <div>
         <h3 className="text-lg font-medium text-gray-900">Share Profile</h3>
         <p className="text-sm text-gray-500 mt-1">
-          Add users or groups from your Databricks workspace who can access this profile.
+          Add users from your Databricks workspace who can access this profile.
         </p>
       </div>
 
@@ -216,7 +216,7 @@ export const ContributorsManager: React.FC<ContributorsManagerProps> = ({
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search users or groups..."
+              placeholder="Search users..."
               className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               disabled={addingContributor}
             />
@@ -285,7 +285,7 @@ export const ContributorsManager: React.FC<ContributorsManagerProps> = ({
         {/* No results */}
         {searchQuery.length >= 2 && !searching && searchResults.length === 0 && (
           <p className="mt-2 text-sm text-gray-500 text-center py-2">
-            No users or groups found matching "{searchQuery}"
+            No users found matching "{searchQuery}"
           </p>
         )}
       </div>

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -112,7 +112,7 @@ fi
 
 # Note: Environment names must match keys in config/deployment.yaml
 # Add new environments to the regex below when adding to deployment.yaml
-if [[ ! "$ENV" =~ ^(development|staging|production|test|kholoud-dev)$ ]]; then
+if [[ ! "$ENV" =~ ^(development|staging|production|test)$ ]]; then
     echo -e "${RED}Invalid environment: $ENV${NC}"
     echo "   Check config/deployment.yaml for valid environment names"
     exit 1

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -112,7 +112,7 @@ fi
 
 # Note: Environment names must match keys in config/deployment.yaml
 # Add new environments to the regex below when adding to deployment.yaml
-if [[ ! "$ENV" =~ ^(development|staging|production|test)$ ]]; then
+if [[ ! "$ENV" =~ ^(development|staging|production|test|kholoud-dev)$ ]]; then
     echo -e "${RED}Invalid environment: $ENV${NC}"
     echo "   Check config/deployment.yaml for valid environment names"
     exit 1

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -297,13 +297,12 @@ async def user_auth_middleware(request: Request, call_next):
         set_current_user(dev_user)
         logger.debug("OBO auth: no token header — using dev identity %s", dev_user)
 
-    # Build and set permission context (includes group memberships)
-    # Skip group fetching in dev/test to avoid API calls
-    fetch_groups = ENVIRONMENT not in ("development", "test")
+    # Build and set permission context
+    # Group fetching disabled — deck sharing uses user identities only, not groups
     permission_ctx = build_permission_context(
         user_id=user_id,
         user_name=user_name,
-        fetch_groups=fetch_groups,
+        fetch_groups=False,
     )
     set_permission_context(permission_ctx)
 


### PR DESCRIPTION
Deck sharing uses user identities only, not groups. The SCIM API call was failing with 403 because the app's service principal is not a workspace admin.