### PR TITLE
fix: remove group references from sharing UI

### DIFF
--- a/frontend/src/components/DeckContributorsManager.tsx
+++ b/frontend/src/components/DeckContributorsManager.tsx
@@ -188,7 +188,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
       <div>
         <h3 className="text-lg font-medium text-gray-900">Share Deck</h3>
         <p className="text-sm text-gray-500 mt-1">
-          Add users or groups from your Databricks workspace who can access this deck.
+          Add users from your Databricks workspace who can access this deck.
         </p>
       </div>
 
@@ -220,7 +220,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search users or groups..."
+                placeholder="Search users..."
                 className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 disabled={addingContributor}
               />
@@ -274,7 +274,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
           {/* No results */}
           {searchQuery.length >= 2 && !searching && searchResults.length === 0 && (
             <p className="mt-2 text-sm text-gray-500 text-center py-2">
-              No users or groups found matching "{searchQuery}"
+              No users found matching "{searchQuery}"
             </p>
           )}
         </div>
@@ -293,7 +293,7 @@ export const DeckContributorsManager: React.FC<DeckContributorsManagerProps> = (
               No contributors yet. This deck is private to you.
             </p>
             <p className="text-xs text-blue-600 mt-1">
-              Search above to add users or groups.
+              Search above to add users.
             </p>
           </div>
         ) : (

--- a/frontend/src/components/config/ContributorsManager.tsx
+++ b/frontend/src/components/config/ContributorsManager.tsx
@@ -185,7 +185,7 @@ export const ContributorsManager: React.FC<ContributorsManagerProps> = ({
       <div>
         <h3 className="text-lg font-medium text-gray-900">Share Profile</h3>
         <p className="text-sm text-gray-500 mt-1">
-          Add users or groups from your Databricks workspace who can access this profile.
+          Add users from your Databricks workspace who can access this profile.
         </p>
       </div>
 
@@ -216,7 +216,7 @@ export const ContributorsManager: React.FC<ContributorsManagerProps> = ({
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search users or groups..."
+              placeholder="Search users..."
               className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               disabled={addingContributor}
             />
@@ -285,7 +285,7 @@ export const ContributorsManager: React.FC<ContributorsManagerProps> = ({
         {/* No results */}
         {searchQuery.length >= 2 && !searching && searchResults.length === 0 && (
           <p className="mt-2 text-sm text-gray-500 text-center py-2">
-            No users or groups found matching "{searchQuery}"
+            No users found matching "{searchQuery}"
           </p>
         )}
       </div>

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -112,7 +112,7 @@ fi
 
 # Note: Environment names must match keys in config/deployment.yaml
 # Add new environments to the regex below when adding to deployment.yaml
-if [[ ! "$ENV" =~ ^(development|staging|production|test)$ ]]; then
+if [[ ! "$ENV" =~ ^(development|staging|production|test|kholoud-dev)$ ]]; then
     echo -e "${RED}Invalid environment: $ENV${NC}"
     echo "   Check config/deployment.yaml for valid environment names"
     exit 1


### PR DESCRIPTION
Group fetching is disabled — sharing only supports users, not groups. Updated placeholder text and descriptions accordingly. Also added kholoud-dev to deploy script env allowlist.