### PR TITLE
fix: display RC11 conflict note

### DIFF
--- a/frontend/src/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel/ChatPanel.tsx
@@ -297,7 +297,15 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(({
           }
 
           if (event.replacement_info && slideContext) {
-            setLastReplacement(event.replacement_info);
+            // Include conflict_note from metadata if present (RC11)
+            const replacementWithConflict = {
+              ...event.replacement_info,
+              conflict_note: event.metadata?.conflict_note,
+            };
+            setLastReplacement(replacementWithConflict);
+          } else if (event.metadata?.sync_error) {
+            // RC14: Deck sync error (no replacement_info, but show error feedback)
+            setLastReplacement({ sync_error: event.metadata.sync_error });
           }
 
           // Refresh agent config to pick up updated conversation_ids from Genie tools

--- a/frontend/src/components/ChatPanel/ReplacementFeedback.css
+++ b/frontend/src/components/ChatPanel/ReplacementFeedback.css
@@ -1,7 +1,12 @@
+.replacement-feedback-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .replacement-feedback {
   padding: 0.75rem 1rem;
   border-radius: 6px;
-  margin-top: 0.5rem;
   font-size: 0.875rem;
   font-weight: 500;
 }
@@ -16,5 +21,19 @@
   background: #fef2f2;
   border: 1px solid #ef4444;
   color: #991b1b;
+}
+
+.replacement-feedback.conflict-note {
+  background: #fefce8;
+  border: 1px solid #eab308;
+  color: #854d0e;
+  font-weight: 400;
+}
+
+.replacement-feedback.sync-error {
+  background: #fef2f2;
+  border: 1px solid #ef4444;
+  color: #991b1b;
+  font-weight: 400;
 }
 

--- a/frontend/src/components/ChatPanel/ReplacementFeedback.tsx
+++ b/frontend/src/components/ChatPanel/ReplacementFeedback.tsx
@@ -26,9 +26,27 @@ const buildMessage = (info: ReplacementInfo): string => {
 export const ReplacementFeedback: React.FC<ReplacementFeedbackProps> = ({
   replacementInfo,
 }) => {
+  // RC14: If only sync_error, show error without success message
+  if (replacementInfo.sync_error && !replacementInfo.original_count) {
+    return (
+      <div className="replacement-feedback-container">
+        <div className="replacement-feedback sync-error">
+          {replacementInfo.sync_error}
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="replacement-feedback success">
-      {buildMessage(replacementInfo)}
+    <div className="replacement-feedback-container">
+      <div className="replacement-feedback success">
+        {buildMessage(replacementInfo)}
+      </div>
+      {replacementInfo.conflict_note && (
+        <div className="replacement-feedback conflict-note">
+          {replacementInfo.conflict_note}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/types/slide.ts
+++ b/frontend/src/types/slide.ts
@@ -44,4 +44,8 @@ export interface ReplacementInfo {
   error?: string | null;
   canvas_ids?: string[];
   is_add_operation?: boolean;
+  /** RC11: Conflict note when selection differs from text reference */
+  conflict_note?: string;
+  /** RC14: Deck sync error when frontend/backend state mismatch */
+  sync_error?: string;
 }

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -377,6 +377,17 @@ class ChatService:
 
         # RC13: Auto-create slide_context from text reference (sync path)
         # Runs before agent build so mode can be determined accurately.
+        logger.info(
+            "RC13: Checking condition (sync)",
+            extra={
+                "session_id": session_id,
+                "_is_edit": _is_edit,
+                "_slide_refs": _slide_refs,
+                "slide_context_is_none": slide_context is None,
+                "slide_context_indices": slide_context.get("indices") if slide_context else None,
+                "rc13_will_run": _is_edit and bool(_slide_refs) and not slide_context,
+            },
+        )
         if _is_edit and _slide_refs and not slide_context:
             existing_deck = self._get_or_load_deck(session_id)
             if existing_deck and len(existing_deck.slides) > 0:
@@ -616,8 +627,18 @@ class ChatService:
 
             # RC11: Check for conflict between selection and text reference (sync path)
             conflict_note = None
+            text_refs, _ = self._parse_slide_references(message)
+            logger.info(
+                "RC11: Checking for selection/text conflict (sync)",
+                extra={
+                    "session_id": session_id,
+                    "has_slide_context": slide_context is not None,
+                    "slide_context_indices": slide_context.get("indices", []) if slide_context else None,
+                    "text_refs": text_refs,
+                    "message_preview": message[:100] if message else None,
+                },
+            )
             if slide_context:
-                text_refs, _ = self._parse_slide_references(message)
                 if text_refs:
                     selected_indices = slide_context.get("indices", [])
                     if set(text_refs) != set(selected_indices):
@@ -637,6 +658,16 @@ class ChatService:
                             content=conflict_note,
                             message_type="info",
                         )
+                    else:
+                        logger.info(
+                            "RC11: No conflict - indices match (sync)",
+                            extra={"session_id": session_id, "selected_indices": selected_indices, "text_refs": text_refs},
+                        )
+                else:
+                    logger.info(
+                        "RC11: Skipped - no text reference found in message (sync)",
+                        extra={"session_id": session_id},
+                    )
 
             # Substitute image placeholders before sending to client
             slide_deck_dict, raw_html = self._substitute_images_for_response(slide_deck_dict, raw_html)
@@ -837,6 +868,17 @@ class ChatService:
 
         # RC13: Auto-create slide_context from text reference (e.g., "edit slide 7")
         # Runs before agent build so mode can be determined accurately.
+        logger.info(
+            "RC13: Checking condition",
+            extra={
+                "session_id": session_id,
+                "_is_edit": _is_edit,
+                "_slide_refs": _slide_refs,
+                "slide_context_is_none": slide_context is None,
+                "slide_context_indices": slide_context.get("indices") if slide_context else None,
+                "rc13_will_run": _is_edit and bool(_slide_refs) and not slide_context,
+            },
+        )
         if _is_edit and _slide_refs and not slide_context:
             existing_deck = self._get_or_load_deck(session_id)
             if existing_deck and len(existing_deck.slides) > 0:
@@ -886,27 +928,30 @@ class ChatService:
                         "This can happen if a previous save failed. "
                         "Please refresh the page to resync your session."
                     )
-                    session_manager.add_message(
-                        session_id=session_id,
-                        role="assistant",
-                        content=error_msg,
-                        message_type="error",
-                    )
-                    yield StreamEvent(
-                        type=StreamEventType.ASSISTANT,
-                        content=error_msg,
-                    )
                     early_deck_dict = existing_deck.to_dict() if existing_deck else None
                     if early_deck_dict:
                         early_deck_dict, _ = self._substitute_images_for_response(early_deck_dict)
+                    # Include error in metadata for ReplacementFeedback display
                     yield StreamEvent(
                         type=StreamEventType.COMPLETE,
                         slides=early_deck_dict,
+                        metadata={"sync_error": error_msg},
                     )
                     return
 
         # RC11: Detect conflict between selection and text reference
         conflict_note = None
+        # Debug: Log RC11 inputs
+        logger.info(
+            "RC11: Checking for selection/text conflict",
+            extra={
+                "session_id": session_id,
+                "has_slide_context": slide_context is not None,
+                "slide_context_indices": slide_context.get("indices", []) if slide_context else None,
+                "_slide_refs": _slide_refs,
+                "message_preview": message[:100] if message else None,
+            },
+        )
         if slide_context:
             if _slide_refs:
                 selected_indices = slide_context.get("indices", [])
@@ -925,6 +970,20 @@ class ChatService:
                             "text_refs": _slide_refs,
                         },
                     )
+                else:
+                    logger.info(
+                        "RC11: No conflict - indices match",
+                        extra={
+                            "session_id": session_id,
+                            "selected_indices": selected_indices,
+                            "_slide_refs": _slide_refs,
+                        },
+                    )
+            else:
+                logger.info(
+                    "RC11: Skipped - no text reference found in message",
+                    extra={"session_id": session_id},
+                )
 
         # Capture deck version BEFORE LLM runs so we can detect concurrent edits.
         _deck_version_before_llm = self._get_deck_version(session_id)
@@ -1333,30 +1392,21 @@ class ChatService:
         # Update session activity
         session_manager.update_last_activity(session_id)
 
-        # RC11: Yield conflict note if selection differed from text reference
-        if conflict_note:
-            yield StreamEvent(
-                type=StreamEventType.ASSISTANT,
-                content=conflict_note,
-            )
-            # Persist the note
-            session_manager.add_message(
-                session_id=session_id,
-                role="assistant",
-                content=conflict_note,
-                message_type="info",
-            )
-
         # Substitute image placeholders before sending to client
         slide_deck_dict, raw_html = self._substitute_images_for_response(slide_deck_dict, raw_html)
 
-        # Yield final complete event FIRST so the user sees slides immediately
+        # RC11: Include conflict note in metadata for ReplacementFeedback display
+        complete_metadata = result.get("metadata") or {}
+        if conflict_note:
+            complete_metadata["conflict_note"] = conflict_note
+
+        # Yield final complete event with slides and optional conflict note
         yield StreamEvent(
             type=StreamEventType.COMPLETE,
             slides=slide_deck_dict,
             raw_html=raw_html,
             replacement_info=_sanitize_replacement_info(replacement_info),
-            metadata=result.get("metadata"),
+            metadata=complete_metadata if complete_metadata else None,
             experiment_url=experiment_url or result.get("experiment_url"),
         )
 


### PR DESCRIPTION

  - Fix RC11 bug: conflict note wasn't returned by polling (missing request_id)
  - Move RC11 conflict note from chat message to styled feedback component
  - Move RC14 sync error from chat message to styled feedback component
  - Add debug logging for RC11/RC13 intent detection

  Frontend: Add conflict_note and sync_error to ReplacementInfo type,
  update ReplacementFeedback with yellow (conflict) and red (error) styles.

<img width="692" height="506" alt="Screenshot 2026-04-14 at 13 33 46" src="https://github.com/user-attachments/assets/60cd2648-43a7-4d47-b273-9a81cbb49dcc" />

