### PR TITLE
feat(mcp): expose tellr as an MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Step-by-step instructions with screenshots:
 | [Backend Overview](docs/technical/backend-overview.md) | FastAPI, agent lifecycle, API contracts |
 | [Frontend Overview](docs/technical/frontend-overview.md) | React components, state management |
 | [Databricks Deployment](docs/technical/databricks-app-deployment.md) | Deployment CLI, environments |
+| [MCP Server](docs/technical/mcp-server.md) | Call tellr programmatically from other Databricks Apps or MCP agent tools |
 | [Database Config](docs/technical/database-configuration.md) | PostgreSQL/Lakebase schema |
 
 ### More Technical Docs

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Step-by-step instructions with screenshots:
 | [Backend Overview](docs/technical/backend-overview.md) | FastAPI, agent lifecycle, API contracts |
 | [Frontend Overview](docs/technical/frontend-overview.md) | React components, state management |
 | [Databricks Deployment](docs/technical/databricks-app-deployment.md) | Deployment CLI, environments |
-| [MCP Server](docs/technical/mcp-server.md) | Call tellr programmatically from other Databricks Apps or MCP agent tools |
+| [MCP Integration Guide](docs/technical/mcp-integration-guide.md) | How-to: wire tellr into your Databricks App or into an MCP client like Claude Code |
+| [MCP Server Reference](docs/technical/mcp-server.md) | Protocol, tool schemas, response payloads |
 | [Database Config](docs/technical/database-configuration.md) | PostgreSQL/Lakebase schema |
 
 ### More Technical Docs

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AI slide generators exist — but they can't touch your governed data without br
 - **Respects permissions** — Uses Unity Catalog security out of the box
 - **Conversational editing** — Refine slides through natural language ("add a comparison to Q3", "make the EMEA section more prominent")
 - **Prompt-only mode** — Works without Genie for general-purpose slide generation
+- **Agent-ready** — Call tellr from other Databricks Apps or MCP-compatible agents (Claude Code, Cursor) via a Model Context Protocol server. Programmatically generated decks are attributed to the end user and appear alongside UI-created ones. See the [MCP Integration Guide](docs/technical/mcp-integration-guide.md).
 
 tellr is the third pillar in Databricks' AI/BI suite, completing the story alongside Genie and Dashboards: conversational analytics, conversational dashboards, and now **conversational presentations**.
 

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -64,6 +64,8 @@ const sidebars = {
         'technical/image-upload',
         'technical/google-slides-integration',
         'technical/feedback-system',
+        'technical/mcp-server',
+        'technical/mcp-integration-guide',
       ],
     },
   ],

--- a/docs/getting-started/how-it-works.md
+++ b/docs/getting-started/how-it-works.md
@@ -25,6 +25,7 @@
 - **Respects permissions** — Uses Unity Catalog security out of the box
 - **Conversational editing** — Refine slides through natural language ("add a comparison to Q3", "make the EMEA section more prominent")
 - **Prompt-only mode** — Works without Genie for general-purpose slide generation
+- **Agent-ready** — Call tellr from other Databricks Apps or MCP-compatible agents (Claude Code, Cursor) via a Model Context Protocol server. Programmatically generated decks are attributed to the end user and appear alongside UI-created ones. See the [MCP Integration Guide](../technical/mcp-integration-guide.md).
 
 tellr is the third pillar in Databricks' AI/BI suite, completing the story alongside Genie and Dashboards: conversational analytics, conversational dashboards, and now **conversational presentations**.
 

--- a/docs/superpowers/plans/2026-04-22-tellr-mcp-server.md
+++ b/docs/superpowers/plans/2026-04-22-tellr-mcp-server.md
@@ -1,0 +1,2896 @@
+# Tellr MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose tellr as an MCP (Model Context Protocol) server at `/mcp` on the existing Databricks App so external Databricks Apps and MCP-compatible agent tools can programmatically generate and edit slide decks, using tellr's existing agent pipeline.
+
+**Architecture:** Mount a FastMCP (Python `mcp` SDK) router at `/mcp` inside the existing FastAPI app, registered before the SPA catch-all. Four tools (`create_deck`, `get_deck_status`, `edit_deck`, `get_deck`) are thin wrappers over existing services (`ChatService`, `SessionManager`, `SlideDeck`, `permission_service`). Authentication accepts `x-forwarded-access-token` (proxy-injected) and `Authorization: Bearer` (external) in that priority order, reusing the existing `get_or_create_user_client` identity resolution. A lifespan-managed sweeper marks jobs stuck beyond 10 minutes as failed. No new infrastructure, no new queue, no new worker — MCP submissions ride the existing chat job queue.
+
+**Tech Stack:** Python 3.10+, FastAPI, `mcp` Python SDK (FastMCP), SQLAlchemy, Pydantic v2, pytest + pytest-asyncio. Frontend is unchanged.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md`
+
+**Branch:** `ty/feature/tellr-mcp-server` (user will create this branch at a later stage; for now commits land on the current working branch)
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+|---|---|
+| `src/api/mcp_server.py` | FastMCP instance + 4 tool handlers; thin wrappers over existing services |
+| `src/api/mcp_auth.py` | Dual-token extraction + `ContextVar` scope helper for MCP tool handlers |
+| `tests/unit/test_mcp_auth.py` | Unit tests for the auth helper |
+| `tests/unit/test_mcp_server.py` | Unit tests for each tool handler (with mocked services) |
+| `tests/unit/test_slide_deck_to_html_document.py` | Unit tests for the new serializer |
+| `tests/unit/test_job_queue_timeout_sweeper.py` | Unit tests for `mark_timed_out_jobs_loop` |
+| `tests/integration/test_mcp_endpoint.py` | End-to-end MCP protocol tests (TestClient + mocked LLM) |
+| `scripts/mcp_smoke/mcp_smoke_httpx.py` | Post-deploy smoke test against a real tellr URL |
+| `scripts/mcp_smoke/README.md` | How to run the smoke script |
+| `docs/technical/mcp-server.md` | Caller-facing integration reference (follows `docs/technical/technical-doc-template.md`) |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `pyproject.toml` | Add `mcp>=1.0.0` to `dependencies`; bump `[project]` version to `0.3.0` |
+| `src/api/main.py` | Register MCP router before `_mount_frontend`; start `mark_timed_out_jobs_loop` in lifespan |
+| `src/api/services/job_queue.py` | Add `JOB_HARD_TIMEOUT_SECONDS` constant + `mark_timed_out_jobs_loop` coroutine |
+| `src/domain/slide_deck.py` | Add `to_html_document(chart_js_cdn: str = CHART_JS_URL) -> str` method |
+| `README.md` | Add one-paragraph breadcrumb to the MCP tech doc |
+
+### Decomposition rationale
+
+`mcp_server.py` holds the tool surface (4 tool handlers, each ~30-60 lines). `mcp_auth.py` is a focused dependency-like helper. Tests are one file per logical surface. This keeps each file under ~400 lines, each with one clear responsibility, and each independently testable.
+
+---
+
+## Phase 1: Foundation
+
+### Task 1: Add `mcp` SDK dependency and bump version
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Read the current dependencies block**
+
+Read `pyproject.toml` and confirm the `[project] dependencies = [...]` block and the current version line.
+
+- [ ] **Step 2: Add `mcp>=1.0.0` to dependencies**
+
+Edit the `[project] dependencies` array — add one line:
+
+```toml
+"mcp>=1.0.0",
+```
+
+Place it alphabetically relative to existing `databricks-mcp>=0.1.0` line (so `mcp` comes after `litellm` and before `mlflow` or similar — preserve the file's existing ordering pattern).
+
+- [ ] **Step 3: Bump `dynamic = ["version"]` handling**
+
+`pyproject.toml` currently uses `dynamic = ["version"]` with `setuptools_scm`. The runtime version comes from git tags. Do NOT add an explicit `version = "0.3.0"` line. Instead, the `0.3.0` version will be set at release time by tagging `v0.3.0`. This task only adds the dependency; the version bump happens at release.
+
+- [ ] **Step 4: Install the new dependency**
+
+Run:
+
+```bash
+cd "/path/to/ai-slide-generator"
+uv sync
+```
+
+Expected: uv installs `mcp>=1.0.0` and its transitive deps. No errors.
+
+- [ ] **Step 5: Verify the SDK imports**
+
+Run:
+
+```bash
+python -c "from mcp.server.fastmcp import FastMCP; print('OK')"
+```
+
+Expected output: `OK`
+
+If import fails, check installed version: `pip show mcp`. The required module path may differ slightly in very new SDK versions — verify with `python -c "import mcp; print(mcp.__version__)"` and adjust the import to `from mcp.server import FastMCP` if the former path doesn't exist in the installed version.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "$(cat <<'EOF'
+feat(mcp): add mcp SDK dependency for MCP server implementation
+
+Adds mcp>=1.0.0 Python SDK dependency. Version bump to 0.3.0 will
+happen at release tagging time via setuptools_scm.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `SlideDeck.to_html_document()` method
+
+**Files:**
+- Modify: `src/domain/slide_deck.py`
+- Create: `tests/unit/test_slide_deck_to_html_document.py`
+
+- [ ] **Step 1: Read `src/domain/slide_deck.py` in full** to identify existing methods that produce HTML output (e.g., `knit()` or `to_html()`). If a method already produces a full standalone HTML document, evaluate whether to reuse it with a thin wrapper. If not, add a new method.
+
+Record findings before proceeding.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/test_slide_deck_to_html_document.py`:
+
+```python
+"""Tests for SlideDeck.to_html_document() serializer."""
+
+import pytest
+
+from src.domain.slide import Slide
+from src.domain.slide_deck import SlideDeck
+
+
+@pytest.fixture
+def minimal_deck():
+    return SlideDeck(
+        title="Test Deck",
+        css=".slide { background: white; }",
+        external_scripts=["https://cdn.jsdelivr.net/npm/chart.js"],
+        slides=[
+            Slide(html='<div class="slide"><h1>Slide 1</h1></div>', scripts=""),
+            Slide(
+                html='<div class="slide"><canvas id="c1"></canvas></div>',
+                scripts='new Chart(document.getElementById("c1"), {});',
+            ),
+        ],
+    )
+
+
+def test_to_html_document_is_valid_html5(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert out.startswith("<!doctype html>") or out.startswith("<!DOCTYPE html>")
+    assert "<html" in out
+    assert "<head>" in out
+    assert "<body>" in out
+    assert "</html>" in out
+
+
+def test_to_html_document_includes_title(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert "<title>Test Deck</title>" in out
+
+
+def test_to_html_document_includes_deck_css(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert ".slide { background: white; }" in out
+
+
+def test_to_html_document_includes_chart_js_cdn(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert "chart.js" in out
+
+
+def test_to_html_document_includes_all_slide_html(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert "<h1>Slide 1</h1>" in out
+    assert '<canvas id="c1"></canvas>' in out
+
+
+def test_to_html_document_includes_slide_scripts(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert 'new Chart(document.getElementById("c1")' in out
+
+
+def test_to_html_document_overrides_chart_js_cdn(minimal_deck):
+    out = minimal_deck.to_html_document(chart_js_cdn="https://internal.cdn/chart.js")
+    assert "https://internal.cdn/chart.js" in out
+    assert "cdn.jsdelivr.net" not in out or out.count("cdn.jsdelivr.net") == 0
+
+
+def test_to_html_document_empty_deck():
+    deck = SlideDeck(title="Empty")
+    out = deck.to_html_document()
+    assert "<!doctype html>" in out.lower()
+    assert "<title>Empty</title>" in out
+
+
+def test_to_html_document_is_deterministic(minimal_deck):
+    a = minimal_deck.to_html_document()
+    b = minimal_deck.to_html_document()
+    assert a == b
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_slide_deck_to_html_document.py -v
+```
+
+Expected: 9 failures / errors due to `to_html_document` not being defined (or producing wrong output if a similar method exists).
+
+- [ ] **Step 4: Implement `to_html_document` in `src/domain/slide_deck.py`**
+
+Add the method inside the `SlideDeck` class (place it near other serialization methods like `to_dict` if present, or near `knit` if that exists). If an existing method already produces similar output, implement `to_html_document` as a thin wrapper; otherwise, implement from scratch:
+
+```python
+    def to_html_document(self, chart_js_cdn: str = None) -> str:
+        """Serialize the deck as a standalone renderable HTML document.
+
+        Produces a complete <!doctype html> page with the deck's CSS, external
+        scripts (with the Chart.js CDN URL overridable for air-gapped
+        environments), all slide HTML in order, and per-slide scripts
+        aggregated at the bottom.
+
+        Args:
+            chart_js_cdn: Override for the Chart.js CDN URL. If provided,
+                replaces the default Chart.js entry in external_scripts for
+                this serialization only (does NOT mutate the deck).
+
+        Returns:
+            A complete HTML document string, renderable in any modern browser.
+        """
+        title = self.title or "Slide Deck"
+
+        scripts_list = list(self.external_scripts)
+        if chart_js_cdn is not None:
+            scripts_list = [
+                chart_js_cdn if s == self.CHART_JS_URL else s
+                for s in scripts_list
+            ]
+            if self.CHART_JS_URL not in self.external_scripts and chart_js_cdn not in scripts_list:
+                scripts_list.append(chart_js_cdn)
+
+        external_script_tags = "\n".join(
+            f'  <script src="{src}"></script>' for src in scripts_list
+        )
+
+        slide_html = "\n".join(slide.html for slide in self.slides)
+        aggregated_scripts = self.scripts  # IIFE-wrapped per existing property
+
+        return (
+            "<!doctype html>\n"
+            "<html>\n"
+            "<head>\n"
+            '  <meta charset="utf-8">\n'
+            f"  <title>{title}</title>\n"
+            f"  <style>\n{self.css}\n  </style>\n"
+            f"{external_script_tags}\n"
+            "</head>\n"
+            "<body>\n"
+            f"{slide_html}\n"
+            f"<script>\n{aggregated_scripts}\n</script>\n"
+            "</body>\n"
+            "</html>\n"
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_slide_deck_to_html_document.py -v
+```
+
+Expected: 9 passed.
+
+If `test_to_html_document_overrides_chart_js_cdn` fails because the default CDN still appears (e.g., `_ensure_default_external_scripts` re-adds it), adjust the override logic so `chart_js_cdn` fully replaces the default rather than appending alongside.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/slide_deck.py tests/unit/test_slide_deck_to_html_document.py
+git commit -m "$(cat <<'EOF'
+feat(domain): add SlideDeck.to_html_document() serializer
+
+Adds a standalone-document HTML serializer so deck content can be
+returned as a self-contained renderable page to MCP callers (Stride,
+Vibe, and other external agents) without requiring them to assemble
+head/body/scripts themselves. Default Chart.js CDN is overridable for
+air-gapped environments.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 3: Add 10-minute hard-timeout sweeper to the job queue
+
+**Files:**
+- Modify: `src/api/services/job_queue.py`
+- Create: `tests/unit/test_job_queue_timeout_sweeper.py`
+
+- [ ] **Step 1: Read `src/api/services/job_queue.py` in full** to identify:
+  - The existing data model for in-memory `jobs` dict and any DB-backed `chat_requests` table.
+  - The signature of `recover_stuck_requests` (referenced in `main.py` lifespan).
+  - The pattern used for other background loops (e.g., the `request_log_cleanup_loop` in `src/api/middleware/request_logging.py`).
+
+Record findings.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/test_job_queue_timeout_sweeper.py`:
+
+```python
+"""Tests for the 10-minute hard-timeout sweeper on chat jobs."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from src.api.services import job_queue
+
+
+@pytest.fixture(autouse=True)
+def _clean_jobs():
+    """Ensure an empty in-memory jobs dict between tests."""
+    job_queue.jobs.clear()
+    yield
+    job_queue.jobs.clear()
+
+
+def test_timeout_constant_is_600_seconds():
+    assert job_queue.JOB_HARD_TIMEOUT_SECONDS == 600
+
+
+@pytest.mark.asyncio
+async def test_sweep_marks_old_running_job_as_failed():
+    now = datetime.utcnow()
+    job_queue.jobs["req-old"] = {
+        "status": "running",
+        "session_id": "s1",
+        "started_at": now - timedelta(seconds=700),  # older than timeout
+    }
+
+    await job_queue.mark_timed_out_jobs_once()
+
+    entry = job_queue.jobs["req-old"]
+    assert entry["status"] == "failed"
+    assert "10 minutes" in entry.get("error", "") or "600" in entry.get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_young_running_job_alone():
+    now = datetime.utcnow()
+    job_queue.jobs["req-young"] = {
+        "status": "running",
+        "session_id": "s2",
+        "started_at": now - timedelta(seconds=60),  # fresh
+    }
+
+    await job_queue.mark_timed_out_jobs_once()
+
+    assert job_queue.jobs["req-young"]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_pending_job_alone():
+    now = datetime.utcnow()
+    job_queue.jobs["req-pending"] = {
+        "status": "pending",
+        "session_id": "s3",
+        "queued_at": now - timedelta(seconds=1200),
+    }
+
+    await job_queue.mark_timed_out_jobs_once()
+
+    assert job_queue.jobs["req-pending"]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_sweep_idempotent_on_already_failed():
+    now = datetime.utcnow()
+    job_queue.jobs["req-already-failed"] = {
+        "status": "failed",
+        "session_id": "s4",
+        "started_at": now - timedelta(hours=1),
+        "error": "Existing error",
+    }
+
+    await job_queue.mark_timed_out_jobs_once()
+
+    # status unchanged; existing error preserved
+    entry = job_queue.jobs["req-already-failed"]
+    assert entry["status"] == "failed"
+    assert entry["error"] == "Existing error"
+
+
+@pytest.mark.asyncio
+async def test_sweep_handles_missing_started_at():
+    """Sweeper should not crash if a running job has no started_at timestamp."""
+    job_queue.jobs["req-no-ts"] = {
+        "status": "running",
+        "session_id": "s5",
+    }
+
+    # Should not raise; the job is left alone (we can't determine age)
+    await job_queue.mark_timed_out_jobs_once()
+
+    assert job_queue.jobs["req-no-ts"]["status"] == "running"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_job_queue_timeout_sweeper.py -v
+```
+
+Expected: all fail (constant not defined, function not defined, etc.).
+
+- [ ] **Step 4: Implement the sweeper**
+
+Add to `src/api/services/job_queue.py` (at module top, near existing constants):
+
+```python
+# Maximum duration (seconds) a chat request can stay in "running" before the
+# hard-timeout sweeper marks it failed. Belt-and-suspenders on top of the
+# startup recover_stuck_requests() pass: the sweeper runs continuously while
+# the app is up, whereas recovery only runs at process boot.
+JOB_HARD_TIMEOUT_SECONDS = 600
+```
+
+Then add two functions:
+
+```python
+async def mark_timed_out_jobs_once() -> int:
+    """Single sweep: mark running jobs older than JOB_HARD_TIMEOUT_SECONDS as failed.
+
+    Examines the in-memory jobs dict. For any job whose status is "running"
+    and whose started_at is older than the timeout, flips status to "failed"
+    and records an explanatory error. Jobs with no started_at are left
+    untouched (we cannot determine age).
+
+    Returns:
+        Number of jobs marked failed in this sweep.
+    """
+    now = datetime.utcnow()
+    cutoff = now - timedelta(seconds=JOB_HARD_TIMEOUT_SECONDS)
+    marked = 0
+
+    for request_id, entry in list(jobs.items()):
+        if entry.get("status") != "running":
+            continue
+        started_at = entry.get("started_at")
+        if started_at is None:
+            continue
+        if started_at > cutoff:
+            continue
+
+        entry["status"] = "failed"
+        entry["error"] = (
+            f"Generation exceeded maximum duration "
+            f"({JOB_HARD_TIMEOUT_SECONDS // 60} minutes)"
+        )
+        entry["ended_at"] = now
+        marked += 1
+        logger.warning(
+            "Marked job as timed-out",
+            extra={
+                "request_id": request_id,
+                "session_id": entry.get("session_id"),
+                "age_seconds": (now - started_at).total_seconds(),
+            },
+        )
+
+    return marked
+
+
+async def mark_timed_out_jobs_loop() -> None:
+    """Background loop: runs mark_timed_out_jobs_once() every 60 seconds.
+
+    Started in the FastAPI lifespan alongside the existing workers. Survives
+    its own exceptions so a single DB or logging hiccup does not take down
+    the loop for the lifetime of the process.
+    """
+    while True:
+        try:
+            await asyncio.sleep(60)
+            marked = await mark_timed_out_jobs_once()
+            if marked:
+                logger.info(
+                    "Timeout sweep marked %d jobs as failed", marked
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("Timeout sweep iteration failed: %s", e, exc_info=True)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_job_queue_timeout_sweeper.py -v
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/services/job_queue.py tests/unit/test_job_queue_timeout_sweeper.py
+git commit -m "$(cat <<'EOF'
+feat(job-queue): add 10-minute hard-timeout sweeper for stuck jobs
+
+Adds JOB_HARD_TIMEOUT_SECONDS (600) constant, a single-sweep helper
+mark_timed_out_jobs_once(), and a long-running mark_timed_out_jobs_loop()
+coroutine started in the lifespan. Belt-and-suspenders on top of
+startup recover_stuck_requests(): guarantees a predictable upper bound
+on polling duration for MCP callers regardless of deploy cadence.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+The lifespan wiring (actually starting the loop) is deferred to Task 10 (`main.py` changes), so this commit only adds the building block.
+
+---
+
+## Phase 2: MCP Authentication Helper
+
+### Task 4: Create `src/api/mcp_auth.py` with dual-token extraction
+
+**Files:**
+- Create: `src/api/mcp_auth.py`
+- Create: `tests/unit/test_mcp_auth.py`
+
+- [ ] **Step 1: Read `src/api/main.py` lines 240-329** — the existing `user_auth_middleware`. Note specifically:
+  - How `x-forwarded-access-token` is extracted
+  - How `get_or_create_user_client(token)` is called from `src/core/databricks_client`
+  - How `set_current_user`, `set_user_client`, `set_permission_context` are used
+  - How the `finally` block clears context
+
+The MCP auth helper mirrors this exactly, just with a different token source priority.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/unit/test_mcp_auth.py`:
+
+```python
+"""Tests for the dual-token MCP auth helper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.api.mcp_auth import (
+    MCPAuthError,
+    extract_mcp_identity,
+    mcp_auth_scope,
+)
+
+
+class _FakeRequest:
+    """Minimal Request stand-in with a headers dict."""
+
+    def __init__(self, headers: dict):
+        self.headers = headers
+
+
+@pytest.fixture
+def fake_user_client():
+    client = MagicMock()
+    me = MagicMock()
+    me.id = "user-abc"
+    me.user_name = "alice@example.com"
+    client.current_user.me.return_value = me
+    return client
+
+
+# ---- extract_mcp_identity -------------------------------------------------
+
+
+def test_extracts_from_x_forwarded_access_token_when_present(fake_user_client):
+    req = _FakeRequest(headers={"x-forwarded-access-token": "tok-xfa"})
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.user_id == "user-abc"
+    assert identity.user_name == "alice@example.com"
+    assert identity.token == "tok-xfa"
+    assert identity.source == "x-forwarded-access-token"
+
+
+def test_falls_back_to_authorization_bearer(fake_user_client):
+    req = _FakeRequest(headers={"authorization": "Bearer tok-bearer"})
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.token == "tok-bearer"
+    assert identity.source == "authorization-bearer"
+
+
+def test_x_forwarded_wins_over_authorization_when_both_present(fake_user_client):
+    req = _FakeRequest(
+        headers={
+            "x-forwarded-access-token": "tok-xfa",
+            "authorization": "Bearer tok-bearer",
+        }
+    )
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.token == "tok-xfa"
+    assert identity.source == "x-forwarded-access-token"
+
+
+def test_raises_on_missing_credentials():
+    req = _FakeRequest(headers={})
+    with pytest.raises(MCPAuthError) as exc:
+        extract_mcp_identity(req)
+    assert "authentication" in str(exc.value).lower() or "credentials" in str(exc.value).lower()
+
+
+def test_raises_on_malformed_authorization_header():
+    req = _FakeRequest(headers={"authorization": "Basic abcd"})
+    with pytest.raises(MCPAuthError):
+        extract_mcp_identity(req)
+
+
+def test_raises_when_identity_resolution_fails():
+    req = _FakeRequest(headers={"authorization": "Bearer tok-bad"})
+    bad_client = MagicMock()
+    bad_client.current_user.me.side_effect = Exception("token invalid")
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=bad_client,
+    ):
+        with pytest.raises(MCPAuthError):
+            extract_mcp_identity(req)
+
+
+def test_bearer_extraction_trims_whitespace(fake_user_client):
+    req = _FakeRequest(headers={"authorization": "Bearer    tok-spaced   "})
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.token == "tok-spaced"
+
+
+# ---- mcp_auth_scope context manager --------------------------------------
+
+
+def test_scope_sets_and_clears_context_vars(fake_user_client):
+    req = _FakeRequest(headers={"x-forwarded-access-token": "tok"})
+
+    with patch("src.api.mcp_auth.get_or_create_user_client", return_value=fake_user_client), \
+         patch("src.api.mcp_auth.set_current_user") as set_user, \
+         patch("src.api.mcp_auth.set_user_client") as set_client, \
+         patch("src.api.mcp_auth.set_permission_context") as set_perm:
+
+        with mcp_auth_scope(req) as identity:
+            assert identity.user_name == "alice@example.com"
+
+        # After exit: all three setters were called with None for teardown
+        assert set_user.call_args_list[-1].args[0] is None
+        assert set_client.call_args_list[-1].args[0] is None
+        assert set_perm.call_args_list[-1].args[0] is None
+
+
+def test_scope_clears_context_even_on_exception(fake_user_client):
+    req = _FakeRequest(headers={"x-forwarded-access-token": "tok"})
+
+    with patch("src.api.mcp_auth.get_or_create_user_client", return_value=fake_user_client), \
+         patch("src.api.mcp_auth.set_current_user") as set_user, \
+         patch("src.api.mcp_auth.set_user_client") as set_client, \
+         patch("src.api.mcp_auth.set_permission_context") as set_perm:
+
+        with pytest.raises(RuntimeError):
+            with mcp_auth_scope(req):
+                raise RuntimeError("boom")
+
+        # Context was still cleared
+        assert set_user.call_args_list[-1].args[0] is None
+        assert set_client.call_args_list[-1].args[0] is None
+        assert set_perm.call_args_list[-1].args[0] is None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_mcp_auth.py -v
+```
+
+Expected: all 9 fail with import errors (module doesn't exist yet).
+
+- [ ] **Step 4: Implement the auth helper**
+
+Create `src/api/mcp_auth.py`:
+
+```python
+"""Dual-token authentication for the MCP endpoint.
+
+Accepts two token sources in priority order:
+
+1. ``x-forwarded-access-token`` — injected by the Databricks Apps proxy.
+   Highest trust; cannot be spoofed from outside the proxy.
+2. ``Authorization: Bearer <token>`` — fallback for external callers
+   (laptop MCP clients, agent tools) that are not behind the proxy.
+
+The resolved identity is bound into the same request-scoped ContextVars
+the browser flow uses (``set_current_user``, ``set_user_client``,
+``set_permission_context``), so downstream services (session manager,
+permission service, MLflow, Google OAuth) see the caller's identity
+without any MCP-specific plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+from fastapi import Request
+
+from src.core.databricks_client import (
+    get_or_create_user_client,
+    set_user_client,
+)
+from src.core.permission_context import (
+    build_permission_context,
+    set_permission_context,
+)
+from src.core.user_context import set_current_user
+
+logger = logging.getLogger(__name__)
+
+
+class MCPAuthError(Exception):
+    """Raised when a request to /mcp lacks valid authentication."""
+
+
+@dataclass
+class MCPIdentity:
+    user_id: Optional[str]
+    user_name: str
+    token: str
+    source: str  # "x-forwarded-access-token" or "authorization-bearer"
+
+
+def extract_mcp_identity(request: Request) -> MCPIdentity:
+    """Resolve the caller's identity from request headers.
+
+    Raises ``MCPAuthError`` if no valid token is found or if the token
+    cannot be resolved to an identity.
+    """
+    # Priority 1: proxy-injected token
+    token = request.headers.get("x-forwarded-access-token")
+    source = "x-forwarded-access-token"
+
+    if not token:
+        # Priority 2: Authorization: Bearer fallback
+        authz = request.headers.get("authorization") or request.headers.get("Authorization") or ""
+        if authz.lower().startswith("bearer "):
+            token = authz[len("Bearer "):].strip()
+            source = "authorization-bearer"
+        elif authz:
+            raise MCPAuthError(
+                "Unsupported Authorization scheme; expected 'Bearer <token>'"
+            )
+
+    if not token:
+        raise MCPAuthError("Authentication required: no credentials presented")
+
+    try:
+        user_client = get_or_create_user_client(token)
+        me = user_client.current_user.me()
+    except Exception as e:
+        logger.warning("MCP auth: identity resolution failed: %s", e)
+        raise MCPAuthError("Invalid or expired credentials") from e
+
+    return MCPIdentity(
+        user_id=getattr(me, "id", None),
+        user_name=getattr(me, "user_name", "") or "",
+        token=token,
+        source=source,
+    )
+
+
+@contextmanager
+def mcp_auth_scope(request: Request) -> Iterator[MCPIdentity]:
+    """Context manager that authenticates an MCP request and binds identity
+    ContextVars for the duration of the block.
+
+    On entry: resolves identity, binds ``current_user``, ``user_client``,
+    and ``permission_context``.
+
+    On exit: clears all three ContextVars, even if the wrapped block raised.
+    """
+    identity = extract_mcp_identity(request)
+
+    user_client = get_or_create_user_client(identity.token)
+    permission_ctx = build_permission_context(
+        user_id=identity.user_id,
+        user_name=identity.user_name,
+        fetch_groups=False,
+    )
+
+    set_current_user(identity.user_name)
+    set_user_client(user_client)
+    set_permission_context(permission_ctx)
+
+    logger.debug(
+        "MCP auth scope entered",
+        extra={
+            "user_name": identity.user_name,
+            "token_source": identity.source,
+        },
+    )
+
+    try:
+        yield identity
+    finally:
+        set_current_user(None)
+        set_user_client(None)
+        set_permission_context(None)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_mcp_auth.py -v
+```
+
+Expected: 9 passed.
+
+If any test around `set_current_user` / `set_user_client` patches fails because of import paths (e.g., the `ContextVar` setter lives in a different module than my import), adjust the import path in `mcp_auth.py` to match the real setter location in the codebase. The unit tests patch `src.api.mcp_auth.set_*` so the functions must be imported *by name into `mcp_auth.py`*, not called via module attribute.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/mcp_auth.py tests/unit/test_mcp_auth.py
+git commit -m "$(cat <<'EOF'
+feat(mcp): add dual-token auth helper for MCP endpoint
+
+Introduces extract_mcp_identity() and mcp_auth_scope() context manager.
+Accepts x-forwarded-access-token (proxy-injected, highest trust) with
+Authorization: Bearer fallback for external callers (laptop agent
+tools, Claude Code, etc). Binds the same ContextVars as the browser
+flow so downstream services see identity transparently.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+## Phase 3: MCP Tools
+
+### Task 5: Create `src/api/mcp_server.py` skeleton with FastMCP instance
+
+**Files:**
+- Create: `src/api/mcp_server.py`
+
+- [ ] **Step 1: Create the skeleton file**
+
+Create `src/api/mcp_server.py`:
+
+```python
+"""MCP (Model Context Protocol) server for tellr.
+
+Exposes tellr's deck-generation capabilities as a set of MCP tools so
+external Databricks Apps and MCP-compatible agent tools (e.g., Claude
+Code) can programmatically create, edit, and retrieve slide decks.
+
+The tools are thin wrappers over existing services (ChatService,
+SessionManager, SlideDeck, permission_service) — no re-implementation
+of the agent pipeline.
+
+See docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md for
+the design rationale and docs/technical/mcp-server.md for the
+caller-facing integration guide.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+from fastapi import Request
+from mcp.server.fastmcp import FastMCP
+
+from src.api.mcp_auth import MCPAuthError, mcp_auth_scope
+
+logger = logging.getLogger(__name__)
+
+# FastMCP instance — one per process. Tools are registered via decorators below.
+mcp = FastMCP("tellr")
+
+
+def _public_app_url() -> str:
+    """Return the base URL for constructing deck_url / deck_view_url.
+
+    Reads TELLR_APP_URL from the environment; this is set at deploy time
+    by the Databricks App platform or by local dev config.
+    """
+    return os.getenv("TELLR_APP_URL", "").rstrip("/")
+
+
+# Tool implementations are added in subsequent tasks.
+```
+
+- [ ] **Step 2: Smoke-test the module imports**
+
+```bash
+python -c "from src.api.mcp_server import mcp; print(type(mcp).__name__)"
+```
+
+Expected output: `FastMCP`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/mcp_server.py
+git commit -m "$(cat <<'EOF'
+feat(mcp): add mcp_server.py skeleton with FastMCP instance
+
+Creates the module that will host tellr's four MCP tools (create_deck,
+get_deck_status, edit_deck, get_deck). Tools are added in subsequent
+commits, each wrapping existing services without duplication.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 6: Implement `create_deck` tool
+
+**Files:**
+- Modify: `src/api/mcp_server.py`
+- Create: `tests/unit/test_mcp_server.py`
+
+- [ ] **Step 1: Read `src/api/routes/chat.py`** for the `/api/chat/async` route implementation. Identify:
+  - How a new session is created (`SessionManager.create_session` signature)
+  - How the async submission works (likely `ChatService.submit_chat_async(...)` or direct `job_queue.enqueue_job(...)`)
+  - The agent_config structure used for prompt-only generation
+
+Record the exact function signatures and module paths.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/test_mcp_server.py`:
+
+```python
+"""Unit tests for MCP tool handlers.
+
+Each handler is tested in isolation with mocked services. Integration
+behavior (full JSON-RPC round trip, FastMCP routing) lives in
+tests/integration/test_mcp_endpoint.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.api.mcp_auth import MCPIdentity
+
+
+@pytest.fixture
+def identity():
+    return MCPIdentity(
+        user_id="user-abc",
+        user_name="alice@example.com",
+        token="tok",
+        source="x-forwarded-access-token",
+    )
+
+
+@pytest.fixture
+def fake_request():
+    req = MagicMock()
+    req.headers = {"x-forwarded-access-token": "tok"}
+    return req
+
+
+# ---- create_deck --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_deck_creates_session_and_submits_job(fake_request, identity):
+    from src.api import mcp_server
+
+    mock_session = {"session_id": "sess-123"}
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job") as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        sm = MagicMock()
+        sm.create_session.return_value = mock_session
+        get_sm.return_value = sm
+
+        enqueue.return_value = "req-777"
+
+        result = await mcp_server._create_deck_impl(
+            request=fake_request,
+            prompt="make a deck about Q3",
+            num_slides=7,
+            slide_style_id=4,
+            deck_prompt_id=2,
+            correlation_id="vibe-xyz",
+        )
+
+        sm.create_session.assert_called_once()
+        create_kwargs = sm.create_session.call_args.kwargs
+        assert create_kwargs["created_by"] == "alice@example.com"
+        agent_config = create_kwargs["agent_config"]
+        assert agent_config["tools"] == []
+        assert agent_config["slide_style_id"] == 4
+        assert agent_config["deck_prompt_id"] == 2
+
+        enqueue.assert_called_once()
+        assert enqueue.call_args.kwargs["session_id"] == "sess-123"
+        assert enqueue.call_args.kwargs["prompt"] == "make a deck about Q3"
+        assert enqueue.call_args.kwargs["mode"] == "generate"
+        assert enqueue.call_args.kwargs["correlation_id"] == "vibe-xyz"
+
+        assert result == {
+            "session_id": "sess-123",
+            "request_id": "req-777",
+            "status": "pending",
+        }
+
+
+@pytest.mark.asyncio
+async def test_create_deck_rejects_empty_prompt(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope:
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="",
+            )
+        assert "prompt" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_create_deck_rejects_num_slides_out_of_range(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope:
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        with pytest.raises(MCPToolError):
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="foo",
+                num_slides=0,
+            )
+        with pytest.raises(MCPToolError):
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="foo",
+                num_slides=51,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_deck_surfaces_auth_error_as_tool_error(fake_request):
+    from src.api import mcp_server
+    from src.api.mcp_auth import MCPAuthError
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope:
+        auth_scope.return_value.__enter__.side_effect = MCPAuthError("no creds")
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="foo",
+            )
+        assert "auth" in str(exc.value).lower() or "credentials" in str(exc.value).lower()
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: all fail with import errors (`MCPToolError` not defined, `_create_deck_impl` not defined, etc.).
+
+- [ ] **Step 4: Implement `create_deck`**
+
+Add to `src/api/mcp_server.py` (below the skeleton):
+
+```python
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+class MCPToolError(Exception):
+    """Raised when an MCP tool cannot complete its operation.
+
+    FastMCP renders these as tool results with ``isError: true`` rather
+    than as JSON-RPC protocol errors, per MCP convention.
+    """
+
+
+# ---------------------------------------------------------------------------
+# create_deck
+# ---------------------------------------------------------------------------
+
+from src.api.services.session_manager import get_session_manager
+from src.api.services.chat_service import get_chat_service
+
+
+async def enqueue_create_job(
+    session_id: str,
+    prompt: str,
+    mode: str = "generate",
+    slide_context: Optional[dict] = None,
+    correlation_id: Optional[str] = None,
+) -> str:
+    """Submit a generate or edit job using tellr's existing chat async path.
+
+    Thin wrapper so tests can patch at one call site. Delegates to
+    ChatService.submit_chat_async if present, or to the job_queue
+    directly — executor should verify which signature is in use.
+    """
+    chat_service = get_chat_service()
+    # Use the same entry point /api/chat/async uses.
+    # Executor: verify the exact signature of submit_chat_async against
+    # src/api/services/chat_service.py and adjust kwargs below if needed.
+    request_id = await chat_service.submit_chat_async(
+        session_id=session_id,
+        message=prompt,
+        mode=mode,
+        slide_context=slide_context,
+        correlation_id=correlation_id,
+    )
+    return request_id
+
+
+@mcp.tool(
+    name="create_deck",
+    description=(
+        "Generate a new slide deck from a natural-language prompt. Returns a "
+        "session_id and a request_id; the caller polls get_deck_status for "
+        "completion. The resulting deck is attributed to the calling user and "
+        "appears in their tellr UI. v1 runs prompt-only: the agent does not "
+        "invoke Genie, Vector Search, or other tools. Callers that want data-"
+        "backed decks should gather the data themselves and include it in the "
+        "prompt."
+    ),
+)
+async def create_deck(
+    request: Request,
+    prompt: str,
+    num_slides: Optional[int] = None,
+    slide_style_id: Optional[int] = None,
+    deck_prompt_id: Optional[int] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    return await _create_deck_impl(
+        request=request,
+        prompt=prompt,
+        num_slides=num_slides,
+        slide_style_id=slide_style_id,
+        deck_prompt_id=deck_prompt_id,
+        correlation_id=correlation_id,
+    )
+
+
+async def _create_deck_impl(
+    request: Request,
+    prompt: str,
+    num_slides: Optional[int] = None,
+    slide_style_id: Optional[int] = None,
+    deck_prompt_id: Optional[int] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    """Implementation, separated from the decorated tool for testability."""
+    if not prompt or not prompt.strip():
+        raise MCPToolError("prompt must be a non-empty string")
+    if num_slides is not None and not (1 <= num_slides <= 50):
+        raise MCPToolError("num_slides must be between 1 and 50")
+
+    try:
+        with mcp_auth_scope(request) as identity:
+            agent_config: dict[str, Any] = {"tools": []}
+            if slide_style_id is not None:
+                agent_config["slide_style_id"] = slide_style_id
+            if deck_prompt_id is not None:
+                agent_config["deck_prompt_id"] = deck_prompt_id
+            if num_slides is not None:
+                agent_config["num_slides"] = num_slides
+
+            sm = get_session_manager()
+            session = sm.create_session(
+                created_by=identity.user_name,
+                agent_config=agent_config,
+            )
+            session_id = session["session_id"]
+
+            request_id = await enqueue_create_job(
+                session_id=session_id,
+                prompt=prompt,
+                mode="generate",
+                slide_context=None,
+                correlation_id=correlation_id,
+            )
+
+            logger.info(
+                "MCP create_deck submitted",
+                extra={
+                    "event": "mcp_tool_invoked",
+                    "tool_name": "create_deck",
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "user_name": identity.user_name,
+                    "token_source": identity.source,
+                    "correlation_id": correlation_id,
+                },
+            )
+
+            return {
+                "session_id": session_id,
+                "request_id": request_id,
+                "status": "pending",
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP create_deck failed")
+        raise MCPToolError(f"Internal error (correlation_id={correlation_id}): {e}") from e
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: 4 passed (only the create_deck tests so far).
+
+If the test `test_create_deck_creates_session_and_submits_job` fails because `sm.create_session` expects different kwargs than `(created_by=..., agent_config=...)` (e.g., the real signature uses `user_name` instead of `created_by`, or returns a model object rather than a dict), update `_create_deck_impl` to match the real signature found in `src/api/services/session_manager.py`, and update the test accordingly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/mcp_server.py tests/unit/test_mcp_server.py
+git commit -m "$(cat <<'EOF'
+feat(mcp): implement create_deck tool
+
+Adds the create_deck MCP tool. Creates a new tellr session attributed
+to the authenticated caller with an empty agent_config.tools list
+(prompt-only generation), then submits a generate-mode async job via
+tellr's existing chat queue. Returns {session_id, request_id, status:
+pending}; caller polls get_deck_status for completion.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 7: Implement `get_deck_status` tool
+
+**Files:**
+- Modify: `src/api/mcp_server.py`
+- Modify: `tests/unit/test_mcp_server.py`
+
+- [ ] **Step 1: Read `src/api/routes/chat.py`** for the `poll_chat` / polling implementation to identify how job status + session state are merged for the caller. Key bits to reuse:
+  - How to tell "running" from "ready" from "failed"
+  - How the deck_json is loaded into a SlideDeck instance on ready
+  - How messages are extracted for the current turn
+  - How replacement_info propagates back
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/unit/test_mcp_server.py`:
+
+```python
+# ---- get_deck_status ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_returns_pending_shape(fake_request, identity):
+    from src.api import mcp_server
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_job_status") as get_status, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = True
+        get_status.return_value = {"status": "pending", "session_id": "sess-1"}
+
+        result = await mcp_server._get_deck_status_impl(
+            request=fake_request,
+            session_id="sess-1",
+            request_id="req-1",
+        )
+
+        assert result == {
+            "session_id": "sess-1",
+            "request_id": "req-1",
+            "status": "pending",
+            "progress": None,
+        }
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_returns_ready_with_full_deck(fake_request, identity):
+    from src.api import mcp_server
+
+    fake_session = {
+        "session_id": "sess-1",
+        "title": "Q3 Pitch",
+        "deck_json": {
+            "title": "Q3 Pitch",
+            "slides": [{"html": "<div class='slide'>A</div>", "scripts": ""}],
+            "css": "",
+            "external_scripts": ["https://cdn.jsdelivr.net/npm/chart.js"],
+            "head_meta": {},
+        },
+    }
+
+    fake_turn_messages = [
+        {"role": "user", "content": "make Q3 deck"},
+        {"role": "assistant", "content": "I created 1 slide..."},
+    ]
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_job_status") as get_status, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server._public_app_url", return_value="https://t.example"):
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = True
+        get_status.return_value = {
+            "status": "ready",
+            "session_id": "sess-1",
+            "messages": fake_turn_messages,
+            "replacement_info": None,
+            "started_at": None,
+            "ended_at": None,
+            "mode": "generate",
+            "latency_ms": 10000,
+            "tool_calls": 0,
+            "correlation_id": None,
+        }
+
+        sm = MagicMock()
+        sm.get_session.return_value = fake_session
+        get_sm.return_value = sm
+
+        result = await mcp_server._get_deck_status_impl(
+            request=fake_request,
+            session_id="sess-1",
+            request_id="req-1",
+        )
+
+        assert result["status"] == "ready"
+        assert result["session_id"] == "sess-1"
+        assert result["slide_count"] == 1
+        assert result["title"] == "Q3 Pitch"
+        assert "deck" in result and "slides" in result["deck"]
+        assert result["html_document"].startswith(("<!doctype", "<!DOCTYPE"))
+        assert result["deck_url"] == "https://t.example/sessions/sess-1/edit"
+        assert result["deck_view_url"] == "https://t.example/sessions/sess-1/view"
+        assert result["messages"] == fake_turn_messages
+        assert result["replacement_info"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_returns_failed_with_error(fake_request, identity):
+    from src.api import mcp_server
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_job_status") as get_status, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = True
+        get_status.return_value = {
+            "status": "failed",
+            "session_id": "sess-1",
+            "error": "Generation exceeded maximum duration (10 minutes)",
+        }
+
+        result = await mcp_server._get_deck_status_impl(
+            request=fake_request,
+            session_id="sess-1",
+            request_id="req-1",
+        )
+
+        assert result["status"] == "failed"
+        assert "10 minutes" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_denies_when_not_permitted(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = False
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._get_deck_status_impl(
+                request=fake_request,
+                session_id="sess-other",
+                request_id="req-1",
+            )
+        assert "permission" in str(exc.value).lower() or "not found" in str(exc.value).lower()
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: the four new tests fail; previous `create_deck` tests still pass.
+
+- [ ] **Step 4: Implement `get_deck_status`**
+
+Append to `src/api/mcp_server.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# get_deck_status
+# ---------------------------------------------------------------------------
+
+from src.api.services.job_queue import get_job_status
+from src.services import permission_service
+from src.domain.slide_deck import SlideDeck
+
+
+def _render_deck_response(session: dict, base_url: str) -> dict:
+    """Serialize a session's deck for inclusion in a ready response."""
+    deck_json = session.get("deck_json") or {}
+    deck = SlideDeck.from_dict(deck_json) if deck_json else SlideDeck(title=session.get("title"))
+    session_id = session["session_id"]
+    return {
+        "slide_count": len(deck.slides),
+        "title": session.get("title") or deck.title,
+        "deck": deck.to_dict(),
+        "html_document": deck.to_html_document(),
+        "deck_url": f"{base_url}/sessions/{session_id}/edit" if base_url else f"/sessions/{session_id}/edit",
+        "deck_view_url": f"{base_url}/sessions/{session_id}/view" if base_url else f"/sessions/{session_id}/view",
+    }
+
+
+@mcp.tool(
+    name="get_deck_status",
+    description=(
+        "Poll the status of a deck generation or edit job. Returns "
+        "lightweight status while pending/running; when ready, returns the "
+        "complete deck as structured slide data, a standalone HTML "
+        "document, and URLs into tellr's full editor and view-only surfaces."
+    ),
+)
+async def get_deck_status(
+    request: Request,
+    session_id: str,
+    request_id: str,
+) -> dict:
+    return await _get_deck_status_impl(
+        request=request, session_id=session_id, request_id=request_id
+    )
+
+
+async def _get_deck_status_impl(
+    request: Request, session_id: str, request_id: str
+) -> dict:
+    try:
+        with mcp_auth_scope(request):
+            if not permission_service.can_view_deck(session_id):
+                raise MCPToolError(
+                    "Deck not found or you do not have permission to view it"
+                )
+
+            status = get_job_status(request_id)
+            if status is None:
+                raise MCPToolError(f"Unknown request_id: {request_id}")
+
+            job_status = status.get("status", "pending")
+
+            if job_status in ("pending", "running"):
+                return {
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "status": job_status,
+                    "progress": status.get("progress"),
+                }
+
+            if job_status == "failed":
+                return {
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "status": "failed",
+                    "error": status.get("error", "Generation failed"),
+                }
+
+            # status == "ready"
+            sm = get_session_manager()
+            session = sm.get_session(session_id)
+            base = _public_app_url()
+            deck_fields = _render_deck_response(session, base)
+
+            return {
+                "session_id": session_id,
+                "request_id": request_id,
+                "status": "ready",
+                **deck_fields,
+                "replacement_info": status.get("replacement_info"),
+                "messages": status.get("messages") or [],
+                "metadata": {
+                    "mode": status.get("mode"),
+                    "tool_calls": status.get("tool_calls"),
+                    "latency_ms": status.get("latency_ms"),
+                    "correlation_id": status.get("correlation_id"),
+                },
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP get_deck_status failed")
+        raise MCPToolError(f"Internal error: {e}") from e
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: 8 passed (4 create_deck + 4 get_deck_status).
+
+If `SlideDeck.from_dict` / `to_dict` are not the exact method names in `src/domain/slide_deck.py`, adjust `_render_deck_response` to use the actual serialization API. Common alternatives: `SlideDeck.from_html_string(...)` + `SlideDeck.knit()`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/mcp_server.py tests/unit/test_mcp_server.py
+git commit -m "$(cat <<'EOF'
+feat(mcp): implement get_deck_status tool
+
+Adds the get_deck_status MCP tool. Returns lightweight pending/running
+status during generation and a full response on ready — structured
+deck, standalone html_document, deck_url / deck_view_url into tellr's
+UI, current-turn messages, replacement_info, and metadata. Permission-
+checks via permission_service.can_view_deck.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 8: Implement `edit_deck` tool
+
+**Files:**
+- Modify: `src/api/mcp_server.py`
+- Modify: `tests/unit/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_mcp_server.py`:
+
+```python
+# ---- edit_deck ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_submits_with_slide_context(fake_request, identity):
+    from src.api import mcp_server
+
+    fake_session = {
+        "session_id": "sess-1",
+        "deck_json": {
+            "title": "x",
+            "slides": [
+                {"html": "<div class='slide'>0</div>", "scripts": ""},
+                {"html": "<div class='slide'>1</div>", "scripts": ""},
+                {"html": "<div class='slide'>2</div>", "scripts": ""},
+            ],
+            "css": "",
+            "external_scripts": [],
+            "head_meta": {},
+        },
+    }
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job") as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = True
+
+        sm = MagicMock()
+        sm.get_session.return_value = fake_session
+        get_sm.return_value = sm
+
+        enqueue.return_value = "req-edit-1"
+
+        result = await mcp_server._edit_deck_impl(
+            request=fake_request,
+            session_id="sess-1",
+            instruction="make slide 2 more exciting",
+            slide_indices=[1],
+        )
+
+        enqueue.assert_called_once()
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["session_id"] == "sess-1"
+        assert kwargs["prompt"] == "make slide 2 more exciting"
+        assert kwargs["mode"] == "edit"
+        assert kwargs["slide_context"]["indices"] == [1]
+        assert kwargs["slide_context"]["slide_htmls"] == ["<div class='slide'>1</div>"]
+
+        assert result == {
+            "session_id": "sess-1",
+            "request_id": "req-edit-1",
+            "status": "pending",
+        }
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_submits_without_slide_context_when_indices_omitted(
+    fake_request, identity
+):
+    from src.api import mcp_server
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job") as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = True
+
+        sm = MagicMock()
+        sm.get_session.return_value = {"session_id": "sess-1", "deck_json": {}}
+        get_sm.return_value = sm
+
+        enqueue.return_value = "req-edit-2"
+
+        await mcp_server._edit_deck_impl(
+            request=fake_request,
+            session_id="sess-1",
+            instruction="make it more exciting",
+        )
+
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["mode"] == "edit"
+        assert kwargs["slide_context"] is None
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_rejects_non_contiguous_indices(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = True
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._edit_deck_impl(
+                request=fake_request,
+                session_id="sess-1",
+                instruction="edit",
+                slide_indices=[0, 2],  # not contiguous
+            )
+        assert "contiguous" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_denies_without_edit_permission(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = False
+
+        with pytest.raises(MCPToolError):
+            await mcp_server._edit_deck_impl(
+                request=fake_request,
+                session_id="sess-other",
+                instruction="edit",
+            )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: 4 new tests fail.
+
+- [ ] **Step 3: Implement `edit_deck`**
+
+Append to `src/api/mcp_server.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# edit_deck
+# ---------------------------------------------------------------------------
+
+
+def _check_contiguous(indices: list[int]) -> None:
+    if not indices:
+        return
+    sorted_idx = sorted(indices)
+    for a, b in zip(sorted_idx, sorted_idx[1:]):
+        if b - a != 1:
+            raise MCPToolError(
+                "slide_indices must be contiguous (e.g. [2, 3, 4], not [2, 4])"
+            )
+
+
+@mcp.tool(
+    name="edit_deck",
+    description=(
+        "Refine an existing deck through a natural-language instruction. "
+        "Optionally target specific contiguous slides via slide_indices. "
+        "The edit is applied in-place; the session_id and deck_url stay "
+        "stable across edits. Returns a request_id; the caller polls "
+        "get_deck_status for completion and receives the updated deck "
+        "plus replacement_info summarizing what changed."
+    ),
+)
+async def edit_deck(
+    request: Request,
+    session_id: str,
+    instruction: str,
+    slide_indices: Optional[list[int]] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    return await _edit_deck_impl(
+        request=request,
+        session_id=session_id,
+        instruction=instruction,
+        slide_indices=slide_indices,
+        correlation_id=correlation_id,
+    )
+
+
+async def _edit_deck_impl(
+    request: Request,
+    session_id: str,
+    instruction: str,
+    slide_indices: Optional[list[int]] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    if not instruction or not instruction.strip():
+        raise MCPToolError("instruction must be a non-empty string")
+    if slide_indices is not None:
+        _check_contiguous(slide_indices)
+
+    try:
+        with mcp_auth_scope(request) as identity:
+            if not permission_service.can_edit_deck(session_id):
+                raise MCPToolError(
+                    "Deck not found or you do not have permission to edit it"
+                )
+
+            slide_context = None
+            if slide_indices:
+                sm = get_session_manager()
+                session = sm.get_session(session_id)
+                deck_json = session.get("deck_json") or {}
+                all_slides = deck_json.get("slides") or []
+                try:
+                    slide_htmls = [all_slides[i]["html"] for i in slide_indices]
+                except IndexError as e:
+                    raise MCPToolError(
+                        f"slide_indices contains out-of-range index: {e}"
+                    ) from e
+                slide_context = {"indices": slide_indices, "slide_htmls": slide_htmls}
+
+            request_id = await enqueue_create_job(
+                session_id=session_id,
+                prompt=instruction,
+                mode="edit",
+                slide_context=slide_context,
+                correlation_id=correlation_id,
+            )
+
+            logger.info(
+                "MCP edit_deck submitted",
+                extra={
+                    "event": "mcp_tool_invoked",
+                    "tool_name": "edit_deck",
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "user_name": identity.user_name,
+                    "slide_indices": slide_indices,
+                    "correlation_id": correlation_id,
+                },
+            )
+
+            return {
+                "session_id": session_id,
+                "request_id": request_id,
+                "status": "pending",
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP edit_deck failed")
+        raise MCPToolError(f"Internal error: {e}") from e
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: 12 passed (4 create_deck + 4 get_deck_status + 4 edit_deck).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/mcp_server.py tests/unit/test_mcp_server.py
+git commit -m "$(cat <<'EOF'
+feat(mcp): implement edit_deck tool
+
+Adds the edit_deck MCP tool. Validates CAN_EDIT via permission_service,
+builds a slide_context from the caller's slide_indices (requiring
+contiguous indices, matching tellr's existing SlideContext invariant),
+and submits an edit-mode job through the same async pipeline as
+create_deck. The edit reuses tellr's existing _parse_slide_replacements
+and _apply_slide_replacements logic without change.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 9: Implement `get_deck` tool
+
+**Files:**
+- Modify: `src/api/mcp_server.py`
+- Modify: `tests/unit/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_mcp_server.py`:
+
+```python
+# ---- get_deck -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_deck_returns_deck_without_job(fake_request, identity):
+    from src.api import mcp_server
+
+    fake_session = {
+        "session_id": "sess-1",
+        "title": "Existing Deck",
+        "deck_json": {
+            "title": "Existing Deck",
+            "slides": [{"html": "<div class='slide'>1</div>", "scripts": ""}],
+            "css": "",
+            "external_scripts": ["https://cdn.jsdelivr.net/npm/chart.js"],
+            "head_meta": {},
+        },
+    }
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server._public_app_url", return_value="https://t.example"):
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_view_deck.return_value = True
+
+        sm = MagicMock()
+        sm.get_session.return_value = fake_session
+        get_sm.return_value = sm
+
+        result = await mcp_server._get_deck_impl(
+            request=fake_request,
+            session_id="sess-1",
+        )
+
+        assert result["session_id"] == "sess-1"
+        assert result["slide_count"] == 1
+        assert result["title"] == "Existing Deck"
+        assert "deck" in result
+        assert result["html_document"].lower().startswith("<!doctype")
+        assert result["deck_url"] == "https://t.example/sessions/sess-1/edit"
+        assert result["deck_view_url"] == "https://t.example/sessions/sess-1/view"
+        # Fields tied to a job/turn are absent
+        for absent_key in ("status", "request_id", "messages", "replacement_info", "metadata"):
+            assert absent_key not in result
+
+
+@pytest.mark.asyncio
+async def test_get_deck_denies_without_view_permission(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_view_deck.return_value = False
+
+        with pytest.raises(MCPToolError):
+            await mcp_server._get_deck_impl(
+                request=fake_request,
+                session_id="sess-other",
+            )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: 2 new tests fail.
+
+- [ ] **Step 3: Implement `get_deck`**
+
+Append to `src/api/mcp_server.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# get_deck
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="get_deck",
+    description=(
+        "Retrieve the current state of a deck without submitting new work. "
+        "Returns structured slide data, a standalone HTML document, and "
+        "URLs into tellr's editor — same payload as a ready get_deck_status "
+        "response, without status/request_id/messages. Idempotent; no job "
+        "queue interaction. Use when you have a session_id from earlier and "
+        "want to re-render without polling."
+    ),
+)
+async def get_deck(request: Request, session_id: str) -> dict:
+    return await _get_deck_impl(request=request, session_id=session_id)
+
+
+async def _get_deck_impl(request: Request, session_id: str) -> dict:
+    try:
+        with mcp_auth_scope(request):
+            if not permission_service.can_view_deck(session_id):
+                raise MCPToolError(
+                    "Deck not found or you do not have permission to view it"
+                )
+
+            sm = get_session_manager()
+            session = sm.get_session(session_id)
+            base = _public_app_url()
+            deck_fields = _render_deck_response(session, base)
+
+            return {
+                "session_id": session_id,
+                **deck_fields,
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP get_deck failed")
+        raise MCPToolError(f"Internal error: {e}") from e
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_mcp_server.py -v
+```
+
+Expected: 14 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/mcp_server.py tests/unit/test_mcp_server.py
+git commit -m "$(cat <<'EOF'
+feat(mcp): implement get_deck tool
+
+Adds the get_deck MCP tool — an idempotent read that returns a session's
+current deck as structured data, standalone HTML, and tellr URLs,
+without submitting any job. Used by callers re-rendering a deck they
+already have a session_id for.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+## Phase 4: Wire the MCP Router into FastAPI
+
+### Task 10: Register MCP router in `main.py` and start the timeout sweeper
+
+**Files:**
+- Modify: `src/api/main.py`
+
+- [ ] **Step 1: Read `src/api/main.py` in full** — confirm the current:
+  - Router registration order (where `app.include_router(...)` calls live)
+  - Lifespan function structure and where background tasks are created
+  - The exact location where `_mount_frontend` is called in production
+
+Record findings.
+
+- [ ] **Step 2: Integrate the MCP router mount**
+
+Locate the block near line 337–355 of `src/api/main.py` where existing `app.include_router(...)` calls happen. **Before** the `@app.get("/api/health")` definition and **before** the `_mount_frontend(app, frontend_dist)` call inside `lifespan`, add:
+
+```python
+# MCP server — mount before any catch-all SPA route so /mcp is handled.
+from src.api.mcp_server import mcp as tellr_mcp  # noqa: E402
+app.include_router(
+    tellr_mcp.streamable_http_app().router,
+    prefix="/mcp",
+    tags=["mcp"],
+)
+logger.info("MCP server mounted at /mcp")
+```
+
+Placement intent: top-level module-load registration, alongside the other `app.include_router` calls. Do NOT place it inside the lifespan.
+
+**Executor note:** The exact API for mounting FastMCP into FastAPI differs slightly between `mcp` SDK versions. Verify against the installed version with:
+
+```bash
+python -c "from mcp.server.fastmcp import FastMCP; m = FastMCP('t'); print(dir(m))"
+```
+
+Common patterns:
+- `mcp.streamable_http_app()` returns an ASGI app you can `app.mount("/mcp", ...)` — preferred.
+- If the SDK exposes `mcp.fastapi_router()`, use that with `app.include_router(..., prefix="/mcp")`.
+- If neither exists in the installed version, use `mcp.http_server()` + `app.mount("/mcp", ...)`.
+
+Pick whichever the installed version supports. Run a quick smoke request afterward (Step 4 below) to confirm mounting succeeded.
+
+- [ ] **Step 3: Start the timeout sweeper in lifespan**
+
+In the `lifespan` function (around line 105), after `start_export_worker` and before `recover_stuck_requests`, add:
+
+```python
+# Start the MCP job timeout sweeper
+from src.api.services.job_queue import mark_timed_out_jobs_loop
+_timeout_task = asyncio.create_task(mark_timed_out_jobs_loop())
+logger.info("MCP job timeout sweeper started")
+```
+
+Declare `_timeout_task` in the globals section near the other worker task refs (near line 53):
+
+```python
+_timeout_task = None
+```
+
+Add shutdown handling in the cleanup section (near line 154):
+
+```python
+if _timeout_task:
+    _timeout_task.cancel()
+    try:
+        await _timeout_task
+    except asyncio.CancelledError:
+        pass
+    logger.info("MCP job timeout sweeper stopped")
+```
+
+- [ ] **Step 4: Smoke-test by starting the app locally**
+
+Activate the Python environment and run:
+
+```bash
+cd "/path/to/ai-slide-generator"
+ENVIRONMENT=development uvicorn src.api.main:app --port 8000 --reload &
+sleep 3
+curl -i -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fake-token-for-local-dev" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "smoke", "version": "0.0.0"}}}'
+```
+
+Expected: an HTTP 200 response with a JSON-RPC envelope containing capabilities and an `mcp-session-id` header. If auth fails with a test token (because current_user.me() can't resolve it), mock the identity temporarily with `DEV_USER_ID=dev@local.dev` in env and a stub user client, or ensure `get_or_create_user_client` has a dev-mode bypass in local dev. If the server returns HTML (from the SPA catch-all) instead of JSON-RPC, the router is registered too late — move its registration earlier in the file.
+
+Kill the local server:
+
+```bash
+kill %1
+```
+
+- [ ] **Step 5: Run all unit tests to confirm no regressions**
+
+```bash
+pytest tests/unit/ -v
+```
+
+Expected: all pass (including the new MCP tests from Tasks 2, 3, 4, 6, 7, 8, 9).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/main.py
+git commit -m "$(cat <<'EOF'
+feat(mcp): mount MCP router at /mcp and start timeout sweeper
+
+Registers the FastMCP router at /mcp before the SPA catch-all so MCP
+JSON-RPC POSTs reach the tool handlers. Starts mark_timed_out_jobs_loop
+in the lifespan and cancels it cleanly on shutdown alongside the
+existing chat and export workers.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+## Phase 5: Integration Tests
+
+### Task 11: End-to-end MCP protocol tests
+
+**Files:**
+- Create: `tests/integration/test_mcp_endpoint.py`
+
+- [ ] **Step 1: Write the integration tests**
+
+Create `tests/integration/test_mcp_endpoint.py`:
+
+```python
+"""End-to-end integration tests for the /mcp endpoint.
+
+Uses FastAPI TestClient against the full app. LLM generation and
+Databricks identity client are mocked; DB layer uses the in-memory
+SQLite test harness configured in tests/conftest.py.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+
+MCP_PATH = "/mcp"
+
+
+def _jsonrpc(method: str, params: dict | None = None, rid: int = 1) -> dict:
+    body: dict = {"jsonrpc": "2.0", "id": rid, "method": method}
+    if params is not None:
+        body["params"] = params
+    return body
+
+
+def _init_payload() -> dict:
+    return _jsonrpc(
+        "initialize",
+        {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "integration-test", "version": "0.0.0"},
+        },
+    )
+
+
+@pytest.fixture
+def mock_identity_client():
+    """Patch get_or_create_user_client to return a fake user client."""
+    client = MagicMock()
+    me = MagicMock()
+    me.id = "user-alice"
+    me.user_name = "alice@example.com"
+    client.current_user.me.return_value = me
+
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=client,
+    ):
+        yield client
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_initialize_returns_session_id(client, mock_identity_client):
+    resp = client.post(
+        MCP_PATH,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer fake-tok",
+        },
+        json=_init_payload(),
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("mcp-session-id")
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert "result" in body
+
+
+def test_tools_list_returns_four_tools(client, mock_identity_client):
+    # initialize first to get session id
+    init = client.post(
+        MCP_PATH,
+        headers={"Authorization": "Bearer fake-tok", "Content-Type": "application/json"},
+        json=_init_payload(),
+    )
+    session_id = init.headers["mcp-session-id"]
+
+    resp = client.post(
+        MCP_PATH,
+        headers={
+            "Authorization": "Bearer fake-tok",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
+        json=_jsonrpc("tools/list"),
+    )
+    body = resp.json()
+    tool_names = {t["name"] for t in body["result"]["tools"]}
+    assert tool_names == {"create_deck", "get_deck_status", "edit_deck", "get_deck"}
+
+
+def test_create_deck_returns_pending(client, mock_identity_client):
+    init = client.post(
+        MCP_PATH,
+        headers={"Authorization": "Bearer fake-tok", "Content-Type": "application/json"},
+        json=_init_payload(),
+    )
+    session_id = init.headers["mcp-session-id"]
+
+    with patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job", return_value="req-int-1"):
+        sm = MagicMock()
+        sm.create_session.return_value = {"session_id": "sess-int-1"}
+        get_sm.return_value = sm
+
+        resp = client.post(
+            MCP_PATH,
+            headers={
+                "Authorization": "Bearer fake-tok",
+                "Content-Type": "application/json",
+                "mcp-session-id": session_id,
+            },
+            json=_jsonrpc(
+                "tools/call",
+                {
+                    "name": "create_deck",
+                    "arguments": {"prompt": "integration test deck"},
+                },
+            ),
+        )
+
+    body = resp.json()
+    content = body["result"]["content"]
+    # FastMCP serializes tool return dicts as text content by default
+    text = content[0]["text"] if isinstance(content, list) else content
+    parsed = json.loads(text) if isinstance(text, str) else text
+    assert parsed["session_id"] == "sess-int-1"
+    assert parsed["request_id"] == "req-int-1"
+    assert parsed["status"] == "pending"
+
+
+def test_rejects_request_without_auth(client):
+    resp = client.post(
+        MCP_PATH,
+        headers={"Content-Type": "application/json"},
+        json=_init_payload(),
+    )
+    # Depending on FastMCP's error-envelope behavior, this is either an HTTP 401 or
+    # a 200 with a JSON-RPC error. Both are acceptable v1 outcomes; assert one of them.
+    if resp.status_code == 401:
+        return
+    body = resp.json()
+    assert "error" in body or (
+        "result" in body and body["result"].get("isError")
+    )
+
+
+def test_permission_denied_on_other_users_deck(client, mock_identity_client):
+    init = client.post(
+        MCP_PATH,
+        headers={"Authorization": "Bearer fake-tok", "Content-Type": "application/json"},
+        json=_init_payload(),
+    )
+    session_id = init.headers["mcp-session-id"]
+
+    with patch("src.api.mcp_server.permission_service.can_view_deck", return_value=False):
+        resp = client.post(
+            MCP_PATH,
+            headers={
+                "Authorization": "Bearer fake-tok",
+                "Content-Type": "application/json",
+                "mcp-session-id": session_id,
+            },
+            json=_jsonrpc(
+                "tools/call",
+                {
+                    "name": "get_deck",
+                    "arguments": {"session_id": "someone-elses-deck"},
+                },
+            ),
+        )
+
+    body = resp.json()
+    # Tool-level error is returned with isError: true
+    result = body.get("result") or {}
+    is_error = result.get("isError") is True
+    content = result.get("content") or []
+    text = content[0]["text"] if content else ""
+    assert is_error or "permission" in text.lower()
+
+
+def test_create_deck_forwards_correlation_id(client, mock_identity_client):
+    init = client.post(
+        MCP_PATH,
+        headers={"Authorization": "Bearer fake-tok", "Content-Type": "application/json"},
+        json=_init_payload(),
+    )
+    session_id = init.headers["mcp-session-id"]
+
+    with patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job", return_value="req-corr") as enqueue:
+        sm = MagicMock()
+        sm.create_session.return_value = {"session_id": "sess-corr"}
+        get_sm.return_value = sm
+
+        client.post(
+            MCP_PATH,
+            headers={
+                "Authorization": "Bearer fake-tok",
+                "Content-Type": "application/json",
+                "mcp-session-id": session_id,
+            },
+            json=_jsonrpc(
+                "tools/call",
+                {
+                    "name": "create_deck",
+                    "arguments": {
+                        "prompt": "x",
+                        "correlation_id": "caller-42",
+                    },
+                },
+            ),
+        )
+
+    kwargs = enqueue.call_args.kwargs
+    assert kwargs["correlation_id"] == "caller-42"
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+pytest tests/integration/test_mcp_endpoint.py -v
+```
+
+Expected: all 6 tests pass.
+
+If any test fails because FastMCP's content serialization format differs from the expected `content[0]["text"]` JSON-of-dict pattern, adjust the test's parsing — FastMCP newer versions may return structured content blocks directly.
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+```bash
+pytest tests/ -v --ignore=tests/integration/test_client_integration.py
+```
+
+(Exclude the `test_client_integration.py` file if it requires a live Databricks connection — it's marked with `@pytest.mark.live` and is excluded in CI.)
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_mcp_endpoint.py
+git commit -m "$(cat <<'EOF'
+test(mcp): add end-to-end integration tests for the /mcp endpoint
+
+Covers: initialize handshake, tools/list returns expected four tools,
+create_deck end-to-end with mocked services, auth rejection,
+permission denial on other-user decks, and correlation_id propagation.
+LLM and Databricks identity client are mocked; DB uses the existing
+test harness.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+## Phase 6: Smoke Tests, Documentation, README Breadcrumb
+
+### Task 12: Create post-deploy smoke test script
+
+**Files:**
+- Create: `scripts/mcp_smoke/mcp_smoke_httpx.py`
+- Create: `scripts/mcp_smoke/README.md`
+
+- [ ] **Step 1: Create the smoke script**
+
+Create `scripts/mcp_smoke/mcp_smoke_httpx.py`:
+
+```python
+"""Post-deploy smoke test for the tellr MCP endpoint.
+
+Runs a full create_deck -> poll -> ready flow against a deployed tellr
+Databricks App using a real user token. Prints each step's outcome.
+
+Usage:
+    export TELLR_URL=https://<your-tellr-app-url>
+    export DATABRICKS_TOKEN=<your-databricks-token>
+    python scripts/mcp_smoke/mcp_smoke_httpx.py
+
+Exits 0 on success, non-zero with an error message on failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+import httpx
+
+
+def main() -> int:
+    tellr_url = os.environ.get("TELLR_URL", "").rstrip("/")
+    token = os.environ.get("DATABRICKS_TOKEN", "")
+
+    if not tellr_url:
+        print("ERROR: TELLR_URL is required", file=sys.stderr)
+        return 2
+    if not token:
+        print("ERROR: DATABRICKS_TOKEN is required", file=sys.stderr)
+        return 2
+
+    mcp_url = f"{tellr_url}/mcp"
+    headers_base = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    print(f"Smoke-testing {mcp_url}")
+
+    # Step 1: initialize
+    print("Step 1: initialize")
+    init_body = {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "tellr-smoke", "version": "0.0.1"},
+        },
+    }
+    resp = httpx.post(mcp_url, headers=headers_base, json=init_body, timeout=30)
+    resp.raise_for_status()
+    session_id = resp.headers.get("mcp-session-id")
+    if not session_id:
+        print(f"ERROR: no mcp-session-id in response headers: {dict(resp.headers)}")
+        return 1
+    print(f"  mcp-session-id: {session_id}")
+
+    mcp_headers = {**headers_base, "mcp-session-id": session_id}
+
+    # Step 2: tools/list
+    print("Step 2: tools/list")
+    resp = httpx.post(
+        mcp_url,
+        headers=mcp_headers,
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    tool_names = [t["name"] for t in resp.json()["result"]["tools"]]
+    print(f"  tools: {tool_names}")
+    expected = {"create_deck", "get_deck_status", "edit_deck", "get_deck"}
+    missing = expected - set(tool_names)
+    if missing:
+        print(f"ERROR: missing tools {missing}")
+        return 1
+
+    # Step 3: create_deck
+    print("Step 3: create_deck")
+    resp = httpx.post(
+        mcp_url,
+        headers=mcp_headers,
+        json={
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {
+                "name": "create_deck",
+                "arguments": {"prompt": "a three-slide smoke-test deck about the weather"},
+            },
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+    content = resp.json()["result"]["content"]
+    payload = json.loads(content[0]["text"]) if content else {}
+    session_id_deck = payload["session_id"]
+    request_id = payload["request_id"]
+    print(f"  session_id={session_id_deck}, request_id={request_id}, status={payload['status']}")
+
+    # Step 4: poll get_deck_status
+    print("Step 4: poll get_deck_status (up to 10 minutes)")
+    start = time.time()
+    last_status = None
+    while time.time() - start < 600:
+        resp = httpx.post(
+            mcp_url,
+            headers=mcp_headers,
+            json={
+                "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                "params": {
+                    "name": "get_deck_status",
+                    "arguments": {"session_id": session_id_deck, "request_id": request_id},
+                },
+            },
+            timeout=60,
+        )
+        resp.raise_for_status()
+        content = resp.json()["result"]["content"]
+        payload = json.loads(content[0]["text"]) if content else {}
+        status = payload.get("status")
+        if status != last_status:
+            print(f"  status={status}  (elapsed={int(time.time()-start)}s)")
+            last_status = status
+
+        if status == "ready":
+            print(f"  slide_count={payload.get('slide_count')}")
+            print(f"  deck_url={payload.get('deck_url')}")
+            assert "html_document" in payload and payload["html_document"].lower().startswith("<!doctype")
+            print("SUCCESS")
+            return 0
+        if status == "failed":
+            print(f"FAILED: {payload.get('error')}")
+            return 1
+
+        time.sleep(2)
+
+    print("TIMEOUT: generation did not complete within 10 minutes")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Create the smoke README**
+
+Create `scripts/mcp_smoke/README.md`:
+
+```markdown
+# MCP Smoke Tests
+
+Manual verification scripts for the tellr MCP endpoint after deploy.
+These are NOT run in CI — they require a live deployed tellr app and a
+real Databricks user token.
+
+## `mcp_smoke_httpx.py`
+
+Runs the full `initialize → tools/list → create_deck → poll → ready`
+flow using raw `httpx`. Prints each step's outcome and exits 0 on
+success.
+
+### Running
+
+```bash
+export TELLR_URL=https://<your-tellr-app-url>
+export DATABRICKS_TOKEN=<a-databricks-user-token>
+python scripts/mcp_smoke/mcp_smoke_httpx.py
+```
+
+Expected output ends with:
+
+```
+Step 4: poll get_deck_status (up to 10 minutes)
+  status=running  (elapsed=2s)
+  status=ready  (elapsed=47s)
+  slide_count=3
+  deck_url=https://<your-tellr-app-url>/sessions/<id>/edit
+SUCCESS
+```
+
+### Notes
+
+- The script polls every 2 seconds with a 10-minute hard timeout
+  that matches the server-side `JOB_HARD_TIMEOUT_SECONDS`.
+- If `initialize` returns no `mcp-session-id` header, the app
+  deployment did not pick up the MCP router — redeploy and check
+  `/api/health` is healthy.
+- If auth fails with the token, try generating a fresh PAT or using
+  `databricks auth login` output.
+```
+
+- [ ] **Step 3: Run the script against local dev (optional but recommended)**
+
+Start the local app (from Task 10), then:
+
+```bash
+export TELLR_URL=http://localhost:8000
+export DATABRICKS_TOKEN=<local-dev-token-or-mock>
+python scripts/mcp_smoke/mcp_smoke_httpx.py
+```
+
+If this requires real Databricks auth that local dev can't provide, skip and rely on unit+integration tests — the script's true purpose is post-deploy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/mcp_smoke/
+git commit -m "$(cat <<'EOF'
+test(mcp): add post-deploy smoke script
+
+Adds scripts/mcp_smoke/mcp_smoke_httpx.py for manual verification
+against a deployed tellr app. Runs the full create → poll → ready
+flow and exits non-zero on any failure. Not part of CI.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 13: Write the caller-facing technical documentation
+
+**Files:**
+- Create: `docs/technical/mcp-server.md`
+
+- [ ] **Step 1: Read `docs/technical/technical-doc-template.md` in full** to match the project's doc-template structure exactly. Do not deviate from the template's top-level headings or ordering.
+
+- [ ] **Step 2: Read 2-3 existing tech docs for tone/length reference**, e.g. `docs/technical/google-slides-integration.md` and `docs/technical/real-time-streaming.md`. Match the depth (schemas, code examples, troubleshooting) without copying their structure.
+
+- [ ] **Step 3: Write the tech doc**
+
+Create `docs/technical/mcp-server.md`. Follow the template from Step 1. Content scope:
+
+- **Overview** — what the MCP server is, when to use it, how it relates to the tellr browser UI.
+- **Prerequisites** — deployed tellr app URL, Databricks user token, MCP-compatible client (or raw HTTP).
+- **Endpoint & protocol** — `https://<your-tellr-app-url>/mcp`, Streamable HTTP MCP rev 2025-03-26, JSON-RPC 2.0. Include the "how to find your tellr app URL" guidance (Databricks Apps UI or CLI: `databricks apps get <app-name> --output json`).
+- **Authentication** — the dual-token model in plain prose, with three caller recipes:
+  1. **In-workspace Databricks App** — pseudocode showing how the caller's backend extracts its own `x-forwarded-access-token` and forwards it as `Authorization: Bearer` on the outbound call to tellr. Include the "deliberately unsupported: using your SP token to call tellr" warning.
+  2. **External MCP client (Claude Code, Claude Desktop, Cursor, etc.)** — `mcp_servers.json` snippet with `Authorization: Bearer ${DATABRICKS_TOKEN}` header.
+  3. **Direct HTTP** — `httpx` example mirroring the smoke script.
+- **Tool catalog** — one subsection per tool (`create_deck`, `get_deck_status`, `edit_deck`, `get_deck`):
+  - Description
+  - Input schema (table with field / type / required / description)
+  - Output schema (JSON example)
+  - Example request payload
+  - Example response payload
+  - Common error cases and what they mean
+- **Client recipes** — full, copy-pasteable:
+  - Python `httpx` — complete `create → poll → ready` script (same as `mcp_smoke_httpx.py` but standalone)
+  - Claude Code / Vibe `mcp_servers.json` snippet
+  - Databricks App backend pseudocode for OBO forwarding
+- **Rendering recipes**:
+  - Minimal: `<iframe srcdoc="{html_document}">` with an HTML-escaping note
+  - Custom: iterate `deck.slides` with a short React/TypeScript example rendering each slide
+  - Air-gapped: overriding the default Chart.js CDN (mention `to_html_document(chart_js_cdn=…)` isn't exposed over MCP in v1; if needed, serve the `html_document` through a CDN-rewriting proxy on the caller side)
+- **Integration best practices** (section inside the same doc):
+  - Polling cadence: 1–2s with backoff; do not poll faster than 500ms.
+  - Error retry: respect `retry_after_seconds` on rate-limit responses.
+  - Always forward the end-user's OBO token; never call with an SP token if the deck should surface to a user.
+  - Use `correlation_id` on every call for cross-system trace correlation.
+  - Render `html_document` for single-pane preview; iterate `deck.slides` for custom grids.
+  - Hand-off-to-tellr vs. render-in-app: use `deck_url` when users need full editor features (presentation mode, Google Slides export, Monaco HTML editing, save points); render HTML locally for passive display or custom editing UIs.
+- **Troubleshooting**:
+  - 401 with a valid token → check proxy header forwarding
+  - `status: running` forever → check server logs; verify 10-minute timeout sweeper is active
+  - Deck doesn't appear in my tellr UI → check that the OBO token forwarded actually resolves to the user who's browsing tellr
+  - `isError: true` with "permission" → caller identity differs from deck's `created_by`
+  - Chart.js fails to load in an air-gapped environment → serve the `html_document` through a proxy that rewrites the Chart.js CDN URL
+- **Versioning & changelog** — current version (match tellr's `0.3.0`), note that v1.1 will add exports / structural edit tools / tool configurability; include a link back to the spec for deferred items.
+- **Links** — back to the design spec at `docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md`.
+
+Use `<your-tellr-app-url>` as the placeholder throughout. Do NOT bake any specific workspace or deployment URL into this file.
+
+- [ ] **Step 4: Verify the doc renders cleanly**
+
+```bash
+# Ensure no broken internal links and markdown renders OK.
+# If the project has a markdown linter (e.g., markdownlint), run it:
+markdownlint docs/technical/mcp-server.md || true
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/technical/mcp-server.md
+git commit -m "$(cat <<'EOF'
+docs(mcp): add caller-facing technical reference for MCP endpoint
+
+Adds the integration guide for external teams building Databricks Apps
+or agent tools that want to call tellr via MCP. Covers auth setup,
+tool catalog with schemas, Python and Claude Code client recipes,
+rendering recipes (iframe srcdoc, custom slide grid), integration
+best practices, and troubleshooting. Uses <your-tellr-app-url>
+placeholder throughout.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 14: Add README breadcrumb
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read current `README.md`** to find the appropriate place for the breadcrumb (likely near the "Documentation" section that already links to other `docs/technical/` pages).
+
+- [ ] **Step 2: Add the breadcrumb**
+
+In `README.md`'s "Technical Docs" table (around lines 123-129), add one row:
+
+```markdown
+| [MCP Server](docs/technical/mcp-server.md) | Call tellr programmatically from other Databricks Apps or MCP agent tools |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs: add README breadcrumb to MCP server tech doc
+
+Lists the new MCP integration guide in the Technical Docs table so
+developers landing on the repo's README can find the caller-facing
+reference without searching.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+### Task 15: Final verification pass
+
+**Files:** (no changes)
+
+- [ ] **Step 1: Run the full unit test suite**
+
+```bash
+pytest tests/unit/ -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run the integration test suite (excluding live tests)**
+
+```bash
+pytest tests/integration/ -v -m "not live"
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Verify git log shows all task commits cleanly**
+
+```bash
+git log --oneline -20
+```
+
+Expected: commits for tasks 1–14 all present, in order, with conventional-commit prefixes (`feat(mcp):`, `test(mcp):`, `docs(mcp):`, etc.).
+
+- [ ] **Step 4: Deploy to dev workspace (user action)**
+
+User step: deploy via `tellr.update(...)` from a Databricks notebook or the Apps UI. Smoke-test with `scripts/mcp_smoke/mcp_smoke_httpx.py`.
+
+- [ ] **Step 5: Resolve the three open verification items from the spec**
+
+From the spec's "Open Verification Items" section, run real smoke tests (or manual curl) against the dev deployment to confirm:
+
+1. Databricks Apps proxy forwards `Authorization: Bearer` headers unmodified (or adjust auth helper if it strips them)
+2. App-to-app calls: identify whose identity lands in `x-forwarded-access-token` for in-workspace app-to-app traffic
+3. `current_user.me()` latency under realistic load
+
+Record findings in a follow-up entry at the bottom of the spec, or as an issue to close before GA.
+
+- [ ] **Step 6: Deploy to production (user action)**
+
+User step: `tellr.update(...)` against the production workspace. Smoke-test again.
+
+No commit for this task — it's verification only.
+
+---
+
+## Summary of task structure
+
+| # | Task | Files | Test coverage |
+|---|---|---|---|
+| 1 | Add `mcp` SDK dependency | `pyproject.toml` | Import verification |
+| 2 | `SlideDeck.to_html_document()` | `slide_deck.py` + unit tests | 9 tests |
+| 3 | 10-min timeout sweeper | `job_queue.py` + unit tests | 6 tests |
+| 4 | Dual-token auth helper | `mcp_auth.py` + unit tests | 9 tests |
+| 5 | `mcp_server.py` skeleton | `mcp_server.py` | Import smoke |
+| 6 | `create_deck` tool | `mcp_server.py` + unit tests | 4 tests |
+| 7 | `get_deck_status` tool | `mcp_server.py` + unit tests | 4 tests |
+| 8 | `edit_deck` tool | `mcp_server.py` + unit tests | 4 tests |
+| 9 | `get_deck` tool | `mcp_server.py` + unit tests | 2 tests |
+| 10 | Wire MCP into `main.py` | `main.py` | Local smoke test |
+| 11 | Integration tests | `tests/integration/test_mcp_endpoint.py` | 6 tests |
+| 12 | Post-deploy smoke script | `scripts/mcp_smoke/` | Manual verification |
+| 13 | Technical documentation | `docs/technical/mcp-server.md` | N/A |
+| 14 | README breadcrumb | `README.md` | N/A |
+| 15 | Final verification | — | All tests + deploy smoke |
+
+Total: ~44 new unit tests, 6 integration tests, 1 smoke script, 1 technical doc, 1 README update, ~4 existing files modified, ~6 new files created.
+
+Each task ships independently via its own commit. Tasks 1–9 can be executed in order without any deploy. Task 10 enables local testing. Tasks 11–15 harden and document.

--- a/docs/superpowers/plans/2026-04-23-system-default-slide-style-admin.md
+++ b/docs/superpowers/plans/2026-04-23-system-default-slide-style-admin.md
@@ -286,10 +286,19 @@ After the component work lands (between the last TDD cycle and the manual verifi
 
 Files to revisit:
 
+**Technical docs:**
+
 - **`docs/technical/mcp-server.md`** — The `slide_style_id` row in the `create_deck` input schema currently says "Omit for default." Clarify: "Omit to use the system default (settable at `/admin`); MCP cannot see per-user localStorage overrides."
 - **`docs/technical/mcp-integration-guide.md`** — Cross-check any mention of slide style defaults and align with the MCP server doc's updated wording so they don't drift.
 - **`docs/technical/frontend-overview.md`** — Add a short note that `/admin` now exposes a "Slide Style" tab for setting the system default, and briefly describe the two-tier resolution (localStorage → DB `is_default` → `is_system` fallback) so a future reader can understand why the frontend helper `resolveDefaultStyleId()` has three tiers.
 - **`docs/technical/database-configuration.md`** — If it references `slide_style_library.is_default`, confirm the description matches the new behavior (one row system-wide, settable via `/admin`).
+
+**User-facing docs:**
+
+- **`docs/user-guide/05-creating-custom-styles.md`** — The primary place users learn about slide styles. Add a short section (one or two paragraphs) covering: (a) there is a system-wide "corporate" default that applies to every new deck out of the box, settable only at `/admin`; (b) the existing "Set as default" button on their own slide style list continues to let them set a personal default that overrides the corporate one for their browser only. Frame it the way the design's Google Slides analogy does — "new decks inherit the corporate look unless you've chosen otherwise for yourself."
+- **`docs/user-guide/02-creating-profiles.md`** — If it describes slide style selection flow in terms that imply "the default is whatever your last choice was," update to reference the two-tier model briefly and cross-link to 05-creating-custom-styles.
+- **`docs/user-guide/01-generating-slides.md`** — Scan for any mention of default styling and align if needed; likely nothing to change.
+- **`docs/user-guide/README.md`** — If it has a table of contents entry or section overview touching styles, ensure nothing there conflicts with the new model.
 
 What to write: one or two sentences per file. The goal is to leave no stale descriptions claiming there's no UI surface for changing the DB default, which is where the docs stand today. Do NOT rewrite these docs wholesale — scope is "fix the specific lines that would mislead a reader after this change ships."
 

--- a/docs/superpowers/plans/2026-04-23-system-default-slide-style-admin.md
+++ b/docs/superpowers/plans/2026-04-23-system-default-slide-style-admin.md
@@ -280,6 +280,21 @@ cd frontend && npx playwright test
 
 ---
 
+## Documentation updates
+
+After the component work lands (between the last TDD cycle and the manual verification), walk through the docs and align wording with the new two-tier model. Keep the edits minimal — no new pages, just a few targeted tweaks.
+
+Files to revisit:
+
+- **`docs/technical/mcp-server.md`** — The `slide_style_id` row in the `create_deck` input schema currently says "Omit for default." Clarify: "Omit to use the system default (settable at `/admin`); MCP cannot see per-user localStorage overrides."
+- **`docs/technical/mcp-integration-guide.md`** — Cross-check any mention of slide style defaults and align with the MCP server doc's updated wording so they don't drift.
+- **`docs/technical/frontend-overview.md`** — Add a short note that `/admin` now exposes a "Slide Style" tab for setting the system default, and briefly describe the two-tier resolution (localStorage → DB `is_default` → `is_system` fallback) so a future reader can understand why the frontend helper `resolveDefaultStyleId()` has three tiers.
+- **`docs/technical/database-configuration.md`** — If it references `slide_style_library.is_default`, confirm the description matches the new behavior (one row system-wide, settable via `/admin`).
+
+What to write: one or two sentences per file. The goal is to leave no stale descriptions claiming there's no UI surface for changing the DB default, which is where the docs stand today. Do NOT rewrite these docs wholesale — scope is "fix the specific lines that would mislead a reader after this change ships."
+
+Commit the docs update as its own commit (not bundled with component code) so a future `git log` reader can see "docs align with new admin affordance" as a discrete step.
+
 ## Post-Implementation Manual Verification (after deploy)
 
 Per spec section 9:
@@ -295,6 +310,7 @@ One commit per TDD cycle is ideal but not mandatory — two commits is acceptabl
 
 - Commit A — fixture + tab wiring (Cycles 1 + 2 + test-data update).
 - Commit B — everything else (Cycles 3-7 + API method + component).
+- Commit C — docs updates (see "Documentation updates" section).
 
 Plus a final commit for the manual verification notes if any surprises emerge.
 

--- a/docs/superpowers/plans/2026-04-23-system-default-slide-style-admin.md
+++ b/docs/superpowers/plans/2026-04-23-system-default-slide-style-admin.md
@@ -1,0 +1,314 @@
+# Implementation Plan — System Default Slide Style Admin Affordance
+
+**Date:** 2026-04-23
+**Spec:** [2026-04-23-system-default-slide-style-admin.md](../specs/2026-04-23-system-default-slide-style-admin.md)
+**Method:** Test-Driven Development (Red → Green → Refactor)
+**Test framework:** Playwright E2E (the only frontend test tooling in this repo — no unit-test framework present).
+
+## Summary
+
+Add a new "Slide Style" tab to the existing `/admin` page that lets a caller pick which row in `slide_style_library` is the system default. Reuses the existing `POST /api/settings/slide-styles/{id}/set-default` endpoint. No backend changes. No MCP changes. Fully additive.
+
+Total code footprint (≈ spec estimates):
+
+- `frontend/src/api/config.ts` — one new client method (~5 LOC).
+- `frontend/src/components/Admin/AdminSlideStyleDefault.tsx` — new file (~100 LOC).
+- `frontend/src/components/Admin/AdminPage.tsx` — third tab (~15 LOC delta).
+- `frontend/tests/fixtures/mocks.ts` — add `is_default` fields to existing `mockSlideStyles` (~3 LOC delta).
+- `frontend/tests/e2e/admin-page.spec.ts` — new test cases (~80 LOC delta).
+
+## Prerequisites
+
+Before starting:
+
+1. Confirm the existing `/admin` e2e tests still pass on the branch base:
+   ```bash
+   cd frontend && npx playwright test tests/e2e/admin-page.spec.ts
+   ```
+2. Confirm `is_default` is already on the `SlideStyle` TypeScript type (`frontend/src/api/config.ts`). If not, add it before the TDD cycles — it's a pure type addition, no runtime behavior.
+3. Familiarise yourself with the patterns used by the existing "Feedback" and "Google Slides" tabs in `AdminPage.tsx`. The new tab must follow the same shape.
+
+## Test data update (before Cycle 1)
+
+The existing `mockSlideStyles` fixture in `frontend/tests/fixtures/mocks.ts` does not carry `is_default` fields. Add them so the new assertions can target specific rows:
+
+- Style `id: 1` ("System Default"): `is_default: true`
+- Style `id: 2` ("Corporate Theme"): `is_default: false`
+- Style `id: 3` (inactive example, if present): `is_default: false`
+
+This is a fixture-only change. No existing test asserts on `is_default`, so it cannot regress prior tests. Commit before the first TDD cycle so each cycle starts from a consistent state.
+
+## TDD Cycles
+
+Each cycle follows: **RED** (write test, run, watch fail) → **GREEN** (minimal code, run, watch pass) → **REFACTOR** (tidy only if needed, stay green).
+
+Cycles are ordered to minimise rework — each builds on the previous and each test should fail *only* for the behavior it exercises, not because of missing plumbing from a later cycle.
+
+---
+
+### Cycle 1 — "Slide Style" tab appears on the admin page
+
+**RED.** In `tests/e2e/admin-page.spec.ts`, add:
+
+```ts
+test('renders Slide Style tab alongside Feedback and Google Slides', async ({ page }) => {
+  await page.goto('/admin');
+  await expect(page.getByRole('tab', { name: 'Slide Style' })).toBeVisible();
+});
+```
+
+Run: `npx playwright test tests/e2e/admin-page.spec.ts -g "Slide Style tab"` — must fail ("element not found").
+
+**GREEN.** In `AdminPage.tsx`:
+
+1. Extend the `TabId` type to include `'slide_style'`.
+2. Add a third `<button role="tab">` with text "Slide Style" and the matching `onClick`/`aria-selected` pattern.
+3. Add a third `<div role="tabpanel">` with `hidden={activeTab !== 'slide_style'}` containing a placeholder (e.g., `<div>TBD</div>`) — just enough to make the test pass. Real content comes in Cycle 2.
+
+Run the test — must pass. Re-run the whole `admin-page.spec.ts` file — all four tests must pass.
+
+**REFACTOR.** None needed yet.
+
+---
+
+### Cycle 2 — Slide Style tab renders the list of styles
+
+**RED.** Add:
+
+```ts
+test('Slide Style tab renders each slide style name', async ({ page }) => {
+  await page.goto('/admin');
+  await page.getByRole('tab', { name: 'Slide Style' }).click();
+  await expect(page.getByText('System Default')).toBeVisible();
+  await expect(page.getByText('Corporate Theme')).toBeVisible();
+});
+```
+
+Run — must fail (placeholder doesn't render names).
+
+**GREEN.**
+
+1. Create `frontend/src/components/Admin/AdminSlideStyleDefault.tsx`:
+   - `useState` for `styles: SlideStyle[]` and `loading: boolean`.
+   - `useEffect` on mount: `configApi.listSlideStyles()` → `setStyles(resp.styles)` → `setLoading(false)`.
+   - Render: loading spinner while `loading`; otherwise a `<ul>` of style names (minimum markup to make the assertion pass — one `<li>` per row rendering `style.name`).
+2. In `AdminPage.tsx`, replace the `<div>TBD</div>` placeholder with `<AdminSlideStyleDefault />`.
+
+Run — must pass.
+
+**REFACTOR.** If the markup grew verbose, extract a tiny `StyleRow` sub-component; otherwise leave it.
+
+---
+
+### Cycle 3 — "System default" badge on the `is_default=true` row
+
+**RED.** Add:
+
+```ts
+test('Slide Style tab marks the is_default row with a "System default" badge', async ({ page }) => {
+  await page.goto('/admin');
+  await page.getByRole('tab', { name: 'Slide Style' }).click();
+  // Row 1 ("System Default") is the is_default=true fixture row.
+  const row = page.getByRole('listitem').filter({ hasText: 'System Default' });
+  await expect(row.getByText('System default')).toBeVisible();
+  // Row 2 ("Corporate Theme") must not have the badge.
+  const otherRow = page.getByRole('listitem').filter({ hasText: 'Corporate Theme' });
+  await expect(otherRow.getByText('System default')).toHaveCount(0);
+});
+```
+
+Run — must fail (no badge rendered yet).
+
+**GREEN.** In `AdminSlideStyleDefault.tsx`, add a conditional `<span className="badge">System default</span>` inside the row when `style.is_default === true`. Use whatever badge styling the codebase already uses elsewhere (search for an existing `Badge` component — if none, plain `<span>` + tailwind is fine).
+
+Run — must pass.
+
+**REFACTOR.** None expected.
+
+---
+
+### Cycle 4 — "Set as system default" button on non-default active rows
+
+**RED.** Add:
+
+```ts
+test('Slide Style tab shows "Set as system default" on non-default active rows', async ({ page }) => {
+  await page.goto('/admin');
+  await page.getByRole('tab', { name: 'Slide Style' }).click();
+  const defaultRow = page.getByRole('listitem').filter({ hasText: 'System Default' });
+  const otherRow = page.getByRole('listitem').filter({ hasText: 'Corporate Theme' });
+  // The default row should not offer the action.
+  await expect(defaultRow.getByRole('button', { name: 'Set as system default' })).toHaveCount(0);
+  // Another active, non-default row should.
+  await expect(otherRow.getByRole('button', { name: 'Set as system default' })).toBeVisible();
+});
+```
+
+Run — must fail (no button rendered yet).
+
+**GREEN.** Extend the row rendering: when `style.is_active && !style.is_default`, render a `<button>` labelled "Set as system default". No click handler yet — just the markup. Run — must pass.
+
+**REFACTOR.** None.
+
+---
+
+### Cycle 5 — Clicking the button calls the API and updates the badge
+
+**RED.** Add:
+
+```ts
+test('Clicking Set as system default calls the endpoint and updates the badge', async ({ page }) => {
+  // Intercept the set-default endpoint. Record the URL that was hit.
+  let setDefaultUrl: string | null = null;
+  await page.route('**/api/settings/slide-styles/*/set-default', async (route, req) => {
+    setDefaultUrl = req.url();
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: 2, name: 'Corporate Theme', is_default: true }) });
+  });
+
+  // After the POST, the list refetch should return the new state.
+  // Update the list mock so the second call returns Corporate Theme as default.
+  let listCallCount = 0;
+  await page.route('**/api/settings/slide-styles', (route) => {
+    listCallCount += 1;
+    const styles = listCallCount === 1
+      ? mockSlideStyles.styles // initial: System Default is default
+      : mockSlideStyles.styles.map(s => ({ ...s, is_default: s.id === 2 }));
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ styles, total: styles.length }) });
+  });
+
+  await page.goto('/admin');
+  await page.getByRole('tab', { name: 'Slide Style' }).click();
+  const otherRow = page.getByRole('listitem').filter({ hasText: 'Corporate Theme' });
+  await otherRow.getByRole('button', { name: 'Set as system default' }).click();
+
+  // URL assertion — exact id is in the path.
+  expect(setDefaultUrl).toContain('/api/settings/slide-styles/2/set-default');
+  // Badge now on Corporate Theme.
+  await expect(otherRow.getByText('System default')).toBeVisible();
+  // Badge removed from System Default.
+  const oldRow = page.getByRole('listitem').filter({ hasText: 'System Default' });
+  await expect(oldRow.getByText('System default')).toHaveCount(0);
+});
+```
+
+Run — must fail (no click handler, API client method doesn't exist).
+
+**GREEN.**
+
+1. Add `setSlideStyleSystemDefault(id: number)` to `frontend/src/api/config.ts` — one method posting to `${API_BASE}/slide-styles/${id}/set-default` and returning the updated style. Match the style of the existing `setDefaultProfile` method.
+2. Wire the button's `onClick` in `AdminSlideStyleDefault.tsx`:
+   ```tsx
+   const handleSet = async (id: number) => {
+     setSaving(id);
+     try {
+       await configApi.setSlideStyleSystemDefault(id);
+       const resp = await configApi.listSlideStyles();
+       setStyles(resp.styles);
+     } catch (e) {
+       // Cycle 6 adds toast handling
+     } finally {
+       setSaving(null);
+     }
+   };
+   ```
+3. Add `saving: number | null` state so the button can be disabled while in-flight. Wire a `disabled={saving === style.id}` prop.
+
+Run — must pass.
+
+**REFACTOR.** If the inline-fetch-after-POST pattern feels clunky, consider making `setSlideStyleSystemDefault` return the list directly — but only if it keeps the test green with no change.
+
+---
+
+### Cycle 6 — Error toast on failure
+
+**RED.** Add:
+
+```ts
+test('Failed set-default call surfaces an error toast', async ({ page }) => {
+  await page.route('**/api/settings/slide-styles/*/set-default', (route) => {
+    route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ detail: 'boom' }) });
+  });
+  await page.goto('/admin');
+  await page.getByRole('tab', { name: 'Slide Style' }).click();
+  await page.getByRole('listitem').filter({ hasText: 'Corporate Theme' })
+    .getByRole('button', { name: 'Set as system default' }).click();
+  // The existing codebase uses a toast component; match the assertion to whatever
+  // data-testid or role the existing error toasts expose. Inspect one other admin
+  // error path (e.g. Google Slides credential upload) to confirm the selector.
+  await expect(page.getByText(/failed|error|boom/i)).toBeVisible();
+});
+```
+
+Run — must fail (no toast wiring).
+
+**GREEN.** In `AdminSlideStyleDefault.tsx`, pull in the toast utility the existing admin components use (search `components/Admin` or `contexts/ToastContext` for the pattern) and call `showToast(message, 'error')` in the `catch` branch of `handleSet`. Run — must pass.
+
+**REFACTOR.** None.
+
+---
+
+### Cycle 7 — Inactive rows do not offer the button
+
+**RED.** Ensure the `mockSlideStyles` fixture contains at least one `is_active: false` row (add one if necessary — this is a fixture tweak before the RED step). Then add:
+
+```ts
+test('Inactive slide styles do not show the Set as system default button', async ({ page }) => {
+  await page.goto('/admin');
+  await page.getByRole('tab', { name: 'Slide Style' }).click();
+  const inactiveRow = page.getByRole('listitem').filter({ hasText: '<name-of-inactive-fixture>' });
+  await expect(inactiveRow.getByRole('button', { name: 'Set as system default' })).toHaveCount(0);
+});
+```
+
+Run — must fail if the current condition only checks `!is_default` but not `is_active`. If it already correctly guards on `is_active` from Cycle 4, this test will pass on RED — in that case note it and collapse the cycle (write the test and verify it passes to prevent regression).
+
+**GREEN.** If the test failed, add the `is_active` guard to the button-render condition. Run — must pass.
+
+---
+
+### Final full-file run
+
+```bash
+cd frontend && npx playwright test tests/e2e/admin-page.spec.ts
+```
+
+All tests in the file must pass, including the pre-existing three. Also run the broader test suite once to ensure no cross-test pollution from the new mock routes:
+
+```bash
+cd frontend && npx playwright test
+```
+
+---
+
+## Post-Implementation Manual Verification (after deploy)
+
+Per spec section 9:
+
+1. Deploy tellr. Visit `/admin`, switch to "Slide Style" tab, click "Set as system default" on a chosen style. Confirm the badge moves.
+2. Open a private browser window (no localStorage), log in, click "New Deck". Confirm the deck uses the chosen style.
+3. Call the MCP `create_deck` with no `slide_style_id`. Confirm the returned deck uses the same style.
+4. In your normal browser (with a localStorage preference already set), confirm the personal preference still takes precedence for browser-initiated decks.
+
+## Git Strategy
+
+One commit per TDD cycle is ideal but not mandatory — two commits is acceptable:
+
+- Commit A — fixture + tab wiring (Cycles 1 + 2 + test-data update).
+- Commit B — everything else (Cycles 3-7 + API method + component).
+
+Plus a final commit for the manual verification notes if any surprises emerge.
+
+Push the branch; open a PR targeting `main` with the spec document linked in the description.
+
+## Rollback
+
+If the deploy goes sideways and the admin flow breaks, the change is purely additive — reverting the branch restores the previous behavior. The MCP `create_deck` fallback to `get_default_slide_style_id()` continues to read whatever DB row happens to be `is_default=True` either way.
+
+## Out of scope — do not do in this plan
+
+- No backend changes.
+- No changes to the user-facing slide style list (`SlideStyleList.tsx`).
+- No changes to MCP code.
+- No changes to profile or deck prompt default handling.
+- No server-side auth gating on the `set-default` endpoint.
+- No migration of existing `localStorage.userDefaultSlideStyleId` entries.

--- a/docs/superpowers/plans/2026-04-24-mcp-discoverability.md
+++ b/docs/superpowers/plans/2026-04-24-mcp-discoverability.md
@@ -1,0 +1,725 @@
+# MCP Discoverability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the already-written MCP technical docs reachable from inside tellr (new MCP tab on `/help`, Overview bullet + quick link) and from the public docs-site sidebar, so a user who doesn't already know MCP exists can discover it without touching the GitHub repo.
+
+**Architecture:** Purely additive frontend work plus two sidebar entries on the Docusaurus site. A new `MCPTab` component lives inside `HelpPage.tsx` following the existing single-file convention; it reads `window.location.origin` at render time to surface the user's actual MCP endpoint URL with a copy-to-clipboard button. All substantive setup content stays in the docs; the help surface is a discovery layer only.
+
+**Tech Stack:** React 19, TypeScript, Tailwind (in-app). Playwright E2E (only frontend test framework in this repo). Docusaurus (docs site).
+
+**Spec:** [`docs/superpowers/specs/2026-04-24-mcp-discoverability-design.md`](../specs/2026-04-24-mcp-discoverability-design.md)
+
+---
+
+## File Structure
+
+| File | Role | Size |
+|---|---|---|
+| `frontend/src/constants/docs.ts` | Add two new `DOCS_URLS` entries pointing at the deployed MCP tech docs. | ~4 LOC delta |
+| `frontend/src/components/Help/HelpPage.tsx` | Extend tab union with `'mcp'`, add `TabButton`, add `QuickLinkButton`, add one Overview bullet, define `MCPTab` in-file. | ~110 LOC delta |
+| `docs-site/sidebars.js` | Append two page slugs to the `technical` category's `items` array. | ~2 LOC delta |
+| `frontend/tests/e2e/help-ui.spec.ts` | New Playwright cases covering the MCP tab, Overview bullet, and Quick Link. | ~90 LOC delta |
+
+Total: ~210 LOC across four files, purely additive. No backend or MCP code changes.
+
+---
+
+## Prerequisites
+
+- [ ] **P1: Verify existing help-ui e2e tests pass on the branch base**
+
+Run:
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all existing `HelpNavigation`, `HelpTabs`, `QuickLinks` suites pass. If anything is red on a fresh checkout, stop and triage before continuing.
+
+- [ ] **P2: Confirm `DOCS_BASE` in `frontend/src/constants/docs.ts`**
+
+Read `frontend/src/constants/docs.ts`. Confirm `DOCS_BASE = 'https://robertwhiffin.github.io/ai-slide-generator/docs'` is present. If the base URL has moved, update the new entries in Task 1 to use the current base.
+
+- [ ] **P3: Confirm `ToastContext` is available from `HelpPage.tsx`'s import path**
+
+Run:
+
+```bash
+grep -l "useToast" frontend/src/contexts/ToastContext.tsx && echo ok
+```
+
+Expected: `ok`. The copy-button success/failure toast in Task 4 depends on `useToast` being the app-wide pattern; the Admin `AdminSlideStyleDefault` component imports it via `../../contexts/ToastContext` — the MCP tab uses the same path.
+
+---
+
+## Task 1: Add MCP doc URL constants
+
+**Files:**
+- Modify: `frontend/src/constants/docs.ts`
+
+- [ ] **Step 1: Open the file and add two entries**
+
+Edit `frontend/src/constants/docs.ts`. Inside the `DOCS_URLS` object, alongside the existing user-guide entries, add two technical-doc entries. Place them after `retrievingFeedback: userGuide('retrieving-feedback'),` so the block stays grouped.
+
+```ts
+const DOCS_BASE = 'https://robertwhiffin.github.io/ai-slide-generator/docs';
+
+const userGuide = (slug: string) => `${DOCS_BASE}/user-guide/${slug}`;
+
+export const DOCS_URLS = {
+  home: 'https://robertwhiffin.github.io/ai-slide-generator/',
+
+  generatingSlides: userGuide('generating-slides'),
+  creatingProfiles: userGuide('creating-profiles'),
+  advancedConfig: userGuide('advanced-configuration'),
+  customStyles: userGuide('creating-custom-styles'),
+  uploadingImages: userGuide('uploading-images'),
+  exportingGoogleSlides: userGuide('exporting-to-google-slides'),
+  retrievingFeedback: userGuide('retrieving-feedback'),
+
+  // MCP (technical reference + integration guide)
+  mcpServer: `${DOCS_BASE}/technical/mcp-server`,
+  mcpIntegrationGuide: `${DOCS_BASE}/technical/mcp-integration-guide`,
+
+  // … existing deep-link entries stay as-is …
+} as const;
+```
+
+(Keep every other existing key untouched — only the two new lines are added.)
+
+- [ ] **Step 2: Typecheck**
+
+Run:
+
+```bash
+cd frontend && npx tsc -b
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/constants/docs.ts
+git commit -m "feat(help): add DOCS_URLS entries for MCP server + integration guide"
+```
+
+---
+
+## Task 2: Scaffold the MCP tab
+
+Introduces the tab button and a placeholder panel so a Playwright assertion for "MCP tab in the tab strip" can turn green. Actual content lands in Task 3+.
+
+**Files:**
+- Modify: `frontend/src/components/Help/HelpPage.tsx`
+- Modify: `frontend/tests/e2e/help-ui.spec.ts`
+
+- [ ] **Step 1: Add the failing Playwright test**
+
+Append to `frontend/tests/e2e/help-ui.spec.ts`, inside the existing `HelpTabs` describe block (or alongside it — whichever keeps the file's shape):
+
+```ts
+test('MCP tab renders in the tab strip', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  await expect(page.getByRole('tab', { name: 'MCP' })).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run it; expect fail**
+
+Run:
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts -g "MCP tab renders in the tab strip" --reporter=list
+```
+
+Expected: 1 failed. Error mentions `getByRole('tab', { name: 'MCP' })` not found.
+
+- [ ] **Step 3: Extend the `HelpTab` union and wire the tab**
+
+Edit `frontend/src/components/Help/HelpPage.tsx`. Three changes in this file:
+
+**(a) Extend the `HelpTab` union:**
+
+```tsx
+type HelpTab = 'overview' | 'generator' | 'history' | 'profiles' | 'deck_prompts' | 'slide_styles' | 'images' | 'verification' | 'mcp';
+```
+
+**(b) Add the tab button.** Inside the tab-bar JSX (the `<div ... flex gap-2 mb-6 flex-wrap>`), after `<TabButton tab="images" label="Images" icon={FiImage} />`, add:
+
+```tsx
+<TabButton tab="mcp" label="MCP" icon={FiExternalLink} />
+```
+
+`FiExternalLink` is already imported at the top of the file — no new import needed.
+
+**(c) Mount the panel.** The existing content area uses `{activeTab === 'x' && <XTab />}` conditional renders inside a single `<div className="bg-white rounded-lg shadow-sm …">`. After the `{activeTab === 'images' && <ImagesTab />}` line, add one more conditional:
+
+```tsx
+{activeTab === 'mcp' && <MCPTab />}
+```
+
+**(d) Add the `MCPTab` stub** at the bottom of the file, alongside the other tab components. Content comes in Task 3; the stub only needs to render something so the tab is mountable:
+
+```tsx
+const MCPTab: React.FC = () => <div>TBD</div>;
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run:
+
+```bash
+cd frontend && npx tsc -b
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run the test; expect pass**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all existing help-ui tests + the new "MCP tab renders" test pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/Help/HelpPage.tsx frontend/tests/e2e/help-ui.spec.ts
+git commit -m "feat(help): scaffold MCP tab in help page"
+```
+
+---
+
+## Task 3: MCP tab — "What is MCP?" + "Who's this for?"
+
+**Files:**
+- Modify: `frontend/src/components/Help/HelpPage.tsx`
+- Modify: `frontend/tests/e2e/help-ui.spec.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+```ts
+test('MCP tab shows What is MCP and Who is this for sections', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  await page.getByRole('tab', { name: 'MCP' }).click();
+  await expect(page.getByRole('heading', { name: 'What is MCP?' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: "Who's this for?" })).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run it; expect fail**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts -g "What is MCP" --reporter=list
+```
+
+Expected: 1 failed (headings not found — placeholder renders TBD).
+
+- [ ] **Step 3: Replace the stub with the two sections**
+
+Replace the `MCPTab` stub in `HelpPage.tsx` with:
+
+```tsx
+const MCPTab: React.FC = () => (
+  <div className="space-y-6">
+    <section>
+      <h2 className="text-lg font-semibold text-gray-800 mb-3">What is MCP?</h2>
+      <p className="text-gray-600">
+        The Model Context Protocol (MCP) exposes tellr's deck generator as a
+        programmatic endpoint. Agents like Claude Code, Claude Desktop, and
+        Cursor — and any HTTP-speaking client — can create, edit, and
+        retrieve decks without the browser UI. Decks generated over MCP land
+        in your tellr history exactly as if you'd made them interactively.
+      </p>
+    </section>
+
+    <section>
+      <h2 className="text-lg font-semibold text-gray-800 mb-3">Who's this for?</h2>
+      <p className="text-gray-600">
+        Developers and power users who want to automate deck creation — a CI
+        job that drops a weekly briefing into Slack, an internal app that
+        turns a CRM record into a pitch deck, an agent runtime that calls
+        tellr as one tool in a wider workflow. If you only need interactive
+        generation, stay on the main page.
+      </p>
+    </section>
+  </div>
+);
+```
+
+- [ ] **Step 4: Run the test; expect pass**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all tests pass including the new one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Help/HelpPage.tsx frontend/tests/e2e/help-ui.spec.ts
+git commit -m "feat(help): add What is MCP + Who's this for sections"
+```
+
+---
+
+## Task 4: MCP tab — endpoint URL block + copy button
+
+**Files:**
+- Modify: `frontend/src/components/Help/HelpPage.tsx`
+- Modify: `frontend/tests/e2e/help-ui.spec.ts`
+
+- [ ] **Step 1: Add the failing tests**
+
+```ts
+test('MCP tab shows the live endpoint URL ending in /mcp/', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  await page.getByRole('tab', { name: 'MCP' }).click();
+
+  const endpointBlock = page.getByTestId('mcp-endpoint-url');
+  await expect(endpointBlock).toBeVisible();
+  await expect(endpointBlock).toContainText('/mcp/');
+  // Resolves against Playwright's baseURL — substring match keeps the test
+  // robust to baseURL changes.
+});
+
+test('MCP tab has a copy endpoint button', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  await page.getByRole('tab', { name: 'MCP' }).click();
+  await expect(
+    page.getByRole('button', { name: /copy endpoint/i }),
+  ).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run them; expect fail**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts -g "MCP tab (shows the live|has a copy)" --reporter=list
+```
+
+Expected: 2 failed (`mcp-endpoint-url` testid not found, copy button not found).
+
+- [ ] **Step 3: Import `useToast` at the top of `HelpPage.tsx`**
+
+Add near the other imports (alphabetically if the file sorts imports, otherwise at the end of the existing import block):
+
+```tsx
+import { useToast } from '../../contexts/ToastContext';
+```
+
+- [ ] **Step 4: Add a third section inside `MCPTab`**
+
+Change `MCPTab` so it calls `useToast` and renders the endpoint + copy button. Full new body:
+
+```tsx
+const MCPTab: React.FC = () => {
+  const { showToast } = useToast();
+  const mcpEndpoint = `${window.location.origin}/mcp/`;
+
+  const copyEndpoint = async () => {
+    try {
+      await navigator.clipboard.writeText(mcpEndpoint);
+      showToast('MCP endpoint copied to clipboard', 'success');
+    } catch {
+      showToast(
+        `Unable to copy automatically — endpoint is ${mcpEndpoint}`,
+        'error',
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">What is MCP?</h2>
+        <p className="text-gray-600">
+          The Model Context Protocol (MCP) exposes tellr's deck generator as a
+          programmatic endpoint. Agents like Claude Code, Claude Desktop, and
+          Cursor — and any HTTP-speaking client — can create, edit, and
+          retrieve decks without the browser UI. Decks generated over MCP land
+          in your tellr history exactly as if you'd made them interactively.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Who's this for?</h2>
+        <p className="text-gray-600">
+          Developers and power users who want to automate deck creation — a CI
+          job that drops a weekly briefing into Slack, an internal app that
+          turns a CRM record into a pitch deck, an agent runtime that calls
+          tellr as one tool in a wider workflow. If you only need interactive
+          generation, stay on the main page.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Your endpoint</h2>
+        <div className="flex items-center gap-2 rounded bg-gray-50 border border-gray-200 p-3">
+          <code
+            data-testid="mcp-endpoint-url"
+            className="text-sm font-mono flex-1 break-all"
+          >
+            {mcpEndpoint}
+          </code>
+          <button
+            type="button"
+            onClick={() => void copyEndpoint()}
+            aria-label="Copy endpoint URL"
+            className="shrink-0 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+          >
+            Copy endpoint
+          </button>
+        </div>
+        <p className="text-xs text-gray-500 mt-2">
+          For production deployments behind a custom hostname, see the full
+          guide for how to resolve the correct URL.
+        </p>
+      </section>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Run the tests; expect pass**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all tests pass including the two new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/Help/HelpPage.tsx frontend/tests/e2e/help-ui.spec.ts
+git commit -m "feat(help): show MCP endpoint URL with copy button"
+```
+
+---
+
+## Task 5: MCP tab — prerequisites list + DocLink footer
+
+**Files:**
+- Modify: `frontend/src/components/Help/HelpPage.tsx`
+- Modify: `frontend/tests/e2e/help-ui.spec.ts`
+
+- [ ] **Step 1: Add the failing tests**
+
+```ts
+test('MCP tab shows prerequisites', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  await page.getByRole('tab', { name: 'MCP' }).click();
+  await expect(page.getByRole('heading', { name: 'Prerequisites' })).toBeVisible();
+  await expect(page.getByText(/Databricks user token/i)).toBeVisible();
+});
+
+test('MCP tab links to the integration guide', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  await page.getByRole('tab', { name: 'MCP' }).click();
+
+  const link = page.getByRole('link', { name: /MCP Integration Guide/i });
+  await expect(link).toBeVisible();
+  const href = await link.getAttribute('href');
+  expect(href).toContain('/technical/mcp-integration-guide');
+});
+```
+
+- [ ] **Step 2: Run them; expect fail**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts -g "(prerequisites|links to the integration)" --reporter=list
+```
+
+Expected: 2 failed.
+
+- [ ] **Step 3: Add the Prerequisites section and DocLink footer**
+
+Below the "Your endpoint" section inside `MCPTab`, add:
+
+```tsx
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Prerequisites</h2>
+        <ul className="list-disc list-inside text-gray-600 space-y-2">
+          <li>A Databricks user token (OAuth U2M or PAT)</li>
+          <li>
+            An MCP-capable client: Claude Code, Claude Desktop, Cursor, or a
+            raw HTTP library that speaks JSON-RPC 2.0
+          </li>
+        </ul>
+      </section>
+
+      <DocLink href={DOCS_URLS.mcpIntegrationGuide} label="MCP Integration Guide" />
+```
+
+`DocLink` is already defined at the bottom of `HelpPage.tsx` and `DOCS_URLS` is already imported. No new imports needed.
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run the tests; expect pass**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/Help/HelpPage.tsx frontend/tests/e2e/help-ui.spec.ts
+git commit -m "feat(help): add MCP prerequisites list and integration-guide link"
+```
+
+---
+
+## Task 6: Overview bullet for MCP
+
+**Files:**
+- Modify: `frontend/src/components/Help/HelpPage.tsx`
+- Modify: `frontend/tests/e2e/help-ui.spec.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+```ts
+test('Overview tab shows MCP as a headline capability', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  // Default tab is overview; no click needed.
+  await expect(page.getByText(/Programmatic API via MCP/)).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run it; expect fail**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts -g "MCP as a headline" --reporter=list
+```
+
+Expected: 1 failed.
+
+- [ ] **Step 3: Add the bullet to `OverviewTab`**
+
+Inside the `OverviewTab` component in `HelpPage.tsx`, in the first `<section>` (the "What is databricks tellr?" block), add a fourth `<li>` after the existing three:
+
+```tsx
+      <ul className="list-disc list-inside text-gray-600 space-y-2">
+        <li>Creates presentation slides from natural language using AI</li>
+        <li>Pulls data from Databricks Genie spaces for data-driven presentations</li>
+        <li>Supports iterative editing through conversational interface</li>
+        <li>Programmatic API via MCP — call tellr from agents, CI, or other apps</li>
+      </ul>
+```
+
+- [ ] **Step 4: Run the test; expect pass**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Help/HelpPage.tsx frontend/tests/e2e/help-ui.spec.ts
+git commit -m "feat(help): surface MCP as a headline capability on Overview"
+```
+
+---
+
+## Task 7: Overview Quick Link to the MCP tab
+
+**Files:**
+- Modify: `frontend/src/components/Help/HelpPage.tsx`
+- Modify: `frontend/tests/e2e/help-ui.spec.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+```ts
+test('Overview Quick Link navigates to the MCP tab', async ({ page }) => {
+  await setupMocks(page);
+  await goToHelp(page);
+  await page.getByRole('button', { name: /Learn about MCP/ }).click();
+  // Clicking the quick link should activate the MCP panel.
+  await expect(page.getByRole('heading', { name: 'What is MCP?' })).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run it; expect fail**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts -g "Quick Link navigates to the MCP" --reporter=list
+```
+
+Expected: 1 failed (no button with "Learn about MCP").
+
+- [ ] **Step 3: Add the Quick Link button**
+
+Inside `OverviewTab`, in the "Navigation Quick Links" section, add a new `QuickLinkButton` entry at the end of the list (after the Images one):
+
+```tsx
+        <QuickLinkButton tab="images" label="Learn about Images →" />
+        <QuickLinkButton tab="mcp" label="Learn about MCP →" />
+      </div>
+```
+
+- [ ] **Step 4: Run the test; expect pass**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Help/HelpPage.tsx frontend/tests/e2e/help-ui.spec.ts
+git commit -m "feat(help): add MCP quick link on Overview tab"
+```
+
+---
+
+## Task 8: Docs-site sidebar entries
+
+Adds the two existing MCP markdown files to the Docusaurus "Technical Documentation" sidebar so they're reachable from the docs-site left nav.
+
+**Files:**
+- Modify: `docs-site/sidebars.js`
+
+No Playwright coverage — Docusaurus owns its own sidebar rendering and testing. Verification is a local preview.
+
+- [ ] **Step 1: Append the two slugs**
+
+Edit `docs-site/sidebars.js`. Inside the `technical` sidebar's `items` array, append these two entries at the end of the list:
+
+```js
+        'technical/feedback-system',
+        'technical/mcp-server',
+        'technical/mcp-integration-guide',
+      ],
+    },
+  ],
+```
+
+(The `'technical/feedback-system'` line is already there — just add the two new lines after it.)
+
+- [ ] **Step 2: Preview the docs site locally**
+
+Run:
+
+```bash
+cd docs-site && npm install --no-audit --no-fund && npm run start -- --no-open
+```
+
+Open `http://localhost:3000` in a browser. Navigate to the Technical Documentation section of the sidebar. Confirm both new items appear. Click each; confirm the page renders without a 404.
+
+Kill the dev server with Ctrl+C when done.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs-site/sidebars.js
+git commit -m "docs(site): list MCP pages in technical sidebar"
+```
+
+---
+
+## Task 9: Final full-file test run
+
+- [ ] **Step 1: Run the full help-ui suite**
+
+```bash
+cd frontend && npx playwright test tests/e2e/help-ui.spec.ts --reporter=list
+```
+
+Expected: all pre-existing `HelpNavigation`, `HelpTabs`, `QuickLinks` tests still pass, plus the seven new MCP-related tests from Tasks 2-7.
+
+- [ ] **Step 2: Run the broader e2e suite to catch cross-test pollution**
+
+```bash
+cd frontend && npx playwright test --reporter=list
+```
+
+Expected: no new failures compared to the branch base. If anything in `slide-styles-ui.spec.ts` or elsewhere regresses, triage before moving on — the mock routes added in Task 4-5 are test-local and should not leak, but confirm.
+
+- [ ] **Step 3: Typecheck once more**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+Expected: no output.
+
+---
+
+## Post-Implementation Manual Verification (after deploy)
+
+1. Deploy tellr; visit `/help` in a fresh browser session (no localStorage tweaks).
+2. On the Overview tab, confirm the "Programmatic API via MCP" bullet is present in "What is databricks tellr?" and that a "Learn about MCP →" quick link appears under Navigation Quick Links.
+3. Click the MCP tab. Confirm the four sections render (What is MCP?, Who's this for?, Your endpoint, Prerequisites) and that the "MCP Integration Guide" link points to the deployed docs page.
+4. Click "Copy endpoint". Confirm a success toast appears and that the clipboard contains `https://<your-tellr-app>/mcp/`.
+5. Visit `robertwhiffin.github.io/ai-slide-generator/docs/technical/mcp-server`. Confirm the left-nav sidebar shows "mcp-server" and "mcp-integration-guide" under Technical Documentation and that both pages load.
+
+---
+
+## Documentation follow-up
+
+None required. The two MCP markdown files already shipped with the feature work. This plan only surfaces them; it doesn't rewrite or extend them.
+
+If during implementation you discover a doc inaccuracy — for example, the endpoint URL wording on `mcp-server.md` needs a sentence about what `window.location.origin` resolves to in local dev — capture it as a one-line note and address in a follow-up commit rather than expanding scope here.
+
+---
+
+## Git Strategy
+
+One commit per task (already specified in each task's Step 5/6). Nine commits total:
+
+- Task 1 (constants)
+- Task 2 (tab scaffold)
+- Task 3 (What is / Who is for)
+- Task 4 (endpoint + copy)
+- Task 5 (prerequisites + DocLink)
+- Task 6 (Overview bullet)
+- Task 7 (Overview Quick Link)
+- Task 8 (docs-site sidebar)
+
+(Task 9 is verification only — no commit.)
+
+Rebase/squash before merge is fine if you prefer fewer commits on `main`; keep them atomic on the feature branch so review can walk them in order.
+
+---
+
+## Out of scope — do not do in this plan
+
+- No backend changes.
+- No MCP code changes.
+- No changes to user-facing slide style, profile, or deck-prompt pages.
+- No new MCP documentation — the technical reference and integration guide are already complete.
+- No header/nav entry for MCP outside the help page.
+- No per-deployment URL override — `window.location.origin` is authoritative for v1.

--- a/docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md
@@ -1,0 +1,623 @@
+# Tellr MCP Server Design Spec
+
+**Date:** 2026-04-22
+**Branch:** `ty/feature/tellr-mcp-server`
+**Status:** Draft
+
+## Overview
+
+Today tellr is reachable only via its own browser UI. This design exposes tellr as an **MCP (Model Context Protocol) server** so that external Databricks Apps and MCP-compatible agent tools (e.g., Claude Code and similar) can programmatically request deck generation and editing using the existing tellr agent pipeline, without forking or re-implementing it.
+
+The design follows the guiding principle that **external callers handle research and data collection; tellr produces the presentation**. A caller assembles a prompt (optionally enriched with their own data, Genie output, knowledge-base results, etc.), sends it to tellr's MCP endpoint, and receives either the rendered deck (as structured slide data and standalone HTML) or a URL into tellr's own UI for full-featured editing. The same tellr deployment serves browser users and MCP callers from a single process; MCP is an additional entry point, not a parallel pipeline.
+
+This v1 ships **prompt-only generation** — callers send natural-language prompts; tellr generates slides without invoking Genie, Vector Search, MCP-consumed servers, Model Serving endpoints, or Agent Bricks on the caller's behalf. Tool configurability, exports, and structural edit primitives are deferred to v1.1.
+
+## Goals
+
+- Expose a Streamable HTTP MCP endpoint at `/mcp` on the existing tellr Databricks App, using the 2025-03-26 MCP specification revision.
+- Provide four tools: `create_deck`, `get_deck_status`, `edit_deck`, `get_deck`.
+- Preserve tellr's existing permission and ownership model — the deck creator is the end user whose identity arrived on the MCP call.
+- Accept two authentication paths transparently: proxy-injected `x-forwarded-access-token` (for in-workspace callers) and `Authorization: Bearer` (for external agent tools).
+- Return deck content in multiple useful forms (structured slide data, renderable standalone HTML document, tellr UI URL) so each caller can choose how to present it.
+- Reuse existing async job queue, worker, session manager, slide-deck domain, agent factory, and permission service — no new infrastructure, no parallel pipelines.
+- Ship v1 with unit tests, integration tests, smoke test scripts, design spec, and caller-facing technical reference documentation.
+- Ensure each MCP deployment works against the tellr Databricks App's own URL; callers parameterize on that URL with no additional infrastructure setup.
+
+## Non-Goals
+
+- Tool-level configurability over MCP (Genie Space, Vector Index, MCP consumer, Model Endpoint, Agent Bricks). Callers that need data-backed generation in v1 shape the relevant content into the prompt itself.
+- Deck exports (PPTX, Google Slides) over MCP. Exports remain available in the tellr UI; MCP callers hand users to `deck_url` for export actions in v1.
+- Structural edit primitives (reorder, delete, duplicate). Callers that need these in v1 direct the user to the tellr UI.
+- Raw HTML slide replacement (caller supplying exact HTML for a slide).
+- Cancellation of in-flight generation jobs.
+- Server-sent progress events (SSE) during generation — v1 is polling-based.
+- Unity Catalog HTTP Connection registration of tellr. This is a pure workspace-admin action that requires no tellr code change; documented as a later operational step.
+- Python library extraction of tellr's core pipeline for in-process embedding.
+- UI changes in the tellr frontend (no "created via MCP" badge, no MCP session listing, no new views).
+
+## Design Decisions
+
+| # | Decision | Choice | Rationale |
+|---|---|---|---|
+| 1 | Protocol | Streamable HTTP MCP, spec revision 2025-03-26 | Native support in major MCP clients (Claude Code, Claude Desktop, Cursor) and in-workspace MCP proxy clients; the same protocol tellr already consumes for external MCP servers |
+| 2 | Path | `/mcp` on the existing tellr Databricks App URL | Matches common MCP convention; inherits TLS, DNS, SSO, and deploy cadence from the existing app; no new infrastructure |
+| 3 | Server SDK | Official `mcp` Python package (`FastMCP`) | Spec-compliant by construction; auto-derives tool schemas from Python type hints; handles `initialize`, `tools/list`, `tools/call`, `mcp-session-id`, and JSON-RPC error envelopes without hand-rolled protocol code |
+| 4 | Auth model | Dual-token: `x-forwarded-access-token` first, `Authorization: Bearer` fallback | Supports in-workspace (proxy-injected) and external (laptop agent tools) callers through the same code path; priority order prevents spoofing |
+| 5 | Identity propagation | Re-use existing `ContextVar`-based permission context | Tool handlers run under the same identity contract as browser API routes; every downstream service (session manager, permission service, Google Slides auth, MLflow) inherits identity without additional wiring |
+| 6 | Job lifecycle | Async + polling, reusing existing `chat_requests` queue and background worker | Zero new worker, zero new queue; MCP-submitted jobs are indistinguishable from browser-submitted jobs from the worker's perspective |
+| 7 | v1 tool scope | Prompt-only generation, no tool configuration on the MCP surface | Avoids the hardest unsolved problem for v1 (delegating Genie / Vector OBO through a non-browser auth path); tellr's existing empty-tools path already supports this mode |
+| 8 | Response contract | Return structured `deck`, standalone `html_document`, and `deck_url`/`deck_view_url` together | Each caller chooses: render in their own UI (HTML), consume slide-by-slide (structured), or link users to tellr's full editor (URL). All three are cheap derivations of the same canonical `deck_json` |
+| 9 | Identifier model | `session_id` (stable per deck) + `request_id` (per async call) | Decoupled semantics: multiple edits on one deck share `session_id` and `deck_url`; each call has its own `request_id` for polling |
+| 10 | Hard job timeout | 10 minutes, enforced by a lifespan sweeper task | Gives callers a predictable upper bound on poll duration, independent of deploy cadence; belt-and-suspenders on top of lifespan startup recovery |
+| 11 | Error taxonomy | Protocol errors via JSON-RPC envelope; tool-execution errors via `isError: true` in tool result; async states as normal status values | Conforms to MCP's tool-call error convention; LLM callers can reason over error text naturally |
+| 12 | Clarification / refusal behavior | Returned as successful tool responses with `messages` carrying the LLM text, not as errors | Matches how the existing browser UI handles LLM clarifications; callers surface the message to their user and continue the conversation |
+| 13 | MCP surface attack surface | Strictly a subset of existing user-facing operations; no admin, no lifecycle, no deployment endpoints exposed | Callers can only do what a browser user could do under the same identity |
+| 14 | URL format for callers | `https://<tellr-app-url>/mcp` — no new hostnames created | The MCP endpoint lives on tellr's existing Databricks App URL; each deployment independently gets its own MCP endpoint by virtue of running the updated codebase |
+
+---
+
+## Architecture
+
+### Component layout
+
+```
+┌─────────────────────────── tellr Databricks App (single process) ────────────────────────┐
+│                                                                                           │
+│   [lifespan startup/shutdown — triggered only by platform events, not by HTTP requests]  │
+│     - Lakebase token refresh loop                                                         │
+│     - DB init + profile migration                                                         │
+│     - Chat job queue worker             ← same worker services MCP-submitted jobs         │
+│     - Export job queue worker                                                             │
+│     - Request log cleanup                                                                 │
+│     - [NEW] Stuck-job timeout sweeper (mark_timed_out_jobs_loop)                          │
+│     - recover_stuck_requests() on boot  ← inherited; MCP jobs recovered for free          │
+│                                                                                           │
+│   ┌─── FastAPI app ─────────────────────────────────────────────────────────────────┐     │
+│   │                                                                                  │    │
+│   │   [existing] /api/*                — browser-facing REST routes (unchanged)      │    │
+│   │                                                                                  │    │
+│   │   [NEW]      /mcp                  — FastMCP server mounted here                 │    │
+│   │                                       must be registered before SPA catch-all    │    │
+│   │                                                                                  │    │
+│   │   [existing] /{full_path:path}     — SPA catch-all (last in precedence)          │    │
+│   │                                                                                  │    │
+│   └──────────────────────────────────────────────────────────────────────────────────┘    │
+│                             │                                                             │
+│                             ▼ /mcp tool handlers delegate to                              │
+│                                                                                           │
+│   ┌── existing services (unchanged) ────────────────────────────────────────────────┐     │
+│   │  ChatService.submit_chat_async    SessionManager.create/get/update              │     │
+│   │  SlideDeck.from_dict / to_dict    permission_service.can_view/edit_deck         │     │
+│   │  job_queue.get_status             build_agent_for_request (agent_factory)       │     │
+│   │  [NEW] SlideDeck.to_html_document — small, additive serializer method           │     │
+│   └─────────────────────────────────────────────────────────────────────────────────┘     │
+└───────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Files added or touched
+
+| File | Change type | Purpose |
+|---|---|---|
+| `src/api/mcp_server.py` | **New** | FastMCP instance; four tool handlers; thin wrappers over existing services |
+| `src/api/mcp_auth.py` | **New** | Dual-token extraction + `ContextVar` wiring helper used by each tool handler |
+| `src/api/main.py` | **Edited** | Register MCP router before `_mount_frontend`; start `mark_timed_out_jobs_loop` in lifespan |
+| `src/api/services/job_queue.py` | **Edited** | Add `mark_timed_out_jobs_loop` coroutine with a single SQL sweep per tick |
+| `src/domain/slide_deck.py` | **Edited** | Add `SlideDeck.to_html_document(chart_js_cdn: str = DEFAULT_CHART_JS_CDN) -> str` serializer |
+| `pyproject.toml` | **Edited** | Add `mcp>=1.0.0` dependency |
+| `tests/unit/test_mcp_server.py` | **New** | Unit tests for tool handlers, auth middleware, error mapping, timeout sweeper, HTML serializer |
+| `tests/integration/test_mcp_endpoint.py` | **New** | End-to-end MCP protocol tests using FastAPI `TestClient` + mocked LLM |
+| `scripts/mcp_smoke/mcp_smoke_httpx.py` | **New** | Copy-pasteable smoke script for post-deploy verification |
+| `docs/technical/mcp-server.md` | **New** | Caller-facing integration reference (separate deliverable tracked in plan) |
+
+### Registration order
+
+The SPA catch-all (`/{full_path:path}`) in `src/api/main.py` currently serves `index.html` for any path not starting with `api/`. A request to `/mcp` would be swallowed by that catch-all unless the MCP router is registered earlier.
+
+The MCP router is added at module-load time alongside existing `app.include_router(...)` calls, before any `_mount_frontend(...)` invocation. Production and local dev paths both rely on that ordering.
+
+---
+
+## Authentication & Identity Propagation
+
+### Why dual-token
+
+The existing `user_auth_middleware` in `src/api/main.py` reads only `x-forwarded-access-token`, which the Databricks Apps proxy injects for browser-originated requests. External callers (laptop agent tools) do not go through that injection path and must carry their own bearer token. In-workspace callers (other Databricks Apps calling directly) may or may not have the proxy inject a token depending on how the request is shaped.
+
+A dedicated MCP auth helper accepts tokens from both sources in priority order:
+
+1. `x-forwarded-access-token` header — highest trust; injected by the Databricks Apps proxy and cannot be spoofed from outside.
+2. `Authorization: Bearer <token>` header — fallback for callers that are not behind the proxy (external agent tools) or where the proxy is not injecting.
+
+If neither header is present, the request fails with `isError: true` and a clear authentication message.
+
+### Identity resolution
+
+The bearer token is passed to `get_or_create_user_client(token)` — the same factory the browser flow uses. Identity is resolved via `user_client.current_user.me()` and bound into the per-request `ContextVar`s:
+
+- `set_current_user(user_name)`
+- `set_user_client(user_client)`
+- `set_permission_context(build_permission_context(user_id, user_name, fetch_groups=False))`
+
+Each tool handler runs inside a scope that establishes and tears down these ContextVars — same discipline as the existing middleware. Once set, all downstream services (`session_manager.create_session`, `permission_service.can_edit_deck`, Google OAuth auth, MLflow span tagging) pick up identity transparently.
+
+### Caller contracts
+
+**In-workspace Databricks App callers.** A Databricks App that receives a user's OBO token via its own `x-forwarded-access-token` header must forward that token to tellr's `/mcp` as `Authorization: Bearer <token>`. Pseudocode:
+
+```python
+user_token = request.headers.get("x-forwarded-access-token")
+async with httpx.AsyncClient() as client:
+    await client.post(
+        f"{TELLR_APP_URL}/mcp",
+        headers={
+            "Authorization": f"Bearer {user_token}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+    )
+```
+
+This ensures deck attribution flows to the end user and the deck appears in that user's tellr UI automatically.
+
+**External MCP client callers (laptop agent tools).** Configure the MCP client to include an `Authorization` header carrying a Databricks user token (OAuth U2M or PAT):
+
+```json
+{
+  "tellr": {
+    "type": "streamable-http",
+    "url": "https://<tellr-app-url>/mcp",
+    "headers": {
+      "Authorization": "Bearer ${DATABRICKS_TOKEN}"
+    }
+  }
+}
+```
+
+The URL should be the tellr Databricks App URL the caller is targeting; each deployment has its own URL.
+
+### Security posture
+
+| Concern | Handling | Rationale |
+|---|---|---|
+| Transport | HTTPS-only (Databricks Apps enforced) | Bearer tokens never in plaintext |
+| Token validation | `current_user.me()` on every JSON-RPC call | Short-circuit on expired or invalid tokens; no cross-request identity caching in v1 |
+| Token logging | Never log token values; log `token_source` and resolved `user_name` | Prevent token leakage via structured logs |
+| Authorization | Existing `permission_service` checks on every deck-touching operation | MCP inherits tellr's entire permission model (CAN_VIEW / CAN_EDIT / CAN_MANAGE) |
+| Rate limiting | Inherits existing LLM backend rate limits | No new capacity or bypass added |
+| CORS | Not configured for `/mcp` | MCP clients are server-side HTTP clients, never browsers; avoids widening origin surface |
+| Shared secrets / API keys | Not supported | Would break "creator = end user" attribution |
+| Service-principal callers | Accepted; deck is attributed to the SP | Honest behavior; callers should forward end-user tokens instead if the deck should surface to a user |
+| Creator spoofing | Impossible | `created_by` derives from the resolved identity of the bearer token; no parameter accepts it |
+| Admin / lifecycle operations | Not reachable from `/mcp` | MCP tool list is a strict subset of user-facing functionality; admin routes remain under `/api/admin/*` with their own auth |
+
+### Permission context for MCP-initiated edits
+
+When `edit_deck` is called:
+
+1. The tool handler resolves the caller's identity from the bearer token.
+2. `permission_service.can_edit_deck(session_id)` runs against that identity.
+3. If the caller is neither the session creator nor a contributor with `CAN_EDIT` (including via group membership if enabled), the tool returns `isError: true` with a permission-denied message.
+4. On success, the `edit_deck` call is recorded as a chat message on the session under the caller's identity, just as a browser-originated edit would be.
+
+Cross-user deck access via MCP is therefore governed by the same rules as cross-user deck access via the browser UI. No new authorization surface is introduced.
+
+---
+
+## MCP Tool Catalog
+
+All four tools are registered on a single `FastMCP("tellr")` instance mounted at `/mcp`. Input schemas are derived automatically from Python type hints; output shapes are documented below.
+
+### 1. `create_deck`
+
+Creates a new tellr session and submits a generate-mode job to the async chat queue.
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | string | yes | Natural-language description of the desired deck |
+| `num_slides` | integer | no | Target slide count (1–50); LLM treats as guidance |
+| `slide_style_id` | integer | no | Identifier of a slide style from the slide-style library; resolved server-side |
+| `deck_prompt_id` | integer | no | Identifier of a deck prompt from the deck-prompt library; resolved server-side |
+| `correlation_id` | string | no | Opaque caller-supplied string propagated into MLflow spans and logs |
+
+**Output:**
+
+```json
+{
+  "session_id":     "abc-123",
+  "request_id":     "req-7f2",
+  "status":         "pending"
+}
+```
+
+**Semantics:**
+
+- Creates a row in `user_sessions` with `created_by = <resolved caller identity>`, `agent_config.tools = []` (prompt-only), and optional `slide_style_id` / `deck_prompt_id` resolved from library references.
+- Submits the generate job via `chat_service.submit_chat_async`. Returns immediately; the caller polls `get_deck_status` for completion.
+- `slide_style_id` / `deck_prompt_id` resolve identically to how the browser flow resolves them; unknown identifiers log a warning and fall back to defaults (existing behavior).
+
+### 2. `get_deck_status`
+
+Polls the state of a submitted create or edit job; returns the current deck on completion.
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `session_id` | string | yes | The deck's session identifier |
+| `request_id` | string | yes | The async job identifier returned by `create_deck` / `edit_deck`. Callers that do not have a `request_id` (e.g., re-fetching a previously generated deck) should call `get_deck` instead |
+
+**Output (status = `pending` or `running`):**
+
+```json
+{
+  "session_id":  "abc-123",
+  "request_id":  "req-7f2",
+  "status":      "running",
+  "progress":    null
+}
+```
+
+**Output (status = `ready`):**
+
+```json
+{
+  "session_id":      "abc-123",
+  "request_id":      "req-7f2",
+  "status":          "ready",
+  "slide_count":     7,
+  "title":           "Q3 Revenue Pitch",
+  "deck": {
+    "slides":           [ /* { html, scripts } per slide */ ],
+    "css":              "...",
+    "external_scripts": [ "https://cdn.jsdelivr.net/npm/chart.js" ]
+  },
+  "html_document":   "<!doctype html>…",
+  "deck_url":        "https://<tellr-app-url>/sessions/abc-123/edit",
+  "deck_view_url":   "https://<tellr-app-url>/sessions/abc-123/view",
+  "replacement_info": null,
+  "messages": [
+    { "role": "user",      "content": "…the user prompt…" },
+    { "role": "assistant", "content": "…the agent's summary or clarification…" }
+  ],
+  "metadata": {
+    "mode":           "generate",
+    "tool_calls":     0,
+    "latency_ms":     27340,
+    "correlation_id": "…"
+  }
+}
+```
+
+**Output (status = `failed`):**
+
+```json
+{
+  "session_id": "abc-123",
+  "request_id": "req-7f2",
+  "status":     "failed",
+  "error":      "Generation exceeded maximum duration (10 minutes)"
+}
+```
+
+**Semantics:**
+
+- While status is `pending` or `running`, the response is cheap (single SELECT on `chat_requests`). Callers are expected to poll at ≥ 1s intervals with backoff; no server-side rate limit is enforced in v1.
+- On `ready`, the response contains both structured `deck` and standalone `html_document` — the caller chooses which (or both) to use.
+- `messages` contains the current turn's exchange only, not full session history. Clarification questions from the LLM surface here for the caller to display.
+- `replacement_info` is `null` for generate jobs and populated for edit jobs.
+
+### 3. `edit_deck`
+
+Submits an edit-mode job against an existing session.
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `session_id` | string | yes | The deck to edit |
+| `instruction` | string | yes | Natural-language edit instruction |
+| `slide_indices` | array of int | no | Contiguous slide indices to target; if omitted, the LLM infers from the instruction |
+| `correlation_id` | string | no | Opaque caller-supplied string |
+
+**Output:**
+
+```json
+{
+  "session_id": "abc-123",
+  "request_id": "req-8a1",
+  "status":     "pending"
+}
+```
+
+**Semantics:**
+
+- `permission_service.can_edit_deck(session_id)` runs before any side effects; unauthorized callers receive `isError: true`.
+- If `slide_indices` is provided, a `slide_context` block is constructed from the deck's current HTML at those indices and attached to the agent prompt — exactly the same mechanism the browser UI uses for targeted edits. The existing slide-replacement pipeline (`_parse_slide_replacements` / `_apply_slide_replacements`) handles the merge, canvas deduplication, CSS merge, and script rewriting without change.
+- On `get_deck_status` showing `ready`, the response contains the **updated** deck, updated `html_document`, unchanged `deck_url`, and a populated `replacement_info` summarizing what changed.
+- A new save point is created automatically after deck persistence (existing `ChatService` behavior, capped at 40 per session, oldest deleted on overflow).
+
+### 4. `get_deck`
+
+Idempotent read of the current deck state for a session.
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `session_id` | string | yes | The deck to retrieve |
+
+**Output:**
+
+```json
+{
+  "session_id":    "abc-123",
+  "slide_count":   7,
+  "title":         "Q3 Revenue Pitch",
+  "deck": {
+    "slides":           [ /* { html, scripts } per slide */ ],
+    "css":              "...",
+    "external_scripts": [ "https://cdn.jsdelivr.net/npm/chart.js" ]
+  },
+  "html_document": "<!doctype html>…",
+  "deck_url":      "https://<tellr-app-url>/sessions/abc-123/edit",
+  "deck_view_url": "https://<tellr-app-url>/sessions/abc-123/view"
+}
+```
+
+Fields `status`, `request_id`, `messages`, `replacement_info`, and `metadata` (which are tied to an async job or turn) are omitted — this tool does not execute a job or advance a conversation turn.
+
+**Semantics:**
+
+- Runs `permission_service.can_view_deck(session_id)`; denies per existing rules.
+- Single SELECT on `user_sessions`. No job queue interaction. No new save point.
+- Intended for callers that already know a `session_id` (e.g., they're re-rendering a deck they generated earlier) and want to fetch the current state without triggering new work.
+
+### Tool descriptions for agent consumers
+
+Each tool carries a concise description attribute for LLM-driven callers:
+
+- `create_deck`: "Generate a new slide deck from a natural-language prompt. Returns a session_id and a request_id for polling via get_deck_status. The resulting deck is attributed to the calling user and appears in their tellr UI."
+- `get_deck_status`: "Poll the status of a deck generation or edit job. While running, returns lightweight status. When ready, returns the complete deck as structured data and standalone HTML, along with the tellr URL for full-featured editing."
+- `edit_deck`: "Refine an existing deck through natural-language instructions. Optionally target specific slides via slide_indices. The edit is applied in-place; the session_id and deck_url remain stable across edits."
+- `get_deck`: "Retrieve the current state of a deck without submitting new work. Returns the same rich payload as get_deck_status on a ready job."
+
+---
+
+## Data Flow & State Model
+
+### Identifier semantics
+
+- **`session_id`** identifies a deck. Stable from creation through every edit. Appears in `deck_url`. One session = one deck, visible in the creator's tellr UI.
+- **`request_id`** identifies one async job. Transient; used only for polling the status of that specific job. Every `create_deck` or `edit_deck` call returns a new `request_id`.
+
+A deck created by MCP can later be edited from the tellr browser UI, and vice versa; the `session_id` is the same across surfaces.
+
+### `create_deck` end-to-end
+
+```
+Caller                            MCP tool handler                     Worker                             DB
+──────                            ────────────────                     ──────                             ──
+create_deck(prompt, …)            auth → permission_context            
+                                  session_manager.create_session(             
+                                    created_by = <caller identity>,         
+                                    agent_config = {                         
+                                      tools: [],              ← prompt-only       
+                                      slide_style_id,                        
+                                      deck_prompt_id                         
+                                    })                                       ─────▶  INSERT user_sessions
+                                  chat_service.submit_chat_async(                     
+                                    session_id, prompt,                       
+                                    mode="generate",                          
+                                    correlation_id)                            ─────▶  INSERT chat_requests (pending)
+                                  return {session_id, request_id,                     
+                                          status: "pending"}                  
+                                  
+  (caller polls get_deck_status)                                  
+                                                              [worker picks up]      
+                                                              build_agent_for_request(config, mode="generate")
+                                                              agent.run(prompt)
+                                                              SlideDeck.from_html_string
+                                                              session_manager.update_session          ─────▶  UPDATE user_sessions.deck_json
+                                                              create_save_point                        ─────▶  INSERT slide_deck_versions
+                                                              append_session_messages                   ─────▶  INSERT session_messages
+                                                              mark request ready                       ─────▶  UPDATE chat_requests (ready)
+
+  get_deck_status sees "ready":                                                       
+                                  SELECT chat_requests (status)                  
+                                  SELECT user_sessions (deck_json)               
+                                  deck = SlideDeck.from_dict(...)                
+                                  build response with deck,                      
+                                    html_document (via to_html_document()),      
+                                    deck_url, deck_view_url, messages            
+```
+
+### `edit_deck` end-to-end
+
+```
+edit_deck(session_id, instruction, slide_indices?)     auth → permission_context
+                                                       permission_service.can_edit_deck(session_id)
+                                                       deck = SlideDeck.from_dict(session.deck_json)
+                                                       slide_context = {
+                                                         indices: slide_indices,
+                                                         slide_htmls: [deck.slides[i].html for i in slide_indices]
+                                                       } if slide_indices else None
+                                                       chat_service.submit_chat_async(
+                                                         session_id, instruction,
+                                                         mode="edit",
+                                                         slide_context,
+                                                         correlation_id)                 ─────▶  INSERT chat_requests (pending)
+                                                       return {session_id, request_id, status: pending}
+
+(worker)                                               build_agent_for_request(config, mode="edit")
+                                                       agent.run(prompt_with_slide_context)
+                                                       _parse_slide_replacements(llm_html)
+                                                       _apply_slide_replacements(deck, parsed)
+                                                       session_manager.update_session(deck)            ─────▶  UPDATE user_sessions.deck_json
+                                                       create_save_point                              ─────▶  INSERT slide_deck_versions
+                                                       mark request ready                             ─────▶  UPDATE chat_requests (ready)
+
+get_deck_status response includes replacement_info = {
+  start_index, original_count, replacement_count, net_change, message
+}
+```
+
+Every behavior below this level — parsing replacement slides, canvas deduplication, CSS selector-level merge, script alignment, deck preservation guards, JS validation, clarification guards, unsupported-operation hints — is existing code unchanged.
+
+### State ownership
+
+| State | Owner | Durability | Visible to MCP caller? |
+|---|---|---|---|
+| `user_sessions` row | tellr Postgres | persistent | via `session_id` + title/slide_count |
+| `session_messages` | tellr Postgres | persistent | current turn only, not full history |
+| `chat_requests` | tellr Postgres | persistent with cleanup | yes, via `request_id` polling |
+| `slide_deck_versions` | tellr Postgres | persistent, capped | not in v1 (available via tellr UI) |
+| `replacement_info` | transient | one-shot per edit response | yes |
+| `ChatService._deck_cache` | process memory | until eviction | no (internal) |
+| `deck`, `html_document`, `deck_url` | derived | response-time | yes |
+
+`session.deck_json` is canonical. All MCP responses are derived projections. Concurrent browser edits remain visible to subsequent MCP polls without any staleness management, because polls read fresh from DB.
+
+### `html_document` serialization
+
+A new method `SlideDeck.to_html_document(chart_js_cdn: str = DEFAULT_CHART_JS_CDN) -> str` is added to `src/domain/slide_deck.py`. It produces a complete standalone HTML page: `<!doctype html>` with `<head>` carrying deck-level CSS and external script references, `<body>` carrying all slide divs in order, and per-slide Chart.js initializers appended.
+
+Properties:
+
+- Single pass over `SlideDeck` state; no DB access; no agent invocation.
+- Deterministic output given the same input deck.
+- Default Chart.js CDN is documented and overridable via the method parameter for callers in air-gapped environments.
+- Included in every `ready` response alongside the structured `deck` — cheap enough that no opt-in flag is warranted.
+
+---
+
+## Error Handling
+
+Errors are partitioned into three layers:
+
+| Layer | Examples | Transport |
+|---|---|---|
+| **Protocol** (JSON-RPC 2.0 level) | Malformed JSON, unknown method, unknown tool, missing required fields in the envelope | JSON-RPC `error` response with standard codes (-32600 to -32603); handled automatically by FastMCP |
+| **Application** (tool execution) | Auth failure, permission denied, session missing, input validation, LLM rate limit, generation failure, stuck-job timeout | Successful JSON-RPC response with `result.isError = true` and text explanation |
+| **Async state** (normal operation) | Job still running, not yet ready | Normal response with `status: "pending"` or `"running"` — not an error |
+
+### Failure-mode table
+
+| Failure | Layer | Caller sees |
+|---|---|---|
+| No credentials (no header present) | Application | `isError: true`, "Authentication required" |
+| Invalid or expired token | Application | `isError: true`, "Invalid or expired credentials" |
+| Caller lacks CAN_VIEW / CAN_EDIT on the deck | Application | `isError: true`, "Deck not found or you do not have permission" |
+| Session does not exist or is soft-deleted | Application | `isError: true`, "Deck not found" |
+| `slide_indices` out of range or non-contiguous | Application | `isError: true`, with offending index and reason |
+| `num_slides` out of 1–50 | Application | `isError: true`, "num_slides must be between 1 and 50" |
+| `slide_style_id` or `deck_prompt_id` not found | Application (warning, non-fatal) | Log warning and fall back to defaults (existing behavior) |
+| LLM rate limited by Databricks model serving | Application | `isError: true`, "Generation temporarily rate-limited, retry shortly", with `retry_after_seconds` in metadata |
+| LLM output malformed after existing retries | Application | `isError: true`, "Generation failed: invalid output; deck unchanged" (deck preservation guard enforced) |
+| Canvas / JS validation failure | Application | `isError: true`, "Generated slides failed chart validation" |
+| Worker crashed mid-job | Application | Poll eventually returns `status: "failed"` (via lifespan recovery or 10-minute sweeper) |
+| Session lock contention | Application | `isError: true`, "Deck is being modified by another request, retry shortly" |
+| Unknown tool name | Protocol | JSON-RPC `-32602` Invalid params |
+| Malformed JSON-RPC envelope | Protocol | JSON-RPC `-32700` Parse error or `-32600` Invalid Request |
+| Internal exception (uncaught) | Application | `isError: true`, sanitized message with `correlation_id` for log lookup |
+
+### Stuck-request recovery
+
+Two layers of recovery ensure that no job remains in `running` indefinitely:
+
+1. **Lifespan startup recovery** — existing `recover_stuck_requests()` in the startup path marks orphaned `running` rows as `failed` when the app boots. MCP-submitted jobs inherit this behavior.
+2. **Hard timeout sweeper** — new `mark_timed_out_jobs_loop` coroutine, started in the lifespan, ticks every 60 seconds and executes one SQL update:
+
+   ```sql
+   UPDATE chat_requests
+   SET status = 'failed',
+       error_message = 'Generation exceeded maximum duration (10 minutes)',
+       ended_at = NOW()
+   WHERE status = 'running'
+     AND started_at < NOW() - INTERVAL '10 minutes'
+   ```
+
+The 10-minute constant lives in `src/api/services/job_queue.py` and is tunable. The sweeper updates the database row (so the caller's next poll sees `failed`); it does not itself cancel the worker coroutine. True worker-level cancellation is deferred to v1.1.
+
+### LLM clarification and refusal (not errors)
+
+When the agent responds with a clarifying question or refuses a request, the response shape is identical to a successful generation: `status: "ready"`, deck content (potentially unchanged), and the agent's text carried in `messages`. Callers display the assistant message to their user and continue the conversation via a follow-up `edit_deck` call. Matches the existing browser UI behavior; no new pattern.
+
+---
+
+## Observability
+
+All MCP operations emit structured logs, MLflow spans, and request-log rows consistent with the existing browser flow.
+
+| Signal | Field |
+|---|---|
+| Log `event` | `mcp_tool_invoked`, `mcp_tool_error`, `mcp_auth_missing`, `mcp_timeout_sweep` |
+| Log includes | `tool_name`, `session_id`, `request_id`, `user_name`, `token_source`, `correlation_id`, error class, sanitized message |
+| MLflow span | Existing `generate_slides` span wraps tool-invoked generation; new attribute `source="mcp"` for filtering |
+| MLflow span (edits) | Inherits `replacement_count`, `original_count`, `net_change`, `mode="edit"` attributes |
+| Request log middleware | Existing `RequestLoggingMiddleware` captures `/mcp` POSTs like any other request; `correlation_id` (if supplied) indexed for cross-app traceability |
+| Token logging | Token values never logged; `token_source` indicates which header was used |
+
+---
+
+## Rollout
+
+### Version bump
+
+Tellr's current line is `0.2.x`. This change is additive (no breaking API modifications to existing `/api/*` routes, no schema migrations affecting existing tables) but significant enough to warrant a minor-version bump to **`0.3.0`**.
+
+### Deployment order
+
+1. Merge to main → PyPI release for `databricks-tellr-app`.
+2. Deploy to a dev workspace first; run the smoke script (`scripts/mcp_smoke/mcp_smoke_httpx.py`) against it with a real Databricks token.
+3. Validate with an MCP client configuration pointed at the dev deployment.
+4. Deploy to production workspace(s).
+5. Re-run smoke against production.
+6. Announce availability to the caller-facing documentation audience.
+
+### Caller onboarding sequence
+
+- External MCP clients (laptop agent tools) can adopt immediately using `Authorization: Bearer` with a Databricks user token.
+- In-workspace Databricks Apps adopt after confirming their OBO-forwarding logic (verify they forward `x-forwarded-access-token` as `Authorization: Bearer` on the outbound call).
+- Unity Catalog HTTP Connection registration is a later operational step that does not require any tellr code change.
+
+---
+
+## Open Verification Items
+
+Three empirical questions to resolve via smoke test against the running tellr app before closing this spec as final:
+
+1. **Databricks Apps proxy behavior on `Authorization: Bearer`.** When an external caller sends an `Authorization: Bearer` header to `<tellr-app-url>/mcp`, does the proxy forward it unmodified, strip it, or substitute it with a proxy-issued token? If the proxy strips it, an alternate header (e.g., `X-Tellr-Auth`) may be needed for the external-caller path.
+2. **`x-forwarded-access-token` on app-to-app calls.** When one Databricks App's backend calls `<tellr-app-url>/mcp` directly, does tellr's proxy inject an `x-forwarded-access-token` header, and if so, whose identity does it carry? This determines whether the dual-token priority order is correct as specified or needs adjustment for app-to-app traffic.
+3. **Identity resolution latency under load.** `current_user.me()` on every JSON-RPC call adds one identity-resolution round trip per request. Under Vibe/Stride-class traffic patterns, this should be acceptable; if it becomes a bottleneck, a short-TTL (≤ 30s) per-token identity cache can be introduced without design-level changes.
+
+These are smoke-test-and-adjust items rather than blockers; the design proceeds on the assumption that the behavior is as expected, with verification as part of the ship checklist.
+
+---
+
+## v1.1 Roadmap
+
+Explicitly captured so scope cuts in v1 do not become scope losses:
+
+1. **Export tools** — `export_deck_pptx` and `export_deck_google_slides`, each async with polling, reusing the existing export job queue and converters.
+2. **Structural edit tools** — `reorder_slides(session_id, new_order)`, `delete_slide(session_id, index)`, `duplicate_slide(session_id, index)`; non-LLM operations so callers can present full deck control without redirecting to the tellr UI.
+3. **Unity Catalog HTTP Connection registration** — documented operational procedure plus recommended `USE CONNECTION` grant patterns; no tellr code change required.
+4. **Raw HTML slide replacement** — `update_slide_html(session_id, index, html)` for callers that want local slide editing with server-side persistence.
+5. **Worker-level cancellation** — wrap generation in `asyncio.wait_for` for true in-flight cancellation, plus a `cancel_deck(session_id, request_id)` MCP tool.
+6. **SSE streaming progress** — bridge existing `streaming_callback.py` events into MCP `notifications/progress` for faster perceived latency.
+7. **Save point access** — `list_save_points(session_id)` and `restore_save_point(session_id, n)` to expose tellr's versioning to MCP callers.
+8. **Agent tool configurability over MCP** — `set_session_tools(session_id, tools: [...])` to expose Genie Space / Vector Index / MCP consumer / Model Endpoint / Agent Bricks tool types; unblocks data-backed generation from callers.
+9. **Python library extraction** — a `databricks_tellr_core` package exposing the agent and converters for in-process embedding in other Databricks Apps.
+10. **Deck thumbnails** — `get_deck_thumbnail(session_id, slide_index)` for richer caller previews (terminal hyperlinks, grid views).
+11. **Bulk edit syntax** — predicate-based edit targeting once usage patterns are observed.
+
+---
+
+## References
+
+- MCP (Model Context Protocol) specification, revision **2025-03-26** — the Streamable HTTP transport used by `/mcp`.
+- Tellr backend overview (`docs/technical/backend-overview.md`) — existing agent pipeline, session management, slide replacement, and permission model that MCP reuses.
+- Tellr database configuration (`docs/technical/database-configuration.md`) — schema for `user_sessions`, `chat_requests`, `session_messages`, `slide_deck_versions`.
+- Tellr slide parser and script management (`docs/technical/slide-parser-and-script-management.md`) — HTML/canvas/script integrity rules that govern `SlideDeck.to_html_document` output.
+- Tellr caller-facing integration reference (`docs/technical/mcp-server.md`) — separate deliverable; companion document for teams integrating with the MCP endpoint.

--- a/docs/superpowers/specs/2026-04-23-mcp-test-client-design.md
+++ b/docs/superpowers/specs/2026-04-23-mcp-test-client-design.md
@@ -1,0 +1,218 @@
+# Tellr MCP Test Client Design Spec
+
+**Date:** 2026-04-23
+**Branch:** `ty/feat/tellr-mcp-server` (for the spec + plan; test-app code itself lives only in the Databricks workspace, see decision #9)
+**Status:** Draft
+
+## Overview
+
+A minimal Databricks App whose sole purpose is to verify that tellr's MCP server, introduced on `ty/feat/tellr-mcp-server`, correctly accepts proxy-injected `x-forwarded-access-token` on app-to-app calls within a Databricks workspace — the one verification item in the tellr MCP design spec that no existing test surface can exercise.
+
+The app is a single Streamlit page: a user pastes a tellr app URL, types a prompt, clicks Generate, and the app forwards the inbound OBO token to tellr's `/mcp/` endpoint, polls `get_deck_status`, and renders the returned `html_document` in an iframe. The resulting deck shows up in the tellr UI attributed to the end user (not the test app's service principal), which is the definitive proof that OBO forwarding works end-to-end.
+
+This is a **throwaway verification harness** with the option to promote to a permanent reference example (`examples/mcp-test-client/` in the tellr repo) if other teams show demand. It is explicitly not productised: no tests, no CI, no long-term API stability, no permission model of its own.
+
+## Goals
+
+- Verify that the Databricks Apps proxy injects `x-forwarded-access-token` on app-to-app calls (open verification item #2 in `2026-04-22-tellr-mcp-server-design.md`).
+- Verify that tellr accepts that token, resolves it via `current_user.me()`, and attributes the resulting deck to the end user — not the test app's service principal.
+- Exercise the `html_document` standalone-HTML rendering recipe (section 8.1 of `docs/technical/mcp-server.md`) in a real iframe.
+- Provide a minimal, readable implementation a Databricks SA can deploy in under an hour. Becoming the basis for other MCP integrations is a nice-to-have; a productised reference example is explicitly a non-goal (see below and the v1.1 roadmap).
+
+## Non-Goals
+
+- **Productised reference example.** If promoted to `examples/` this spec will be superseded; v1 targets verification only.
+- **Edit flow.** `edit_deck` is out of scope — it reuses the same OBO forwarding and polling plumbing as `create_deck`, so verifying one verifies the other.
+- **Multi-user support.** Single-user, single-session, blocking polling loop. No `st.session_state` isolation beyond the current browser session.
+- **Local development path.** No Bearer fallback when the OBO header is missing. Running the app outside Databricks Apps is expected to fail loudly — this is by design, because only the proxy-injected path is worth verifying.
+- **Authentication error UX.** A red banner is sufficient; no refresh, no retry, no reauth flow.
+- **Structured deck rendering.** Only `html_document` iframe rendering. Rendering `deck.slides` in a custom grid is section 8.2 of the tellr MCP doc and adds no new verification value.
+- **Persistence.** The test app has no database. State is per-browser-session only.
+- **Observability.** Streamlit's default `print`/logging is sufficient. No MLflow, no structured logs.
+- **Tests.** No unit or integration tests. The manual verification checklist is the test.
+- **Production deployment.** v1 deploys to the same dev workspace tellr is deployed to; no prod path.
+
+## Design Decisions
+
+| # | Decision | Choice | Rationale |
+|---|---|---|---|
+| 1 | Framework | Streamlit | Canonical "textbox + button" Databricks App pattern; single file; `st.components.v1.html` for iframe rendering; `st.context.headers` for OBO extraction. |
+| 2 | Tellr URL config | User input box, persisted in `st.session_state` | Avoids a redeploy when pointing at a different tellr deployment; trivially simpler than env-var plumbing for a throwaway. |
+| 3 | Auth path | OBO only — `x-forwarded-access-token` → forwarded as `Authorization: Bearer` on outbound | Verifying the OBO path *is* the goal; any Bearer fallback dilutes the signal ("was the OBO header actually used?"). |
+| 4 | Workspace client | None | Test app never calls Databricks APIs directly. It is a pure HTTP forwarder. Drops the `databricks-sdk` dependency. |
+| 5 | Polling model | Synchronous blocking loop inside the button handler, with `st.empty()` updates between iterations | Simple; Streamlit's single-user, single-session assumption holds for a test harness. No `st.rerun()`. |
+| 6 | Poll cadence | 2-second sleep, 10-minute total deadline | Matches the guidance and timeout window in `docs/technical/mcp-server.md` section 9. |
+| 7 | Result rendering | `st.components.v1.html(html_document, height=600, scrolling=True)` | Matches the iframe recipe in tellr MCP doc section 8.1. |
+| 8 | Correlation IDs | Each `create_deck` call generates a fresh `mcp-test-client-<uuid8>` and displays it in the status panel | Enables grepping tellr's server logs if generation fails. |
+| 9 | Code location | Authored in the Databricks workspace IDE, not committed to this repo | Matches the throwaway-now-promote-later decision. Promotion to `examples/mcp-test-client/` is a follow-on task if demand materialises. |
+| 10 | Dependencies | `streamlit`, `httpx` only | `databricks-sdk` explicitly excluded; no workspace client is built. |
+
+## Architecture
+
+### Runtime topology
+
+```
+Browser (end user, logged into Databricks workspace)
+   │
+   │  HTTPS (browser cookie / Databricks SSO)
+   ▼
+Databricks Apps proxy
+   │  adds x-forwarded-access-token: <user's OBO>
+   │
+   ▼
+mcp-test-client (Streamlit, this design)
+   │  reads x-forwarded-access-token from st.context.headers
+   │  re-sends as Authorization: Bearer on outbound
+   ▼
+tellr /mcp/ (Streamable HTTP MCP server)
+   │  current_user.me() resolves the Bearer token to the end user
+   │  deck is created under end user's identity
+   ▼
+tellr worker → deck saved → response returned
+```
+
+### File layout
+
+Authored in the Databricks workspace IDE. Exact paths depend on workspace convention; the canonical minimal layout is:
+
+```
+mcp-test-client/
+├── app.py             # Streamlit page (~90 lines)
+├── app.yaml           # Databricks App config (no env vars required)
+└── requirements.txt   # streamlit, httpx
+```
+
+No other files. No tests. No README.
+
+### Registration order
+
+`app.yaml` declares a `command` that launches Streamlit on the port Databricks Apps expects. This is standard Streamlit-on-Databricks-Apps boilerplate and is not design-bearing; the plan document will pin exact contents.
+
+---
+
+## Page Layout
+
+Top to bottom, single column:
+
+1. **Title.** `st.title("Tellr MCP test client")`.
+2. **Tellr URL.** `st.text_input("Tellr app URL", value=st.session_state.get("tellr_url", ""), placeholder="https://tellr-....databricksapps.com")`. Stored back into `st.session_state["tellr_url"]` on change.
+3. **Identity panel.** A single caption:
+   - If `x-forwarded-access-token` is present in `st.context.headers`: `st.caption("x-forwarded-access-token: ✓ present")`.
+   - If absent: `st.error("Not behind the Databricks Apps proxy. Deploy this app to validate the OBO path. Local runs cannot test OBO.")` and early-return before rendering any further inputs.
+4. **Prompt.** `st.text_area("Prompt", height=120, placeholder="e.g., a three-slide briefing on Q3 renewals")`.
+5. **Generate button.** Disabled when prompt is empty or Tellr URL is empty.
+6. **Status panel.** Empty until Generate is clicked. Then a single `st.empty()` slot updated with the current poll state (`pending`, `running`, `ready`, `failed`) plus the correlation ID and the elapsed time.
+7. **Result panel.** Empty until `status == "ready"`. Then:
+   - `st.link_button("Open in tellr", deck_url)` — bounces to tellr's UI.
+   - `st.components.v1.html(html_document, height=600, scrolling=True)` — renders the standalone HTML in-app.
+
+No side navigation, no tabs, no multipage. One surface.
+
+---
+
+## Data Flow
+
+### `create_deck → poll → render`
+
+1. Read `token = st.context.headers.get("x-forwarded-access-token")`. Absent → error banner per above.
+2. Build a `httpx.Client` with timeout 60s and default headers:
+   - `Authorization: Bearer {token}`
+   - `Content-Type: application/json`
+   - `Accept: application/json, text/event-stream`
+3. **Initialize.** POST `{tellr_url}/mcp/` with body `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"tellr-mcp-test-client","version":"0.1.0"}}}`. Capture `mcp-session-id` from response headers.
+4. **Handshake.** POST `{"jsonrpc":"2.0","method":"notifications/initialized"}` with `mcp-session-id` header.
+5. **Submit.** POST `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_deck","arguments":{"prompt":"<user text>","correlation_id":"mcp-test-client-<uuid8>"}}}`. Parse returned `session_id` and `request_id`.
+6. **Poll loop.** Deadline = `time.time() + 600`. Every iteration:
+   - Sleep 2s.
+   - POST `tools/call get_deck_status` with `{session_id, request_id}`.
+   - Decode (handling SSE `data:` frames).
+   - If `status in ("pending","running")`: update status panel, continue.
+   - If `status == "ready"`: break and render.
+   - If `status == "failed"`: break and show error.
+7. **Render.** On ready, set result panel content; on failed or timeout, red error box. Do not clear status panel — leave correlation ID visible for log grepping.
+
+### SSE decoding
+
+Same `decode(resp)` helper as `scripts/mcp_smoke/mcp_smoke_httpx.py`: if `content-type` includes `event-stream`, scan the body for the first `data:` line and JSON-parse the remainder. Otherwise `resp.json()` directly.
+
+---
+
+## Error Handling
+
+Failure modes and UI treatments:
+
+| Trigger | UI |
+|---|---|
+| `x-forwarded-access-token` absent | Red banner: *"Not behind the Databricks Apps proxy — deploy this app to validate the OBO path. Local runs cannot test OBO."* Inputs hidden. |
+| Tellr URL empty | Caption: *"Enter your tellr app URL to begin."* Generate button disabled. |
+| HTTP 4xx / 5xx on any call | Red box: `HTTP {status_code}: {response.text}`. No retry. |
+| JSON-RPC error envelope (`result.isError == true`) | Red box with the text from `result.content[0].text`. |
+| Polling deadline exceeded | Red box: *"Generation did not complete within 10 minutes (matches tellr's `JOB_HARD_TIMEOUT_SECONDS`). Check tellr server logs for correlation_id `<id>`."* |
+| `status == "failed"` | Red box with `payload["error"]`. |
+
+All error states leave the correlation ID visible so the user can cross-reference with tellr's logs.
+
+---
+
+## Verification Plan
+
+This harness exists to execute a checklist against a running tellr deployment. v1 is considered shipped when every item on the checklist passes.
+
+1. [ ] Deploy `mcp-test-client` to a Databricks workspace that also has tellr deployed (same workspace).
+2. [ ] Open the test app in a browser. Identity panel shows `x-forwarded-access-token: ✓ present`.
+3. [ ] Paste the tellr URL. Enter a prompt (*"a three-slide briefing on Q3 renewals"*). Click Generate.
+4. [ ] Status panel transitions `pending → running → ready` within a few minutes.
+5. [ ] Result panel iframe renders the deck. `deck_url` link is clickable.
+6. [ ] Open `deck_url` in a new tab — deck opens in tellr's UI, attributed to the signed-in user (**not** the test app's service principal).
+7. [ ] Grep tellr's server logs for the correlation ID. Confirm the MCP tool log line shows `token_source: x-forwarded-access-token` (not `authorization-bearer`).
+
+Steps 6 and 7 together resolve open verification items #1 and #2 in `2026-04-22-tellr-mcp-server-design.md`. Steps 2 and 7 together confirm Databricks Apps injects OBO on app-to-app calls and that tellr's auth helper reads the correct header in priority order.
+
+---
+
+## Rollout
+
+### Deployment order
+
+1. Deploy `mcp-test-client` to the same workspace as tellr. Since the code lives in the Databricks workspace IDE (decision #9), deploy via the workspace UI's "Deploy app" action on that folder, or via `databricks apps deploy` pointing at the workspace path.
+2. Run the verification checklist above.
+3. If any step fails: diagnose via tellr's logs + `st.write` tracing in the test app; update `docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md` with findings; adjust tellr's `mcp_auth.py` if the proxy behavior differs from spec assumptions.
+4. Record completion of the OBO verification in tellr's `docs/technical/mcp-server.md` changelog entry (currently marked as an open verification item).
+
+### Promote-later path
+
+If, after verification, other teams show demand for a reference example:
+
+1. Create `examples/mcp-test-client/` in the tellr repo.
+2. Port `app.py`, `app.yaml`, `requirements.txt`.
+3. Add a `README.md` explaining deployment, expected behavior, and known limitations.
+4. Add a link to the README from `docs/technical/mcp-server.md` section 7.
+5. Do **not** add tests or CI — the example is illustrative, not a tested product.
+
+If no demand materialises, the Databricks workspace copy is the only artifact and no promotion happens.
+
+---
+
+## Open Items
+
+None at spec time. All design decisions above are final pending user review.
+
+---
+
+## v1.1 Roadmap
+
+Explicitly out of v1 but captured in case the harness is promoted:
+
+1. **Edit flow.** Second text area + Refine button that calls `edit_deck` against the current `session_id`.
+2. **Bearer fallback for local iteration.** Environment-variable Bearer token when OBO is absent, so `streamlit run app.py` works locally.
+3. **Structured deck rendering.** Render the `deck.slides` array in a custom grid (iframe-free), exercising section 8.2 of the tellr MCP doc.
+4. **Streaming status.** Bridge MCP `notifications/progress` into the status panel once the tellr server emits them (v1.1 of the tellr MCP spec).
+5. **Reference example promotion.** Full README, air-gapped CDN guidance, a simple Dockerfile for non-Databricks-Apps hosting.
+
+---
+
+## References
+
+- [Tellr MCP Server Design Spec](./2026-04-22-tellr-mcp-server-design.md) — the server this client verifies.
+- [Tellr MCP caller-facing reference](../../technical/mcp-server.md) — rendering recipes and auth recipes this app exercises.
+- [`scripts/mcp_smoke/mcp_smoke_httpx.py`](../../../scripts/mcp_smoke/mcp_smoke_httpx.py) — the laptop-side smoke script this app mirrors for the in-workspace path.

--- a/docs/superpowers/specs/2026-04-23-system-default-slide-style-admin.md
+++ b/docs/superpowers/specs/2026-04-23-system-default-slide-style-admin.md
@@ -1,0 +1,143 @@
+# System Default Slide Style — Admin Affordance
+
+**Date:** 2026-04-23
+**Status:** Design (awaiting user review)
+**Related:** `docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md`
+
+## 1. Problem
+
+Tellr has two parallel "default slide style" mechanisms that can silently diverge:
+
+- **Server side.** `slide_style_library.is_default` is a single global boolean column. The endpoint `POST /api/settings/slide_styles/{id}/set-default` atomically flips it. `get_default_slide_style_id()` reads it. The recent MCP `create_deck` fix relies on this path.
+- **Client side.** The "Set as default" button on the user-facing slide style list writes only to `localStorage.userDefaultSlideStyleId`. It never calls the server endpoint. When the UI picks a default for a new deck, it prefers localStorage over the server value.
+
+Consequence: no UI surface currently changes the DB value, so the server `is_default` row stays pinned to whatever was seeded at install time. The user's experience is "I set style X as my default," but the DB still points at whichever style the seeder happened to mark. MCP reads the DB, gets the seeded style, returns a deck styled differently than the one the user sees in the browser. The MCP fix looks broken from the user's perspective.
+
+## 2. Guiding principle
+
+**Something becomes a system-wide default if and only if it is organizationally meaningful for it to be consistent.**
+
+Applied:
+
+- **Slide style** — visual identity. Consistent across the org is the explicit goal (corporate branding). Gets a system default.
+- **Deck prompt** — content scaffolding. Varies by workload, use case, individual working style. Stays per-user (localStorage).
+- **Profile** — a bundle of tools + configuration. Personal working preference. Stays per-user (localStorage + server `is_default` already exists but is also dormant — out of scope here).
+
+Only slide styles are changed by this design.
+
+## 3. Target behavior
+
+**System default (new).** Exactly one row in `slide_style_library` has `is_default=true`. Changeable only from the hidden `/admin` route. No authentication gating beyond the app's standard user auth ("security through obscurity" — the `/admin` route has no navigation link; a user has to know the URL). This is the corporate-branding default. MCP always uses this value.
+
+**Per-user override (unchanged).** The existing "Set as default" button on the user-facing slide style list continues to write `localStorage.userDefaultSlideStyleId`. A logged-in user who has set a personal default sees their style on new decks. A user who has not sees the system default.
+
+**First-run experience.** A brand-new user logs in, clicks "New Deck," and the deck opens with the system default applied — matching the Google-Slides "follows your corporate branding" expectation.
+
+**MCP.** Always uses the system default; cannot see per-user localStorage. Accepted limitation; in-scope to revisit if per-user defaults ever move server-side.
+
+## 4. Scope
+
+**In scope:**
+- New admin UI affordance at `/admin` → "Slide Style" tab → list of styles with "Set as system default" action.
+- New frontend API client method `setSlideStyleSystemDefault(id)` calling the existing endpoint.
+
+**Out of scope:**
+- Changing deck prompt or profile default behavior.
+- Server-side auth gating on `POST /api/settings/slide_styles/{id}/set-default`.
+- Migrating per-user `localStorage.userDefaultSlideStyleId` entries to server-side storage.
+- Any backend endpoint changes.
+- Any MCP-side changes (the existing `get_default_slide_style_id()` lookup is already correct).
+
+## 5. Files touched
+
+| File | Change | Estimated size |
+|---|---|---|
+| `src/api/routes/settings/slide_styles.py` | Unchanged. `POST /{id}/set-default` already atomic. | 0 LOC |
+| `src/api/mcp_server.py`, `src/core/settings_db.py` | Unchanged. | 0 LOC |
+| `frontend/src/api/config.ts` | Add `setSlideStyleSystemDefault(id: number)` | ~5 LOC |
+| `frontend/src/components/Admin/AdminSlideStyleDefault.tsx` | New. Lists slide styles, marks the `is_default=true` row with a badge, "Set as system default" button on others, confirmation toast on success/failure. | ~100 LOC |
+| `frontend/src/components/Admin/AdminPage.tsx` | Add third tab entry and panel wiring. | ~15 LOC |
+| `frontend/src/components/Admin/__tests__/AdminSlideStyleDefault.test.tsx` | New unit test for the component. | ~40 LOC |
+
+Total: ~160 LOC, one new component, one new API method, one tab added to an existing page.
+
+## 6. Component sketch
+
+```tsx
+// AdminSlideStyleDefault.tsx — shape only, not final code
+const AdminSlideStyleDefault: React.FC = () => {
+  const [styles, setStyles] = useState<SlideStyle[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<number | null>(null);  // id of style being set
+  const { showToast } = useToast();
+
+  const load = async () => { /* configApi.listSlideStyles() */ };
+  useEffect(() => { load(); }, []);
+
+  const handleSet = async (id: number) => {
+    setSaving(id);
+    try {
+      await configApi.setSlideStyleSystemDefault(id);
+      await load();
+      showToast('System default slide style updated', 'success');
+    } catch (e) {
+      showToast(String(e), 'error');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  // Render: list rows with name + "System default" badge on is_default,
+  // "Set as system default" button otherwise. Disabled while saving.
+};
+```
+
+Matches existing `config/SlideStyleList.tsx` visual language so users recognize the surface; only the action differs.
+
+## 7. Data flow
+
+**Admin sets system default:**
+1. User navigates to `/admin` → selects "Slide Style" tab.
+2. Component fetches `configApi.listSlideStyles()` → renders.
+3. User clicks "Set as system default" on row *X*.
+4. Frontend calls new `configApi.setSlideStyleSystemDefault(X)` → `POST /api/settings/slide-styles/{X}/set-default`.
+5. Backend (existing logic): unsets previous `is_default` row, sets *X*.`is_default=true`, commits.
+6. Frontend refreshes the list and shows the updated badge.
+
+**Normal user creates a new deck (unchanged):**
+1. `AgentConfigContext` resolves the default slide style via `resolveDefaultStyleId()`.
+2. Priority: `localStorage.userDefaultSlideStyleId` > server `is_default` > server `is_system`.
+3. Result populates `agent_config.slide_style_id` on the new session.
+
+**MCP `create_deck` (unchanged; uses existing fix):**
+1. Tool handler receives call with no `slide_style_id`.
+2. `_create_deck_impl` calls `get_default_slide_style_id()` → reads DB `is_default=true`.
+3. Resolved ID written to `agent_config.slide_style_id`.
+4. `agent_factory` resolves the style content from the library by ID.
+
+## 8. Error handling / edge cases
+
+- **POST fails (network, 5xx, permission).** Toast surfaces the server error; list doesn't refresh. Same behavior the other admin-panel mutations already use.
+- **No `is_default=true` row** (admin deleted or deactivated the current default). `get_default_slide_style_id()` already falls back to `is_system=true`, then to `None`. MCP treats `None` as "omit `slide_style_id`", and `agent_factory` uses the hardcoded `DEFAULT_SLIDE_STYLE` constant. Not a hard failure.
+- **Inactive style selected as default.** The existing endpoint rejects this (`400 Cannot set an inactive style as default`). Admin UI does not show the "Set as system default" button on inactive rows.
+
+## 9. Testing
+
+- **Backend.** Existing `set_default_slide_style` tests cover the endpoint. No new backend tests.
+- **Frontend unit.** New `AdminSlideStyleDefault.test.tsx`:
+  - Renders the list from a mocked `listSlideStyles` response.
+  - Clicking "Set as system default" calls `setSlideStyleSystemDefault` with the correct id.
+  - After success, the list refetches and the badge moves to the new row.
+  - Error path shows a toast and leaves the list unchanged.
+- **Manual verification after deploy:**
+  1. Visit `/admin`, switch to "Slide Style" tab, click "Set as system default" on a chosen style.
+  2. Open a private browser window (no localStorage), log in, click "New Deck" → confirm the chosen style is applied to the new deck.
+  3. Call MCP `create_deck` with no `slide_style_id` → confirm the returned deck uses the same style.
+  4. In your normal browser (with a localStorage preference set), confirm the personal preference still takes precedence for browser-initiated decks.
+
+## 10. Non-goals / deferred items
+
+- **Admin role enforcement.** The endpoint remains open to any authenticated user. Acceptable for current scale.
+- **Audit log of default changes.** Not tracked beyond the existing server log line in `set_default_slide_style`.
+- **Per-user server-side default.** Not in this change — would be a significant lift (new table, migration, MCP lookup by caller identity). If later user research justifies it, revisit.
+- **Deck prompt or profile defaults.** Left alone per the guiding principle.

--- a/docs/superpowers/specs/2026-04-24-mcp-discoverability-design.md
+++ b/docs/superpowers/specs/2026-04-24-mcp-discoverability-design.md
@@ -1,0 +1,122 @@
+# MCP Discoverability: In-App Help Surface + Docs-Site Navigation
+
+**Date:** 2026-04-24
+**Status:** Design (awaiting user review)
+**Related:** [2026-04-22-tellr-mcp-server-design.md](./2026-04-22-tellr-mcp-server-design.md), [2026-04-23-system-default-slide-style-admin.md](./2026-04-23-system-default-slide-style-admin.md)
+
+## 1. Problem
+
+Tellr's MCP endpoint ships with a full caller-facing technical reference (`docs/technical/mcp-server.md`) and a worked integration guide (`docs/technical/mcp-integration-guide.md`). Neither is reachable from the product itself:
+
+- The in-app help page (`/help`) has tabs for every user-facing feature (Generator, Verification, History, Profiles, Deck Prompts, Slide Styles, Images). It has no mention of MCP anywhere — no tab, no Overview bullet, no deep link.
+- The public docs site (`robertwhiffin.github.io/ai-slide-generator`) deploys the MCP markdown pages but does not list them in the Docusaurus sidebar (`docs-site/sidebars.js`). The pages exist at their URLs but the navigation tree does not surface them.
+
+A user who likes tellr but doesn't already know MCP exists cannot find it. The only discovery path is the GitHub repo itself, which is the opposite of what good product docs should require.
+
+## 2. Principle
+
+**Docs are canonical. The in-app help is a discovery layer.**
+
+The help page should tell a user *MCP exists, here's what it means in two paragraphs, here's your endpoint URL, here's the full guide* — and nothing more. All actionable setup instructions (auth recipes, client configs, troubleshooting) live in the docs. Duplication is disallowed so the two surfaces can't drift.
+
+## 3. Target behavior
+
+### 3.1 Overview tab (existing)
+
+Add one bullet to the "What is databricks tellr?" list in `OverviewTab`:
+
+> Programmatic API via MCP — call tellr from agents, CI, or other apps
+
+The bullet is descriptive, not a link. Its purpose is to surface MCP as a headline capability so a user reading the Overview for the first time sees it alongside "pulls data from Genie" and "iterative editing."
+
+A matching `QuickLinkButton` entry — *Learn about MCP →* — appears in the Overview tab's existing Navigation Quick Links row so the Overview bullet has a one-click path into the MCP tab.
+
+### 3.2 New MCP tab
+
+Appended to the tab strip in last position (after Images). Icon: `FiExternalLink` or a comparable Feather icon already in use (specific choice is cosmetic). Four sections inside:
+
+1. **What is MCP?** — one paragraph, tellr-specific framing. The Model Context Protocol exposes tellr's deck generator as a programmatic endpoint; agents like Claude Code and any HTTP-speaking client can create, edit, and retrieve decks without the browser UI; resulting decks land in the user's history exactly as if they'd created them interactively.
+2. **Who's this for?** — one paragraph distinguishing casual browser users from developer/agent callers. Explicitly says: if you only need interactive generation, stay on the main page.
+3. **Your endpoint** — a code block showing `${window.location.origin}/mcp/` with a Copy button. One line of fine print pointing to the docs for custom-hostname deployments.
+4. **Prerequisites** — two-bullet list: Databricks user token, MCP-capable client (Claude Code / Cursor / Claude Desktop / raw HTTP).
+
+The tab ends with a `DocLink` footer (the existing pattern used by `SlideStylesTab` and `ImagesTab`) linking to `DOCS_URLS.mcpIntegrationGuide`.
+
+### 3.3 Docs URL constants
+
+`frontend/src/constants/docs.ts` gains two new entries:
+
+```ts
+mcpServer: `${DOCS_BASE}/technical/mcp-server`,
+mcpIntegrationGuide: `${DOCS_BASE}/technical/mcp-integration-guide`,
+```
+
+The naming mirrors the file slugs so future readers can find the source markdown at a glance. `mcpServer` is currently unreferenced in component code — it's added proactively so that any future spot wanting to link to the protocol reference has a canonical constant instead of an ad-hoc URL.
+
+### 3.4 Docs-site navigation
+
+`docs-site/sidebars.js` — the `technical` sidebar appends two items:
+
+```js
+'technical/mcp-server',
+'technical/mcp-integration-guide',
+```
+
+Flat entries in the existing "Technical Documentation" category. Two pages is not enough to justify a nested subcategory.
+
+## 4. Scope
+
+**In scope:**
+
+- Overview tab: one new bullet + one new Quick Link button.
+- New MCP tab with the four sections above.
+- Two new `DOCS_URLS` entries.
+- Two sidebar entries on the docs site.
+- Playwright coverage of the new help surface (see §7).
+
+**Out of scope:**
+
+- Writing any new MCP documentation — the docs are complete.
+- Backend or MCP code changes — none needed.
+- Auth gating or per-user admin enforcement — this surface is informational.
+- Showing the MCP endpoint on any page other than the help MCP tab.
+- Teaching MCP on the help page (auth recipes, code snippets, troubleshooting all stay in the docs per §2).
+- Adding "MCP" as a header nav item or toolbar button — discoverability via the help page is sufficient for v1.
+
+## 5. Files touched
+
+| File | Change | Estimated size |
+|---|---|---|
+| `frontend/src/constants/docs.ts` | Two new entries. | ~4 LOC |
+| `frontend/src/components/Help/HelpPage.tsx` | `HelpTab` union gains `'mcp'`; new `TabButton`; new `QuickLinkButton` on Overview; new bullet on Overview "What is" list; new `MCPTab` component in-file (matches existing single-file convention). | ~110 LOC |
+| `docs-site/sidebars.js` | Append two page slugs to the `technical` category's `items` array. | ~2 LOC |
+| `frontend/tests/e2e/help-ui.spec.ts` | New Playwright cases covering the MCP tab and Overview bullet (see §7). | ~50 LOC |
+
+Total: ~170 LOC across four files, purely additive.
+
+## 6. Data flow
+
+**At render time.** `MCPTab` reads `window.location.origin` directly (no props, no state, no fetch), concatenates `/mcp/`, and renders it in the code block. This is the same origin the browser used to load tellr, which in Databricks Apps production is the correct MCP endpoint host for external callers. In local development it yields `http://localhost:3000/mcp/` — which is the Vite proxy URL, not the backend — but the fine-print caveat and docs link cover that edge.
+
+**Copy button.** `navigator.clipboard.writeText(mcpEndpoint)` with a `.then()` firing a success toast via the existing `useToast` hook. `.catch()` fires an error toast whose message includes the endpoint string so a user without clipboard access can select it from the toast (or from the code block itself, which remains visible).
+
+**Overview bullet + Quick Link.** Static JSX. The Quick Link calls `setActiveTab('mcp')` using the existing callback prop on `OverviewTab`.
+
+## 7. Testing
+
+Playwright (the only frontend test framework in this repo). Extend `frontend/tests/e2e/help-ui.spec.ts`:
+
+- **Overview bullet renders.** After `page.goto('/help')`, the text *Programmatic API via MCP* is visible in the Overview tab.
+- **MCP tab appears in the tab strip.** `page.getByRole('tab', { name: 'MCP' })` is visible.
+- **Clicking MCP shows its content.** After clicking the MCP tab, the *What is MCP?* heading is visible; the *Your endpoint* heading is visible; the endpoint code block contains `/mcp/` and the current origin.
+- **Copy button is present.** `page.getByRole('button', { name: /copy/i })` inside the MCP panel is clickable. (Testing actual clipboard write is finicky across browsers; asserting clickability is sufficient.)
+- **DocLink target.** The footer "MCP Integration Guide" link's `href` matches `DOCS_URLS.mcpIntegrationGuide`. Assert on the rendered attribute, not on the constant — keeps the test honest if the constant value changes.
+- **Quick Link navigates into the MCP tab.** Clicking "Learn about MCP →" on the Overview tab activates the MCP panel.
+
+The endpoint-string assertion uses substring matching (`toContain('/mcp/')`) so the test does not encode Playwright's `baseURL` and continues to work if it changes.
+
+## 8. Non-goals / deferred items
+
+- **Per-deployment URL override.** If an admin wants the help tab to advertise a canonical production URL different from `window.location.origin`, that's a future change (likely an env var the backend injects into the page). Not needed for v1.
+- **Interactive MCP tester on the help page.** A button that issues a live `tools/list` against the endpoint and shows the result. Plausibly useful but pure v1.1 material and duplicates the smoke script's purpose.
+- **Linking to the admin slide style default from the MCP tab.** Users who use MCP care about the system default (since MCP can't see their personal override). Consider a cross-link in a follow-up once both features are live.

--- a/docs/technical/database-configuration.md
+++ b/docs/technical/database-configuration.md
@@ -228,7 +228,7 @@ class SlideStyleLibrary(Base):
     image_guidelines: str | None # Markdown instructions for image usage in slides
     is_active: bool              # Whether available for selection
     is_system: bool              # Protected system styles (cannot be edited/deleted)
-    is_default: bool             # Which style is applied to new sessions by default
+    is_default: bool             # System-wide default. Exactly one row is true at a time; settable only from the /admin "Slide Style" tab. Read by the server-side default resolver and by MCP create_deck when the caller omits slide_style_id.
     created_by: str | None
     created_at: datetime
     updated_by: str | None

--- a/docs/technical/frontend-overview.md
+++ b/docs/technical/frontend-overview.md
@@ -146,7 +146,9 @@ Used by: `AgentConfigBar`, `ChatPanel`.
 | Slide Style | `userDefaultSlideStyleId` | localStorage > server `is_default` > server `is_system` |
 | Deck Prompt | `userDefaultDeckPromptId` | localStorage only (no server-side default) |
 
-Users set their defaults via the "Set as default" button on each settings page (`/profiles`, `/slide-styles`, `/deck-prompts`). The preference is per-browser, not synced to the backend.
+Users set their personal defaults via the "Set as default" button on each settings page (`/profiles`, `/slide-styles`, `/deck-prompts`). The preference is per-browser, not synced to the backend.
+
+For slide styles specifically, the server-side `is_default` row is the **system-wide corporate default**, set only from the hidden `/admin` → "Slide Style" tab. New users (who haven't clicked "Set as default" on any slide style in their browser) see the corporate default on every new deck, mirroring the "new Google Slides deck follows corporate branding" experience. MCP `create_deck` always uses the system default — it cannot read per-user localStorage — so flipping the admin choice instantly affects all MCP-initiated decks.
 
 ### 4c. Profile Context (`src/contexts/ProfileContext.tsx`)
 

--- a/docs/technical/mcp-integration-guide.md
+++ b/docs/technical/mcp-integration-guide.md
@@ -101,18 +101,19 @@ def _rpc(
 
 
 def _open_session(client: httpx.Client, url: str) -> dict:
-    """Run initialize + notifications/initialized; return mcp-session-id header.
+    """Run initialize + notifications/initialized; return any session header.
 
-    Each tool call should open its own session — see "Gotcha: MCP session
-    lifetime" below for why.
+    tellr runs FastMCP stateless, so the server does not emit
+    ``mcp-session-id``. We still run the handshake shape real clients
+    send, and forward a session id if the server does return one.
     """
     init_resp, _ = _rpc(client, url, "initialize", params={
         "protocolVersion": "2025-03-26",
         "capabilities": {},
         "clientInfo": {"name": "my-app", "version": "0.1"},
     }, id_=1)
-    sid = init_resp.headers["mcp-session-id"]
-    headers = {"mcp-session-id": sid}
+    sid = init_resp.headers.get("mcp-session-id")
+    headers = {"mcp-session-id": sid} if sid else {}
     _rpc(client, url, "notifications/initialized", extra_headers=headers)
     return headers
 
@@ -221,10 +222,8 @@ Open the deployed app's URL, paste your tellr app URL, enter a prompt, click Gen
 **Gotcha 1 — Don't send `Authorization: Bearer` or forward the OBO token.**
 It gets stripped by the proxy. Tellr sees nothing and returns "Authentication required: no credentials presented." The correct pattern is to send no auth headers at all from your app and rely on the proxy's identity headers.
 
-**Gotcha 2 — MCP transport sessions age out mid-poll.**
-FastMCP (the MCP server library tellr uses) tracks sessions by the `mcp-session-id` returned from `initialize`. For reasons that aren't fully obvious, active polling on a session does not reset its lifetime; a 5+ minute generation will eventually hit HTTP 404 `"Session not found"` on a poll even if you're polling every 2 seconds.
-
-Workaround: **open a fresh MCP session per tool call.** The helper `_open_session` in the example above does this. The server-side deck session (identified by `session_id` + `request_id` in the `create_deck` response) is separate from the MCP transport session and is fully persistent, so re-initialising the transport between polls is safe and cheap.
+**Gotcha 2 — Tellr's MCP endpoint is stateless; don't require `mcp-session-id`.**
+Tellr runs FastMCP with `stateless_http=True` because the app is served by multiple uvicorn workers and the Databricks Apps proxy does not guarantee session affinity — a stateful handshake's three requests (`initialize` → `notifications/initialized` → `tools/call`) can otherwise split across workers and produce HTTP 404 `"Session not found"`. In stateless mode the server doesn't emit `mcp-session-id` at all; read it with `.get()` rather than `[…]` and only echo it on follow-ups if it's present. The server-side deck session (identified by `session_id` + `request_id` in the `create_deck` response) is a separate app-level concept and is fully persistent.
 
 **Gotcha 3 — `deck_url` might be relative.**
 If tellr's `DATABRICKS_APP_URL` env var is unset, `deck_url` comes back as a path-only string like `/sessions/.../edit`. Rendered in your app, the browser will resolve it against *your app's* origin, not tellr's. Databricks Apps sets `DATABRICKS_APP_URL` automatically on production deployments, so this should only bite during local dev or misconfigured environments.
@@ -428,7 +427,7 @@ Full schemas and examples: [`mcp-server.md`](./mcp-server.md) section 5.
 | `Authentication required: no credentials presented` | No auth headers arrived (proxy stripped them, or external caller didn't send a Bearer). | App-to-app: confirm `x-forwarded-email` is set on your app's inbound requests. External: check your Bearer header is reaching tellr (curl the `/api/health` endpoint with the same token). |
 | `HTTP 401` (empty body `{}`) on external `/mcp/` calls | You're using a PAT (`dapi...`); the Apps proxy rejects PATs for app access. | Switch to an OAuth U2M token via a `databricks-cli` auth profile — see §3.1. |
 | `HTTP 401` mid-session after working fine earlier | OAuth access token (~1-hour lifetime) has expired; `claude mcp add` stored it as a static header. | Re-register the MCP server with a fresh token — see §3.3 (`tellr-refresh` one-liner). |
-| `HTTP 404 {"message": "Session not found"}` | The `mcp-session-id` you're reusing has expired. | Open a fresh MCP session (re-run `initialize` + `notifications/initialized`) per tool call in long-running poll loops. |
+| `HTTP 404 {"message": "Session not found"}` | Your client is echoing an `mcp-session-id` against tellr's stateless endpoint while the request is routed to a different worker than the one that (historically) issued the id. Should not occur with current tellr builds. | Treat `mcp-session-id` as optional — read with `.get()`, only echo when present. Upgrade to a current tellr build if calls against a prior deployment produce this error. |
 | `create_deck tool error: ...` | Tool execution failed after auth succeeded (LLM error, input validation, etc.). | Read the error text — it's the underlying reason. |
 | `Deck not found or you do not have permission to view it` | Your identity doesn't match the deck's creator and you're not a contributor. | Check `created_by` on the deck; use the creator's identity or share the deck. |
 

--- a/docs/technical/mcp-integration-guide.md
+++ b/docs/technical/mcp-integration-guide.md
@@ -227,7 +227,7 @@ FastMCP (the MCP server library tellr uses) tracks sessions by the `mcp-session-
 Workaround: **open a fresh MCP session per tool call.** The helper `_open_session` in the example above does this. The server-side deck session (identified by `session_id` + `request_id` in the `create_deck` response) is separate from the MCP transport session and is fully persistent, so re-initialising the transport between polls is safe and cheap.
 
 **Gotcha 3 — `deck_url` might be relative.**
-If tellr's `TELLR_APP_URL` (or `DATABRICKS_APP_URL`) env var is unset, `deck_url` comes back as a path-only string like `/sessions/.../edit`. Rendered in your app, the browser will resolve it against *your app's* origin, not tellr's. On production tellr deployments both envs should be set; if you're seeing this, check tellr's deployment config.
+If tellr's `DATABRICKS_APP_URL` env var is unset, `deck_url` comes back as a path-only string like `/sessions/.../edit`. Rendered in your app, the browser will resolve it against *your app's* origin, not tellr's. Databricks Apps sets `DATABRICKS_APP_URL` automatically on production deployments, so this should only bite during local dev or misconfigured environments.
 
 **Gotcha 4 — Generation time.**
 Single-slide prompts generate in ~10-30s, 10-slide decks take 3-8 minutes. The hard server-side timeout is 10 minutes (`JOB_HARD_TIMEOUT_SECONDS`). Match your client deadline to it or shorter.

--- a/docs/technical/mcp-integration-guide.md
+++ b/docs/technical/mcp-integration-guide.md
@@ -444,7 +444,6 @@ Full schemas and examples: [`mcp-server.md`](./mcp-server.md) section 5.
 
 - [`mcp-server.md`](./mcp-server.md) — protocol-level reference, full tool schemas, transport details.
 - [`permissions-model.md`](./permissions-model.md) — `can_view_deck` / `can_edit_deck` semantics.
-- Design spec: [`docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md`](../superpowers/specs/2026-04-22-tellr-mcp-server-design.md) — architecture rationale and v1.1 roadmap.
 
 ### 4.5 Getting help
 

--- a/docs/technical/mcp-integration-guide.md
+++ b/docs/technical/mcp-integration-guide.md
@@ -1,0 +1,338 @@
+# Tellr MCP Integration Guide
+
+**One-line:** How to call tellr's deck-generation tools from another app or from an MCP-compatible agent, with the gotchas we learned the hard way.
+
+This is a **how-to** for builders. For the protocol-level reference (tool schemas, JSON-RPC shapes, response payloads) see [`mcp-server.md`](./mcp-server.md).
+
+---
+
+## 1. Which integration pattern is yours?
+
+Two distinct patterns, different auth, different code:
+
+| Pattern | When to use | Auth source |
+|---|---|---|
+| **A. Databricks App → tellr** (in-workspace) | You're building another Databricks App that should create decks on behalf of the signed-in user. | Identity headers injected by the Databricks Apps proxy (`x-forwarded-email`, `x-forwarded-user`). No token — tellr trusts the proxy. |
+| **B. External agent → tellr** (laptop / CI / CLI) | You're wiring tellr into an MCP client like Claude Code, Claude Desktop, or Cursor, or calling from a script outside Databricks Apps. | User-supplied Databricks PAT, sent as `Authorization: Bearer`. |
+
+Pick one and jump to its section. If you need both (e.g., a tool that runs in an app but also has a local-dev mode), build each path separately rather than trying to unify them — the auth models are fundamentally different.
+
+---
+
+## 2. Part A — Databricks App → tellr
+
+### 2.1 Why this path looks different
+
+When Databricks App A calls Databricks App B (both in the same workspace), the Databricks Apps proxy sits between them and **re-writes the auth layer**:
+
+- Any `Authorization: Bearer <token>` header the caller sends is **stripped on ingress** (security: prevents a malicious app from replaying tokens it shouldn't have).
+- Any caller-supplied `x-forwarded-access-token` is also **stripped**.
+- Instead, the proxy **injects** `x-forwarded-email`, `x-forwarded-user`, `x-forwarded-preferred-username` based on the signed-in user who hit app A.
+
+Net result: **the receiving app cannot get a user token; it only gets a proxy-attested identity.** Any Databricks SDK calls the receiving app needs to make use the receiving app's own service principal credentials. User attribution (who created the deck, whose name shows in tellr's UI) still comes from the forwarded identity headers.
+
+Tellr supports this explicitly. When the `TELLR_TRUST_FORWARDED_IDENTITY` env var is set on tellr's deployment (it is, by default), `x-forwarded-email` + `x-forwarded-user` are accepted as identity — *only* from the Databricks Apps proxy, because the proxy strips any caller-supplied versions first.
+
+### 2.2 Minimal working integration (Streamlit example)
+
+The harness below is a complete Databricks App that creates a deck on tellr via MCP and renders it inline. Drop it into a workspace folder, deploy as a Databricks App, done.
+
+**`app.py`:**
+
+```python
+"""Minimum viable tellr MCP integration for a Databricks App."""
+
+from __future__ import annotations
+import json, time, uuid
+import httpx
+import streamlit as st
+
+st.set_page_config(page_title="Tellr integration", layout="centered")
+st.title("Tellr integration")
+
+# ---- Identity: read forwarded identity from the proxy ---------------------
+# The Databricks Apps proxy sets these on every inbound request. If they're
+# absent, you're running locally — stop and explain.
+email = st.context.headers.get("x-forwarded-email")
+if not email:
+    st.error(
+        "Not running behind the Databricks Apps proxy. "
+        "Deploy this app to a Databricks workspace to test the integration."
+    )
+    st.stop()
+
+st.caption(f"Signed in as: {email}")
+
+# ---- Inputs ---------------------------------------------------------------
+tellr_url = st.text_input(
+    "Tellr app URL",
+    placeholder="https://<tellr-app>.databricksapps.com",
+).rstrip("/")
+prompt = st.text_area("Prompt", height=120)
+generate = st.button(
+    "Generate",
+    disabled=not (tellr_url and prompt.strip()),
+    type="primary",
+)
+
+
+# ---- MCP helpers ----------------------------------------------------------
+def _decode(resp: httpx.Response) -> dict:
+    """MCP may respond with JSON or SSE; handle both."""
+    if "event-stream" in resp.headers.get("content-type", "").lower():
+        for line in resp.text.splitlines():
+            if line.startswith("data:"):
+                return json.loads(line[5:].strip())
+        raise RuntimeError("SSE response without data frame")
+    return resp.json()
+
+
+def _rpc(
+    client: httpx.Client, url: str, method: str,
+    params: dict | None = None, id_: int | None = None,
+    extra_headers: dict | None = None,
+) -> tuple[httpx.Response, dict | None]:
+    body = {"jsonrpc": "2.0", "method": method}
+    if id_ is not None: body["id"] = id_
+    if params is not None: body["params"] = params
+    resp = client.post(url, json=body, headers=extra_headers or {})
+    resp.raise_for_status()
+    return resp, (_decode(resp) if id_ is not None else None)
+
+
+def _open_session(client: httpx.Client, url: str) -> dict:
+    """Run initialize + notifications/initialized; return mcp-session-id header.
+
+    Each tool call should open its own session — see "Gotcha: MCP session
+    lifetime" below for why.
+    """
+    init_resp, _ = _rpc(client, url, "initialize", params={
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "my-app", "version": "0.1"},
+    }, id_=1)
+    sid = init_resp.headers["mcp-session-id"]
+    headers = {"mcp-session-id": sid}
+    _rpc(client, url, "notifications/initialized", extra_headers=headers)
+    return headers
+
+
+def generate_deck(tellr_base: str, prompt_text: str, status) -> dict:
+    """Submit create_deck → poll get_deck_status → return ready payload."""
+    mcp = f"{tellr_base}/mcp/"
+    correlation = f"my-app-{uuid.uuid4().hex[:8]}"
+
+    # No Authorization header, no x-forwarded-access-token — the proxy
+    # will strip them. Tellr identifies the user via the forwarded headers
+    # that *its own* inbound proxy sets.
+    base_headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with httpx.Client(timeout=60, headers=base_headers) as c:
+        # Submit
+        status.info(f"Submitting… correlation_id={correlation}")
+        sess_hdrs = _open_session(c, mcp)
+        _, payload = _rpc(c, mcp, "tools/call", params={
+            "name": "create_deck",
+            "arguments": {"prompt": prompt_text, "correlation_id": correlation},
+        }, id_=2, extra_headers=sess_hdrs)
+        if payload["result"].get("isError"):
+            raise RuntimeError(payload["result"]["content"][0]["text"])
+        submit = json.loads(payload["result"]["content"][0]["text"])
+
+        # Poll — fresh MCP session per iteration; see gotcha below
+        deadline = time.time() + 600
+        n = 100
+        while time.time() < deadline:
+            time.sleep(2)
+            poll_hdrs = _open_session(c, mcp)
+            _, payload = _rpc(c, mcp, "tools/call", params={
+                "name": "get_deck_status",
+                "arguments": {
+                    "session_id": submit["session_id"],
+                    "request_id": submit["request_id"],
+                },
+            }, id_=n, extra_headers=poll_hdrs)
+            n += 1
+            if payload["result"].get("isError"):
+                raise RuntimeError(payload["result"]["content"][0]["text"])
+            data = json.loads(payload["result"]["content"][0]["text"])
+            status.info(
+                f"status={data['status']} "
+                f"elapsed={int(time.time() - (deadline - 600))}s"
+            )
+            if data["status"] == "ready":
+                return data
+            if data["status"] == "failed":
+                raise RuntimeError(data.get("error", "generation failed"))
+
+    raise TimeoutError("Generation did not complete within 10 minutes")
+
+
+# ---- Wire it up -----------------------------------------------------------
+if generate:
+    slot = st.empty()
+    try:
+        result = generate_deck(tellr_url, prompt.strip(), slot)
+    except Exception as e:
+        slot.error(f"Failed: {e}")
+    else:
+        slot.success(f"Ready — {result['slide_count']} slides, "
+                     f"title: {result['title']!r}")
+        st.link_button("Open in tellr", result["deck_url"])
+        st.components.v1.html(
+            result["html_document"], height=600, scrolling=True
+        )
+```
+
+**`app.yaml`:**
+
+```yaml
+command:
+  - "sh"
+  - "-c"
+  - |
+    pip install -r requirements.txt && streamlit run app.py \
+      --server.port=$DATABRICKS_APP_PORT \
+      --server.address=0.0.0.0 \
+      --server.headless=true
+```
+
+**`requirements.txt`:**
+
+```
+streamlit>=1.32
+httpx>=0.27
+```
+
+### 2.3 Deploy
+
+```bash
+databricks apps create my-tellr-integration
+databricks apps deploy my-tellr-integration \
+  --source-code-path /Workspace/Users/<you>@databricks.com/<folder>
+```
+
+Open the deployed app's URL, paste your tellr app URL, enter a prompt, click Generate. The resulting deck appears both in-app (iframe) and in the tellr UI attributed to you.
+
+### 2.4 Gotchas we learned
+
+**Gotcha 1 — Don't send `Authorization: Bearer` or forward the OBO token.**
+It gets stripped by the proxy. Tellr sees nothing and returns "Authentication required: no credentials presented." The correct pattern is to send no auth headers at all from your app and rely on the proxy's identity headers.
+
+**Gotcha 2 — MCP transport sessions age out mid-poll.**
+FastMCP (the MCP server library tellr uses) tracks sessions by the `mcp-session-id` returned from `initialize`. For reasons that aren't fully obvious, active polling on a session does not reset its lifetime; a 5+ minute generation will eventually hit HTTP 404 `"Session not found"` on a poll even if you're polling every 2 seconds.
+
+Workaround: **open a fresh MCP session per tool call.** The helper `_open_session` in the example above does this. The server-side deck session (identified by `session_id` + `request_id` in the `create_deck` response) is separate from the MCP transport session and is fully persistent, so re-initialising the transport between polls is safe and cheap.
+
+**Gotcha 3 — `deck_url` might be relative.**
+If tellr's `TELLR_APP_URL` (or `DATABRICKS_APP_URL`) env var is unset, `deck_url` comes back as a path-only string like `/sessions/.../edit`. Rendered in your app, the browser will resolve it against *your app's* origin, not tellr's. On production tellr deployments both envs should be set; if you're seeing this, check tellr's deployment config.
+
+**Gotcha 4 — Generation time.**
+Single-slide prompts generate in ~10-30s, 10-slide decks take 3-8 minutes. The hard server-side timeout is 10 minutes (`JOB_HARD_TIMEOUT_SECONDS`). Match your client deadline to it or shorter.
+
+**Gotcha 5 — `x-forwarded-email` is authoritative; you don't need to verify it.**
+The proxy sets it, strips any caller-supplied version, and signs the whole interaction with TLS. Trusting it at face value is safe *only* when you're behind the Databricks Apps proxy. Don't copy this pattern to services that aren't.
+
+---
+
+## 3. Part B — External agent → tellr (Claude Code / Cursor / CLI)
+
+When your MCP client is running *outside* Databricks Apps — on your laptop, in CI, or in a non-Databricks service — the proxy isn't in the way, and Databricks Apps is happy to accept an `Authorization: Bearer` header. So the integration is much simpler.
+
+### 3.1 Auth: get a Databricks PAT
+
+```bash
+# Short-lived (auto-refreshed):
+databricks auth token | jq -r .access_token
+
+# Or create a long-lived PAT via workspace UI:
+# User Settings → Developer → Access tokens → Generate new token
+```
+
+Export it:
+
+```bash
+export DATABRICKS_TOKEN=<your-token>
+```
+
+### 3.2 Wire it into your MCP client
+
+**Claude Code / Claude Desktop:**
+
+```bash
+claude mcp add --transport http tellr "https://<tellr-app-url>/mcp/" \
+  --header "Authorization: Bearer $DATABRICKS_TOKEN"
+```
+
+Then in a Claude session, run `/mcp` to confirm `tellr` shows `connected` with four tools (`create_deck`, `get_deck_status`, `edit_deck`, `get_deck`). Ask Claude to make a deck:
+
+> Create a three-slide deck summarising our Q3 renewals, then give me the deck URL.
+
+**Cursor / other streamable-HTTP clients:** same URL + header pattern in whatever config shape your client uses. Example shape:
+
+```json
+{
+  "mcpServers": {
+    "tellr": {
+      "url": "https://<tellr-app-url>/mcp/",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer ${DATABRICKS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### 3.3 Gotchas
+
+**Token expiry.** `databricks auth token` tokens last ~1 hour. When Claude starts reporting "Authentication failed" mid-session, refresh and re-register the MCP server. PATs last as configured by the workspace admin.
+
+**Trailing slash on the URL.** Always POST to `/mcp/` (with slash). `/mcp` (no slash) returns a 307 redirect that some clients silently downgrade to GET and break on. The `claude mcp add` command sometimes strips the trailing slash — double-check with `claude mcp list`.
+
+**Handshake.** After `initialize`, MCP requires a `notifications/initialized` before any `tools/*`. The official MCP clients handle this for you; if you're writing raw HTTP, don't skip it.
+
+---
+
+## 4. Reference appendix
+
+### 4.1 Tool catalog summary
+
+| Tool | Purpose | Key inputs | Key outputs |
+|---|---|---|---|
+| `create_deck` | Generate a new deck from a prompt | `prompt`, `num_slides?` | `session_id`, `request_id`, `status: pending` |
+| `get_deck_status` | Poll for completion and retrieve ready deck | `session_id`, `request_id` | `status`, plus (on ready) `deck`, `html_document`, `deck_url`, `deck_view_url` |
+| `edit_deck` | Refine an existing deck via instruction | `session_id`, `instruction`, `slide_indices?` | `request_id` (poll via `get_deck_status`) |
+| `get_deck` | Re-read current deck state without submitting work | `session_id` | Same shape as `get_deck_status` ready response, minus `status`/`messages` |
+
+Full schemas and examples: [`mcp-server.md`](./mcp-server.md) section 5.
+
+### 4.2 Common errors
+
+| Error text | Cause | Fix |
+|---|---|---|
+| `Authentication required: no credentials presented` | No auth headers arrived (proxy stripped them, or external caller didn't send a Bearer). | App-to-app: confirm `x-forwarded-email` is set on your app's inbound requests. External: check your Bearer header is reaching tellr (curl the `/api/health` endpoint with the same token). |
+| `HTTP 404 {"message": "Session not found"}` | The `mcp-session-id` you're reusing has expired. | Open a fresh MCP session (re-run `initialize` + `notifications/initialized`) per tool call in long-running poll loops. |
+| `create_deck tool error: ...` | Tool execution failed after auth succeeded (LLM error, input validation, etc.). | Read the error text — it's the underlying reason. |
+| `Deck not found or you do not have permission to view it` | Your identity doesn't match the deck's creator and you're not a contributor. | Check `created_by` on the deck; use the creator's identity or share the deck. |
+
+### 4.3 v1 limitations
+
+- **Prompt-only generation.** The agent does not call Genie, Vector Search, or other data tools on your behalf. If you want data-backed decks, gather the data yourself and include it in the prompt.
+- **No exports over MCP.** `export_pptx` / `export_google_slides` are v1.1; for now, hand users to `deck_url` for exports in the tellr UI.
+- **No structural edits.** Reorder / delete / duplicate slides are v1.1.
+- **No cancellation.** There's a 10-minute hard timeout but no way to abort an in-flight generation.
+- **No streaming progress.** Status transitions are polling-based; `notifications/progress` is v1.1.
+
+### 4.4 Further reading
+
+- [`mcp-server.md`](./mcp-server.md) — protocol-level reference, full tool schemas, transport details.
+- [`permissions-model.md`](./permissions-model.md) — `can_view_deck` / `can_edit_deck` semantics.
+- Design spec: [`docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md`](../superpowers/specs/2026-04-22-tellr-mcp-server-design.md) — architecture rationale and v1.1 roadmap.
+
+### 4.5 Getting help
+
+- Something broken? Include the `correlation_id` from your tool error — server logs are keyed on it.
+- Design question / feature request? Open a PR against the design spec v1.1 roadmap section.

--- a/docs/technical/mcp-integration-guide.md
+++ b/docs/technical/mcp-integration-guide.md
@@ -13,7 +13,7 @@ Two distinct patterns, different auth, different code:
 | Pattern | When to use | Auth source |
 |---|---|---|
 | **A. Databricks App → tellr** (in-workspace) | You're building another Databricks App that should create decks on behalf of the signed-in user. | Identity headers injected by the Databricks Apps proxy (`x-forwarded-email`, `x-forwarded-user`). No token — tellr trusts the proxy. |
-| **B. External agent → tellr** (laptop / CI / CLI) | You're wiring tellr into an MCP client like Claude Code, Claude Desktop, or Cursor, or calling from a script outside Databricks Apps. | User-supplied Databricks PAT, sent as `Authorization: Bearer`. |
+| **B. External agent → tellr** (laptop / CI / CLI) | You're wiring tellr into an MCP client like Claude Code, Claude Desktop, or Cursor, or calling from a script outside Databricks Apps. | User OAuth (U2M) access token from a `databricks-cli` profile, sent as `Authorization: Bearer`. **PATs do not work against Databricks Apps** — see §3.1. |
 
 Pick one and jump to its section. If you need both (e.g., a tool that runs in an app but also has a local-dev mode), build each path separately rather than trying to unify them — the auth models are fundamentally different.
 
@@ -239,38 +239,125 @@ The proxy sets it, strips any caller-supplied version, and signs the whole inter
 
 ## 3. Part B — External agent → tellr (Claude Code / Cursor / CLI)
 
-When your MCP client is running *outside* Databricks Apps — on your laptop, in CI, or in a non-Databricks service — the proxy isn't in the way, and Databricks Apps is happy to accept an `Authorization: Bearer` header. So the integration is much simpler.
+When your MCP client is running *outside* Databricks Apps — on your laptop, in CI, or in a non-Databricks service — the proxy isn't in the way and Databricks Apps will accept a user bearer token in the `Authorization` header. Two ways to get that token in place:
 
-### 3.1 Auth: get a Databricks PAT
+1. **§3.2 Auto-discovered OAuth (recommended).** Your MCP client does the full OAuth dance itself: browser consent once, refresh token cached, silent renewal thereafter. Works with any MCP-spec-compliant client.
+2. **§3.3 Static OAuth token (fallback).** You mint the token yourself with the Databricks CLI and paste it into the client's header config. Simple; requires manual refresh every ~1 hour.
 
-```bash
-# Short-lived (auto-refreshed):
-databricks auth token | jq -r .access_token
+Whichever path you pick, the one thing you **can't** do is use a PAT — see §3.1.
 
-# Or create a long-lived PAT via workspace UI:
-# User Settings → Developer → Access tokens → Generate new token
-```
+### 3.1 Auth constraint: OAuth U2M only, not PATs
 
-Export it:
+**Verified gotcha:** even a PAT that works against workspace APIs returns HTTP 401 from an app's `/mcp/` endpoint. The Apps proxy has its own authorization layer and only accepts OAuth U2M tokens for app-scoped access. Concretely:
 
 ```bash
-export DATABRICKS_TOKEN=<your-token>
+# PAT against workspace API — works:
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  "https://<workspace>/api/2.0/preview/scim/v2/Me" \
+  -H "Authorization: Bearer dapi<...>"
+# → 200
+
+# Same PAT against the tellr app's MCP endpoint — rejected:
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST \
+  "https://<tellr-app-url>/mcp/" \
+  -H "Authorization: Bearer dapi<...>" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+# → 401
 ```
 
-### 3.2 Wire it into your MCP client
+Save PATs for workspace REST APIs; for Databricks Apps (including tellr), always use an OAuth user access token.
 
-**Claude Code / Claude Desktop:**
+### 3.2 Auto-discovered OAuth (recommended, general-purpose)
+
+This is a spec-level feature — not Claude Code specific. The [MCP authorization spec](https://modelcontextprotocol.io/specification/) uses [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) *OAuth 2.0 Protected Resource Metadata* plus OAuth 2.1 with Dynamic Client Registration. Any spec-compliant MCP client (Claude Code, Claude Desktop, Cursor, VS Code MCP, Continue, etc.) can auto-discover the OAuth server and run the flow on your behalf.
+
+How it works end-to-end:
+
+1. You register the MCP server in your client with a URL and **no** bearer header.
+2. First tool call goes unauthenticated → server returns HTTP 401 with a `WWW-Authenticate` header pointing at `/.well-known/oauth-protected-resource`.
+3. Client fetches that metadata — for a Databricks App it looks like:
+   ```json
+   {
+     "resource": "https://<tellr-app-url>",
+     "authorization_servers": ["https://<workspace>/oidc"],
+     "scopes_supported": ["sql", "iam.current-user:read", ...]
+   }
+   ```
+4. Client performs Dynamic Client Registration against the authorization server, opens a browser for user consent, receives an access token + refresh token, and caches them.
+5. Subsequent calls use the access token; when it expires, the client uses the refresh token to mint a new one silently. **No manual refresh ever.**
+
+First-tool-call UX: a browser tab pops open for consent. Afterwards, invisible.
+
+**Client-specific wiring:**
+
+*Claude Code:*
+
+```bash
+claude mcp add --transport http tellr "https://<tellr-app-url>/mcp/"
+# (no --header flag — that's what triggers the OAuth flow on first use)
+```
+
+Then in a Claude session, invoke any tellr tool (or run `/mcp`); a browser window opens for consent, you sign in, done.
+
+*Cursor / other streamable-HTTP clients:* drop the `headers` block from your config:
+
+```json
+{
+  "mcpServers": {
+    "tellr": {
+      "url": "https://<tellr-app-url>/mcp/",
+      "transport": "streamable-http"
+    }
+  }
+}
+```
+
+*Generic:* any client that claims MCP authorization support needs only the URL; it will handle discovery + browser consent + refresh token storage itself.
+
+**When auto-discovery won't work:**
+
+- Your MCP client hasn't implemented the MCP authorization spec yet (check its release notes).
+- You're running headless / in CI / on a box with no browser — the OAuth consent step can't complete interactively. Use §3.3.
+- You need to pin a specific identity (e.g., a service principal) rather than the interactive user who runs the consent flow.
+
+### 3.3 Static OAuth token (fallback)
+
+When your client doesn't support MCP OAuth discovery, or you're running headless, you can mint an OAuth U2M token via the Databricks CLI and paste it into the client's header config yourself.
+
+One-time profile setup in `~/.databrickscfg`:
+
+```ini
+[tellr-dev-oauth]
+host      = https://<tellr-workspace>.cloud.databricks.com/
+auth_type = databricks-cli
+```
+
+One-time OAuth handshake (opens a browser, caches the refresh token locally under `~/.databricks/`):
+
+```bash
+databricks auth login -p tellr-dev-oauth
+```
+
+Then `databricks auth token -p tellr-dev-oauth` silently mints a fresh ~1-hour access token on demand (using the cached refresh token — no browser round-trip):
+
+```bash
+databricks auth token -p tellr-dev-oauth | jq -r .access_token
+```
+
+Wire it up:
+
+*Claude Code:*
 
 ```bash
 claude mcp add --transport http tellr "https://<tellr-app-url>/mcp/" \
-  --header "Authorization: Bearer $DATABRICKS_TOKEN"
+  --header "Authorization: Bearer $(databricks auth token -p tellr-dev-oauth | jq -r .access_token)"
+
+claude mcp list | grep tellr
+# → tellr: https://<tellr-app-url>/mcp/ (HTTP) - ✓ Connected
 ```
 
-Then in a Claude session, run `/mcp` to confirm `tellr` shows `connected` with four tools (`create_deck`, `get_deck_status`, `edit_deck`, `get_deck`). Ask Claude to make a deck:
-
-> Create a three-slide deck summarising our Q3 renewals, then give me the deck URL.
-
-**Cursor / other streamable-HTTP clients:** same URL + header pattern in whatever config shape your client uses. Example shape:
+*Cursor / generic:*
 
 ```json
 {
@@ -279,20 +366,45 @@ Then in a Claude session, run `/mcp` to confirm `tellr` shows `connected` with f
       "url": "https://<tellr-app-url>/mcp/",
       "transport": "streamable-http",
       "headers": {
-        "Authorization": "Bearer ${DATABRICKS_TOKEN}"
+        "Authorization": "Bearer <paste output of `databricks auth token -p tellr-dev-oauth | jq -r .access_token` here>"
       }
     }
   }
 }
 ```
 
-### 3.3 Gotchas
+### 3.4 Refreshing a static token
 
-**Token expiry.** `databricks auth token` tokens last ~1 hour. When Claude starts reporting "Authentication failed" mid-session, refresh and re-register the MCP server. PATs last as configured by the workspace admin.
+Only applies to §3.3 — §3.2 handles refresh automatically.
+
+`claude mcp add` captures `--header` as a **static string**; it is not re-evaluated per call. OAuth access tokens expire after ~1 hour; once expired, every tool call returns 401 and the client reports "Authentication failed."
+
+Re-register with a fresh token. Keep it as a shell function:
+
+```bash
+tellr-refresh() {
+  claude mcp remove tellr 2>/dev/null
+  claude mcp add --transport http tellr "https://<tellr-app-url>/mcp/" \
+    --header "Authorization: Bearer $(databricks auth token -p tellr-dev-oauth | jq -r .access_token)"
+}
+```
+
+Run `tellr-refresh` whenever you see 401s, or at the start of any session that's been idle for more than an hour. Refresh completes in under a second.
+
+For unattended runs longer than an hour (CI, background agents):
+
+- Re-run `tellr-refresh` on a timer (cron, `launchd`, `systemd` timer) every ~45 minutes, **or**
+- Wrap tellr in a tiny local stdio→HTTP MCP proxy that reads a fresh token per request — equivalent behaviour to §3.2 for clients that don't yet speak MCP OAuth.
+
+### 3.5 Gotchas
+
+**PATs → 401 from the Apps proxy.** Don't use long-lived PATs for app access; see §3.1.
+
+**App-level access is a separate check.** OAuth authenticates *who you are*; the Apps proxy additionally checks you're on the app's user list. If sign-in succeeds but `/mcp/` still returns 403, ask the app owner to grant your user access.
 
 **Trailing slash on the URL.** Always POST to `/mcp/` (with slash). `/mcp` (no slash) returns a 307 redirect that some clients silently downgrade to GET and break on. The `claude mcp add` command sometimes strips the trailing slash — double-check with `claude mcp list`.
 
-**Handshake.** After `initialize`, MCP requires a `notifications/initialized` before any `tools/*`. The official MCP clients handle this for you; if you're writing raw HTTP, don't skip it.
+**Handshake.** After `initialize`, MCP requires a `notifications/initialized` before any `tools/*`. Official MCP clients handle this for you; if you're writing raw HTTP, don't skip it.
 
 ---
 
@@ -314,6 +426,8 @@ Full schemas and examples: [`mcp-server.md`](./mcp-server.md) section 5.
 | Error text | Cause | Fix |
 |---|---|---|
 | `Authentication required: no credentials presented` | No auth headers arrived (proxy stripped them, or external caller didn't send a Bearer). | App-to-app: confirm `x-forwarded-email` is set on your app's inbound requests. External: check your Bearer header is reaching tellr (curl the `/api/health` endpoint with the same token). |
+| `HTTP 401` (empty body `{}`) on external `/mcp/` calls | You're using a PAT (`dapi...`); the Apps proxy rejects PATs for app access. | Switch to an OAuth U2M token via a `databricks-cli` auth profile — see §3.1. |
+| `HTTP 401` mid-session after working fine earlier | OAuth access token (~1-hour lifetime) has expired; `claude mcp add` stored it as a static header. | Re-register the MCP server with a fresh token — see §3.3 (`tellr-refresh` one-liner). |
 | `HTTP 404 {"message": "Session not found"}` | The `mcp-session-id` you're reusing has expired. | Open a fresh MCP session (re-run `initialize` + `notifications/initialized`) per tool call in long-running poll loops. |
 | `create_deck tool error: ...` | Tool execution failed after auth succeeded (LLM error, input validation, etc.). | Read the error text — it's the underlying reason. |
 | `Deck not found or you do not have permission to view it` | Your identity doesn't match the deck's creator and you're not a contributor. | Check `created_by` on the deck; use the creator's identity or share the deck. |

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -1,0 +1,547 @@
+# MCP Server
+
+**One-Line Summary:** Call tellr programmatically from other Databricks Apps or MCP-compatible agent tools over a FastMCP Streamable HTTP endpoint — create, poll, refine, and retrieve decks without touching the browser UI.
+
+---
+
+## 1. Overview
+
+tellr exposes its deck-generation capabilities as a set of Model Context Protocol (MCP) tools. External callers — other Databricks Apps, agent runtimes such as Claude Code or Claude Desktop, or any client that speaks JSON-RPC — can drive the same agent pipeline that powers the tellr browser UI:
+
+- `create_deck` — turn a natural-language prompt into a new deck
+- `get_deck_status` — poll for completion and receive the deck payload
+- `edit_deck` — refine an existing deck (whole-deck or contiguous slide range)
+- `get_deck` — re-read the current state of a deck on demand
+
+**When to use it.** Reach for the MCP endpoint when another app or agent needs to generate slides on a user's behalf — for example, a sales-enablement app that kicks off a deck from a CRM record, or an internal assistant that produces a briefing on request. Reach for the browser UI when a human wants to interactively compose, reorder, or export a deck.
+
+**Relation to the browser UI.** The MCP endpoint is a *peer* of the HTTP + SSE API that the React frontend calls; both paths share `ChatService`, `SessionManager`, and `PermissionService`. A deck created via MCP is attributed to the calling user and shows up in their tellr UI exactly like a browser-created one. The canonical editor remains tellr: MCP returns both a structured deck and a standalone HTML document, so the caller can render a preview in its own surface *and* hand the user a `deck_url` when they need the full editor (presentation mode, Google Slides / PPTX export, Monaco HTML editor, save points).
+
+---
+
+## 2. Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| Deployed tellr app URL | e.g., `https://<your-tellr-app-url>`; see section 3 for how to find it |
+| Databricks user token | A user PAT, Databricks Apps-injected OBO token, or `databricks auth token` output |
+| MCP client or HTTP library | Claude Code / Claude Desktop / Cursor / any MCP-compatible runtime, or a raw HTTP client (`httpx`, `curl`, etc.) |
+| Python 3.10+ (for code recipes) | Only needed if you use the Python recipes in section 7 |
+
+The caller does not need any tellr-specific configuration — no client credentials, no shared secret, no registered application. Authentication is entirely via a user-scoped Databricks token.
+
+---
+
+## 3. Endpoint & Protocol
+
+| Item | Value |
+|------|-------|
+| URL | `https://<your-tellr-app-url>/mcp/` |
+| Protocol | MCP Streamable HTTP, spec revision `2025-03-26` |
+| Transport | JSON-RPC 2.0 over HTTP POST |
+| Required `Accept` header | `application/json, text/event-stream` |
+| Session header (after `initialize`) | `mcp-session-id: <server-issued>` |
+
+**Mandatory trailing slash.** `POST /mcp` returns `307 Temporary Redirect` to `/mcp/`. Always POST to `/mcp/` directly — the redirect will strip `POST` semantics with some clients.
+
+**Handshake sequence.** Every session must run through the standard MCP handshake before any `tools/*` call:
+
+1. `initialize` (request/response) — server returns an `mcp-session-id` header the client echoes on every subsequent call.
+2. `notifications/initialized` (notification, no response expected; 200/202 both acceptable).
+3. `tools/list`, `tools/call` — one or more.
+
+Skipping step 2 produces spec-compliant but inconsistent behaviour from FastMCP.
+
+**Finding your tellr app URL.** The app URL is shown on the Databricks Apps UI page for the `tellr` app, or via the CLI:
+
+```bash
+databricks apps get <your-tellr-app-name> --output json | jq -r .url
+```
+
+Use the `https://...` URL as `TELLR_URL`; do not include a trailing slash.
+
+**SSE vs. JSON responses.** FastMCP may respond with `text/event-stream` for requests whose completion is tied to session initialisation. Clients that send the required `Accept` header must be prepared to parse a single `data: {...}` frame as well as plain JSON. The bundled Python recipe (section 7) shows a minimal decoder.
+
+---
+
+## 4. Authentication
+
+tellr's MCP endpoint accepts two token sources in priority order. This is the same dual-token model documented in `src/api/mcp_auth.py`.
+
+### 4.1 Dual-Token Model
+
+| Priority | Header | Who sets it | Trust level |
+|----------|--------|-------------|-------------|
+| 1 | `x-forwarded-access-token` | The Databricks Apps proxy | Highest — cannot be spoofed from outside the proxy |
+| 2 | `Authorization: Bearer <token>` | The caller | Used for external callers (laptops, agent runtimes) |
+
+The server resolves the token to a Databricks identity via `current_user.me()`. If neither header is present, or the token is invalid/expired, the server returns a JSON-RPC error that MCP clients render as `isError: true` on the tool result.
+
+The resolved identity is bound to request-scoped ContextVars (`current_user`, `user_client`, `permission_context`) so all downstream services — session manager, permission service, MLflow, Google OAuth — see the caller's identity with no MCP-specific plumbing.
+
+### 4.2 Caller Recipes
+
+Three common setups. Pick the one that matches where your code runs.
+
+#### A. In-workspace Databricks App (OBO forwarding)
+
+When your app is itself a Databricks App running in the same workspace as tellr, the platform injects the end user's token into your app as `x-forwarded-access-token`. Extract that token and forward it as `Authorization: Bearer` on the outbound call to tellr. See section 7.3 for a complete code example.
+
+> **Deliberately unsupported: using your own service-principal token.** Do *not* call tellr with the service principal token that Databricks Apps also exposes to your backend. Decks created that way will be attributed to the SP, which will not match any real user in the tellr UI — they will be invisible to the people who asked for them, and permission checks on subsequent `get_deck_status` / `edit_deck` calls from a different identity will fail. Always forward the end user's `x-forwarded-access-token`.
+
+#### B. External MCP client (Claude Code, Claude Desktop, Cursor, etc.)
+
+External MCP runtimes register tellr in their `mcp_servers.json`-style config. Put the user's Databricks token in an env var and reference it from the config:
+
+```json
+{
+  "mcpServers": {
+    "tellr": {
+      "url": "https://<your-tellr-app-url>/mcp/",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer ${DATABRICKS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Refresh the token when it expires (PATs last as configured by the workspace admin; `databricks auth token` output generally refreshes automatically).
+
+#### C. Direct HTTP
+
+For CI scripts, smoke tests, or notebooks, speak JSON-RPC to `/mcp/` directly. See the full recipe in section 7, or the reference implementation in `scripts/mcp_smoke/mcp_smoke_httpx.py`.
+
+---
+
+## 5. Tool Catalog
+
+Each tool subsection below mirrors the `@mcp.tool` descriptions in `src/api/mcp_server.py`. Input schemas are documented as tables (field / type / required / description); output schemas as annotated JSON examples.
+
+### 5.1 `create_deck`
+
+**Description.** Generate a new slide deck from a natural-language prompt. Returns a `session_id` and a `request_id`; the caller polls `get_deck_status` for completion. The resulting deck is attributed to the calling user and appears in their tellr UI. v1 runs prompt-only: the agent does not invoke Genie, Vector Search, or other tools. Callers that want data-backed decks should gather the data themselves and include it in the prompt.
+
+**Input schema**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prompt` | string | yes | Natural-language description of the deck. Any length; longer prompts with explicit slide-by-slide structure tend to work best. |
+| `num_slides` | integer (1–50) | no | Target slide count. The agent is not strictly constrained; treat as a hint. |
+| `slide_style_id` | integer | no | ID of a `SlideStyle` row in tellr's config. Omit for default. |
+| `deck_prompt_id` | integer | no | ID of a `DeckPrompt` row. Omit for default. |
+| `correlation_id` | string | no | Opaque ID echoed in server logs for cross-system trace correlation. |
+
+**Output schema**
+
+```jsonc
+{
+  "session_id": "c4d8e2f3-...",   // Opaque; pass to subsequent tool calls
+  "request_id": "r9a1b2c3-...",   // Poll this via get_deck_status
+  "status": "pending"             // Always "pending" immediately after submission
+}
+```
+
+**Example request**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+  "params": {
+    "name": "create_deck",
+    "arguments": {
+      "prompt": "a three-slide briefing on Q3 renewals with headline metrics and risk summary",
+      "num_slides": 3,
+      "correlation_id": "briefing-app-4f2e"
+    }
+  }
+}
+```
+
+**Example response**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1,
+  "result": {
+    "content": [{"type": "text", "text": "{\"session_id\":\"c4d8...\",\"request_id\":\"r9a1...\",\"status\":\"pending\"}"}],
+    "isError": false
+  }
+}
+```
+
+**Common errors**
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| `prompt must be a non-empty string` | Empty or whitespace-only prompt | Send a meaningful prompt |
+| `num_slides must be between 1 and 50` | Out-of-range `num_slides` | Clamp at the caller |
+| `Authentication failed: ...` | Missing/invalid token | See section 4 |
+| `Session is currently processing another request` | Re-submit before previous job cleared the lock | Retry after a short backoff |
+
+### 5.2 `get_deck_status`
+
+**Description.** Poll the status of a deck generation or edit job. Returns lightweight status while pending/running; when ready, returns the complete deck as structured slide data, a standalone HTML document, and URLs into tellr's full editor and view-only surfaces.
+
+**Input schema**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `session_id` | string | yes | From the originating `create_deck` / `edit_deck` response |
+| `request_id` | string | yes | From the originating `create_deck` / `edit_deck` response |
+
+**Output schema (pending/running)**
+
+```jsonc
+{
+  "session_id": "c4d8...",
+  "request_id": "r9a1...",
+  "status": "running",             // one of "pending", "running"
+  "progress": null                  // optional progress payload when available
+}
+```
+
+**Output schema (ready)**
+
+```jsonc
+{
+  "session_id": "c4d8...",
+  "request_id": "r9a1...",
+  "status": "ready",
+  "slide_count": 3,
+  "title": "Q3 renewals briefing",
+  "deck": {
+    "title": "...",
+    "slides": [ { "html": "<div class='slide'>...</div>", "scripts": "...",
+                   "slide_id": "...", "created_by": "..." } ],
+    "css": "/* shared CSS */",
+    "external_scripts": ["https://cdn.jsdelivr.net/.../chart.umd.min.js"],
+    "head_meta": {}
+  },
+  "html_document": "<!doctype html>...</html>",       // complete, render-ready
+  "deck_url": "https://<your-tellr-app-url>/sessions/c4d8.../edit",
+  "deck_view_url": "https://<your-tellr-app-url>/sessions/c4d8.../view",
+  "replacement_info": null,                              // populated for edit_deck
+  "messages": [ { "role": "assistant", "content": "...",
+                   "message_type": "reasoning", "created_at": "..." } ],
+  "metadata": {
+    "tool_calls": [ ... ],
+    "latency_ms": 47213,
+    "experiment_url": "https://.../mlflow/...",
+    "session_title": "Q3 renewals briefing"
+  }
+}
+```
+
+**Output schema (failed)**
+
+```jsonc
+{
+  "session_id": "c4d8...",
+  "request_id": "r9a1...",
+  "status": "failed",
+  "error": "Generation failed: <reason>"
+}
+```
+
+**Status values.** `pending` → `running` → `ready` is the happy path. A terminal `failed` is returned for agent errors, tool failures, or timeouts (see section 9). A running job that exceeds 10 minutes is swept to `failed` by the server-side timeout sweeper.
+
+**Common errors**
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| `Deck not found or you do not have permission to view it` | Session exists but the caller's identity does not hold view access | Check that the OBO / Bearer token resolves to the deck's creator or a shared viewer |
+| `Unknown request_id: ...` | `request_id` does not match any chat request, or the `session_id` does not own it | Re-check IDs; a single stray request from another session is rejected |
+| `Unknown job status: ...` | Server observed an unexpected terminal state | Rare; retry or inspect server logs |
+
+### 5.3 `edit_deck`
+
+**Description.** Refine an existing deck through a natural-language instruction. Optionally target specific contiguous slides via `slide_indices`. The edit is applied in-place; the `session_id` and `deck_url` stay stable across edits. Returns a `request_id`; the caller polls `get_deck_status` for completion and receives the updated deck plus `replacement_info` summarising what changed.
+
+**Input schema**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `session_id` | string | yes | The deck to edit |
+| `instruction` | string | yes | Natural-language change request |
+| `slide_indices` | array of integers | no | Contiguous range (e.g., `[2, 3, 4]`); omit to target the whole deck |
+| `correlation_id` | string | no | Echoed in server logs |
+
+**Contiguity constraint.** `slide_indices` must be a single contiguous slice. `[2, 3, 4]` is valid; `[2, 4]` raises `slide_indices must be contiguous (e.g. [2, 3, 4], not [2, 4])`. For disjoint edits, issue one call per slice.
+
+**Output schema.** Identical shape to `create_deck` — `{ session_id, request_id, status: "pending" }`. Poll `get_deck_status` to receive the updated deck. `replacement_info` on the ready response describes what changed (the same structure as `ChatResponse.replacement_info`).
+
+**Example request**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+  "params": {
+    "name": "edit_deck",
+    "arguments": {
+      "session_id": "c4d8...",
+      "instruction": "Make the EMEA section more prominent and add Q3 vs Q2 deltas",
+      "slide_indices": [1, 2],
+      "correlation_id": "briefing-app-4f2e"
+    }
+  }
+}
+```
+
+**Common errors**
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| `Deck not found or you do not have permission to edit it` | Caller lacks `CAN_EDIT` on the deck | Use an identity that is the creator or a shared editor |
+| `slide_indices must be contiguous ...` | Non-contiguous indices | Split into multiple calls |
+| `slide_indices contains out-of-range index: ...` | Index ≥ `slide_count` or negative | Fetch `get_deck` first to confirm current count |
+
+### 5.4 `get_deck`
+
+**Description.** Retrieve the current state of a deck without submitting new work. Returns structured slide data, a standalone HTML document, and URLs into tellr's editor — same payload as a ready `get_deck_status` response, without `status` / `request_id` / `messages`. Idempotent; no job queue interaction. Use when you have a `session_id` from earlier and want to re-render without polling.
+
+**Input schema**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `session_id` | string | yes | The deck to retrieve |
+
+**Output schema**
+
+```jsonc
+{
+  "session_id": "c4d8...",
+  "slide_count": 3,
+  "title": "Q3 renewals briefing",
+  "deck": { ... },                                         // same shape as get_deck_status "ready"
+  "html_document": "<!doctype html>...",
+  "deck_url": "https://<your-tellr-app-url>/sessions/c4d8.../edit",
+  "deck_view_url": "https://<your-tellr-app-url>/sessions/c4d8.../view"
+}
+```
+
+**Common errors**
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| `Deck not found: session_id=...` | No session with that ID | Verify `session_id` |
+| `Deck not found or you do not have permission to view it` | Caller lacks view access | Share the deck, or call with the creator's identity |
+
+---
+
+## 6. Component Responsibilities
+
+| File | Responsibility | Talks to |
+|------|----------------|----------|
+| `src/api/mcp_server.py` | Declares `FastMCP` instance; registers the four `@mcp.tool` handlers; builds request-scoped auth scope for each call. | `ChatService`, `SessionManager`, `PermissionService`, `job_queue` |
+| `src/api/mcp_auth.py` | Dual-token resolution: reads `x-forwarded-access-token` or `Authorization: Bearer`, calls `current_user.me()`, binds `current_user` / `user_client` / `permission_context` ContextVars. | Databricks SDK (`WorkspaceClient`) |
+| `src/api/main.py` | Mounts the FastMCP sub-app at `/mcp` with `streamable_http_path="/"`, so external POSTs to `/mcp/` route correctly. Starts the 10-minute timeout sweeper on lifespan. | `tellr_mcp.streamable_http_app()` |
+| `src/api/services/job_queue.py` | In-process asyncio queue for chat jobs. Timeout sweeper flips stuck `running` jobs to `failed` after `JOB_HARD_TIMEOUT_SECONDS = 600`. | `chat_requests` table |
+| `src/domain/slide_deck.py` | `SlideDeck.to_html_document()` emits the standalone HTML payload returned in `html_document`. CSS is sanitized; slide content is HTML-escaped to prevent XSS through MCP consumers. | — |
+| `src/services/permission_service.py` | `can_view_deck` / `can_edit_deck` checks used before every tool that touches a deck. Creator short-circuit lets a freshly created session be viewed/edited before any `DeckContributor` row exists. | `user_sessions`, `deck_contributors` |
+
+---
+
+## 7. Client Recipes
+
+All recipes assume you have already completed section 4 (authentication setup).
+
+### 7.1 Python `httpx` — full `create → poll → ready`
+
+Lightly edited from `scripts/mcp_smoke/mcp_smoke_httpx.py`; drop into any Python environment with `httpx` installed.
+
+```python
+import json, os, time, httpx
+
+TELLR_URL = os.environ["TELLR_URL"].rstrip("/")
+MCP_URL = f"{TELLR_URL}/mcp/"
+HEADERS = {
+    "Authorization": f"Bearer {os.environ['DATABRICKS_TOKEN']}",
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+def decode(resp: httpx.Response) -> dict:
+    """Handle both plain JSON and text/event-stream responses."""
+    if "event-stream" in resp.headers.get("content-type", "").lower():
+        for line in resp.text.splitlines():
+            if line.startswith("data:"):
+                return json.loads(line[5:].strip())
+        raise RuntimeError("SSE response without data frame")
+    return resp.json()
+
+# 1. initialize -> grab mcp-session-id
+r = httpx.post(MCP_URL, headers=HEADERS, timeout=30, json={
+    "jsonrpc": "2.0", "id": 1, "method": "initialize",
+    "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+               "clientInfo": {"name": "my-app", "version": "1.0"}}})
+r.raise_for_status()
+mcp_headers = {**HEADERS, "mcp-session-id": r.headers["mcp-session-id"]}
+
+# 2. notifications/initialized (required before tools/*)
+httpx.post(MCP_URL, headers=mcp_headers, timeout=30, json={
+    "jsonrpc": "2.0", "method": "notifications/initialized"})
+
+# 3. create_deck
+r = httpx.post(MCP_URL, headers=mcp_headers, timeout=60, json={
+    "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+    "params": {"name": "create_deck",
+               "arguments": {"prompt": "a three-slide intro to our product",
+                             "correlation_id": "demo-1"}}})
+r.raise_for_status()
+payload = json.loads(decode(r)["result"]["content"][0]["text"])
+session_id, request_id = payload["session_id"], payload["request_id"]
+
+# 4. poll get_deck_status (10-min deadline matches JOB_HARD_TIMEOUT_SECONDS)
+deadline = time.time() + 600
+while time.time() < deadline:
+    r = httpx.post(MCP_URL, headers=mcp_headers, timeout=60, json={
+        "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+        "params": {"name": "get_deck_status",
+                   "arguments": {"session_id": session_id,
+                                 "request_id": request_id}}})
+    r.raise_for_status()
+    payload = json.loads(decode(r)["result"]["content"][0]["text"])
+    status = payload.get("status")
+    if status == "ready":
+        print("slides:", payload["slide_count"], "url:", payload["deck_url"])
+        break
+    if status == "failed":
+        raise RuntimeError(payload.get("error"))
+    time.sleep(2)
+else:
+    raise TimeoutError("generation did not complete within 10 minutes")
+```
+
+### 7.2 Claude Code / Claude Desktop / Cursor
+
+```json
+{
+  "mcpServers": {
+    "tellr": {
+      "url": "https://<your-tellr-app-url>/mcp/",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer ${DATABRICKS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Put your token in `DATABRICKS_TOKEN` before starting the agent. All four tools (`create_deck`, `get_deck_status`, `edit_deck`, `get_deck`) become available to the agent automatically.
+
+### 7.3 Databricks App backend (OBO forwarding, pseudocode)
+
+```python
+# FastAPI handler inside your own Databricks App.
+@app.post("/generate-briefing")
+async def generate_briefing(request: Request) -> dict:
+    # The Databricks Apps proxy injects the end user's token here.
+    user_token = request.headers.get("x-forwarded-access-token")
+    if not user_token:
+        raise HTTPException(status_code=401, detail="missing OBO token")
+
+    # Forward it as Bearer on the outbound call to tellr; then drive the
+    # initialize -> notifications/initialized -> tools/call -> poll flow
+    # exactly as in recipe 7.1, substituting user_token for DATABRICKS_TOKEN.
+    ...
+```
+
+Exchanging the PAT-derived `DATABRICKS_TOKEN` in recipe 7.1 for the request-scoped `user_token` is the entire delta. Do not cache or reuse `user_token` across requests — it is the end user's OBO token and belongs to that request only.
+
+---
+
+## 8. Rendering Recipes
+
+`get_deck_status` and `get_deck` both return a ready-to-render `html_document` *and* the structured `deck` payload. Pick whichever matches your UI.
+
+### 8.1 Minimal: iframe with `srcdoc`
+
+```tsx
+<iframe
+  title="Deck preview"
+  srcDoc={htmlDocument}  // the html_document field, rendered raw
+  sandbox="allow-scripts"
+  style={{ width: "100%", aspectRatio: "16 / 9", border: 0 }}
+/>
+```
+
+> **HTML-escape the attribute value.** When you interpolate `html_document` into an HTML attribute (e.g., `srcdoc=`), escape it the way your framework normally escapes attribute content. React's `srcDoc` prop does this automatically. In hand-written HTML, make sure `"` in the document becomes `&quot;`.
+
+### 8.2 Custom grid: iterate `deck.slides`
+
+```tsx
+export function SlideGrid({ deck }: { deck: Deck }) {
+  return (
+    <div className="slide-grid">
+      <style>{deck.css}</style>
+      {deck.external_scripts.map(src => <script key={src} src={src} />)}
+      {deck.slides.map((slide, i) => (
+        <article
+          key={slide.slide_id ?? i}
+          dangerouslySetInnerHTML={{ __html: slide.html }}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+The `.slide` wrapper invariant is preserved — tellr never emits a slide without one — so your CSS can rely on `.slide { ... }` selectors.
+
+### 8.3 Air-gapped environments
+
+`html_document` embeds a Chart.js reference via a default CDN (`cdn.jsdelivr.net`). In environments where that CDN is unreachable:
+
+- **v1 (current):** `SlideDeck.to_html_document(chart_js_cdn=…)` is *not* exposed as a parameter on `create_deck` / `edit_deck`. The caller can still serve the returned `html_document` through a proxy that rewrites the CDN URL (e.g., a reverse proxy that rewrites `cdn.jsdelivr.net/npm/chart.js/...` to an internal mirror). The `external_scripts` field on the structured deck makes this rewrite trivial for custom renderers.
+- **v1.1 (planned):** a configurable `chart_js_cdn` argument on `create_deck` / `edit_deck`, surfaced as a tool parameter.
+
+---
+
+## 9. Integration Best Practices
+
+| Topic | Practice |
+|-------|----------|
+| Polling cadence | Poll `get_deck_status` every 1–2 seconds with a small backoff if the server is under load. Do not poll faster than 500 ms — the endpoint is not optimised for sub-second polling and you will see the timeout sweeper cost in headroom. |
+| Error retry | Respect any `retry_after_seconds` hint on rate-limit responses; otherwise back off exponentially. `isError: true` on a tool result is *application* failure, not transport failure — do not retry blindly. |
+| Identity | Always forward the end user's OBO token (section 4.2 recipe A). Never call with a service-principal token if the deck should surface to a specific user. |
+| Correlation IDs | Pass a `correlation_id` on every `create_deck` / `edit_deck` call. It flows through server logs, worker state, and the chat request row, making cross-system traces trivial. |
+| Trailing slash | Always POST to `/mcp/`. `POST /mcp` returns `307 Temporary Redirect`, which some HTTP clients silently downgrade to `GET`. |
+| Handshake | After `initialize`, send `notifications/initialized` before any `tools/*` call. |
+| Hand-off vs. render | Prefer `deck_url` when the user needs the full tellr editor (presentation mode, Google Slides / PPTX export, Monaco HTML editing, save points). Render `html_document` / iterate `deck.slides` for passive previews or custom editing UIs. |
+| Session lifetime | One session = one deck. Reuse the same `session_id` for subsequent `edit_deck` / `get_deck` calls so you benefit from the session lock and chat history. A new `create_deck` call starts a fresh session. |
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Likely cause | What to try |
+|---------|--------------|-------------|
+| `401` / `Authentication failed` with a token that works elsewhere | Proxy or gateway stripped `Authorization` on the way in; or `x-forwarded-access-token` absent when the caller expected it | Log the exact headers the tellr process received; if you are running behind an extra proxy, ensure it preserves `Authorization` unmodified |
+| `status: running` never transitions to `ready` | Worker stuck or generation truly slow | The timeout sweeper marks jobs `failed` after 10 minutes (`JOB_HARD_TIMEOUT_SECONDS`). If you reliably exceed that, inspect server logs for the MLflow experiment URL in the `metadata` field of a successful call to see where the agent stalls. |
+| Deck generated via MCP does not appear in the tellr UI for the intended user | Caller forwarded a service-principal token instead of the user's OBO token | Switch to OBO forwarding (section 4.2 recipe A). Decks created under the SP identity are not visible to any workspace user. |
+| `isError: true` with a "permission" message on `get_deck_status` / `edit_deck` / `get_deck` | Caller identity does not match the deck's `created_by` or any `DeckContributor` row | Check `created_by` on the session. Either call with that user's token or share the deck to the calling user via tellr's UI. |
+| Chart.js fails to load in an air-gapped environment | Default CDN unreachable | See section 8.3 — rewrite the CDN URL through a proxy; v1.1 will expose `chart_js_cdn` as a tool parameter. |
+| `initialize` returns no `mcp-session-id` header | Deployment did not pick up the MCP router | Redeploy tellr; check `/api/health`; confirm `app.mount("/mcp", ...)` ran by looking for `MCP server mounted at /mcp` in the app logs. |
+| Client receives HTML instead of JSON on the first POST | Target URL is `/mcp` (no trailing slash) and the client followed the 307 to a GET | Always POST to `/mcp/` directly |
+
+---
+
+## 11. Versioning & Changelog
+
+| Version | Tellr release | Notes |
+|---------|---------------|-------|
+| v1.0 | 0.3.0 | Initial release. Four tools: `create_deck`, `get_deck_status`, `edit_deck`, `get_deck`. Dual-token auth. Prompt-only generation (no Genie / Vector Search / other tools). 10-minute hard timeout. |
+| v1.1 (planned) | TBD | Export tools (`export_pptx`, `export_google_slides`), structural edit tools (reorder / insert / delete at slide granularity), `chart_js_cdn` passthrough. See the design spec's "Deferred items" section for the full list. |
+
+---
+
+## 12. Cross-References
+
+- [MCP server design spec](../superpowers/specs/2026-04-22-tellr-mcp-server-design.md) — architecture rationale, open verification items, and deferred feature list
+- [Backend Overview](./backend-overview.md) — FastAPI entry points, `ChatService`, `SessionManager`, `PermissionService`
+- [Real-Time Streaming](./real-time-streaming.md) — the polling + `chat_requests` infrastructure that MCP tools reuse
+- [Permissions Model](./permissions-model.md) — `can_view_deck` / `can_edit_deck` semantics and the `DeckContributor` rows
+- [Databricks App Deployment](./databricks-app-deployment.md) — deployment CLI, workspace URL discovery

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -42,17 +42,23 @@ The caller does not need any tellr-specific configuration — no client credenti
 | Protocol | MCP Streamable HTTP, spec revision `2025-03-26` |
 | Transport | JSON-RPC 2.0 over HTTP POST |
 | Required `Accept` header | `application/json, text/event-stream` |
-| Session header (after `initialize`) | `mcp-session-id: <server-issued>` |
+| Session mode | **Stateless** — server does not issue `mcp-session-id` |
 
 **Mandatory trailing slash.** `POST /mcp` returns `307 Temporary Redirect` to `/mcp/`. Always POST to `/mcp/` directly — the redirect will strip `POST` semantics with some clients.
 
-**Handshake sequence.** Every session must run through the standard MCP handshake before any `tools/*` call:
+**Stateless transport.** tellr runs FastMCP with `stateless_http=True` because the app is served by multiple uvicorn workers and the Databricks Apps proxy does not guarantee session affinity. Each HTTP POST is handled independently on whichever worker picks it up. Consequences for callers:
 
-1. `initialize` (request/response) — server returns an `mcp-session-id` header the client echoes on every subsequent call.
+- The server does **not** emit the `mcp-session-id` response header on `initialize`. Clients MUST NOT require one.
+- Clients MAY still send `mcp-session-id` on follow-up requests — it is ignored.
+- The tellr deck `session_id` returned by `create_deck` is a separate concept (app-level state in Lakebase) and is persistent across calls.
+
+**Handshake sequence.** MCP clients should still run the standard handshake before `tools/*` calls — the server accepts it and well-behaved clients expect to send it:
+
+1. `initialize` (request/response).
 2. `notifications/initialized` (notification, no response expected; 200/202 both acceptable).
 3. `tools/list`, `tools/call` — one or more.
 
-Skipping step 2 produces spec-compliant but inconsistent behaviour from FastMCP.
+In stateless mode each of these runs as an independent transport on the server, but the client-visible sequence is unchanged.
 
 **Finding your tellr app URL.** The app URL is shown on the Databricks Apps UI page for the `tellr` app, or via the CLI:
 
@@ -377,15 +383,17 @@ def decode(resp: httpx.Response) -> dict:
         raise RuntimeError("SSE response without data frame")
     return resp.json()
 
-# 1. initialize -> grab mcp-session-id
+# 1. initialize. tellr runs stateless, so no mcp-session-id is issued;
+#    forward one if the server does return it (future-proofing).
 r = httpx.post(MCP_URL, headers=HEADERS, timeout=30, json={
     "jsonrpc": "2.0", "id": 1, "method": "initialize",
     "params": {"protocolVersion": "2025-03-26", "capabilities": {},
                "clientInfo": {"name": "my-app", "version": "1.0"}}})
 r.raise_for_status()
-mcp_headers = {**HEADERS, "mcp-session-id": r.headers["mcp-session-id"]}
+sid = r.headers.get("mcp-session-id")
+mcp_headers = {**HEADERS, **({"mcp-session-id": sid} if sid else {})}
 
-# 2. notifications/initialized (required before tools/*)
+# 2. notifications/initialized (part of the handshake real clients send)
 httpx.post(MCP_URL, headers=mcp_headers, timeout=30, json={
     "jsonrpc": "2.0", "method": "notifications/initialized"})
 
@@ -530,7 +538,8 @@ The `.slide` wrapper invariant is preserved — tellr never emits a slide withou
 | Deck generated via MCP does not appear in the tellr UI for the intended user | Caller forwarded a service-principal token, so the deck was attributed to the SP rather than the user | For user-initiated flows, switch to OBO forwarding (section 4.2 recipe A). SP-authenticated calls are accepted but the resulting deck is attributed to the SP — expected behavior for batch / automation use cases, but not what you want if a specific user needs the deck in their UI. |
 | `isError: true` with a "permission" message on `get_deck_status` / `edit_deck` / `get_deck` | Caller identity does not match the deck's `created_by` or any `DeckContributor` row | Check `created_by` on the session. Either call with that user's token or share the deck to the calling user via tellr's UI. |
 | Chart.js fails to load in an air-gapped environment | Default CDN unreachable | See section 8.3 — rewrite the CDN URL through a proxy; v1.1 will expose `chart_js_cdn` as a tool parameter. |
-| `initialize` returns no `mcp-session-id` header | Deployment did not pick up the MCP router | Redeploy tellr; check `/api/health`; confirm `app.mount("/mcp", ...)` ran by looking for `MCP server mounted at /mcp` in the app logs. |
+| `initialize` returns no `mcp-session-id` header | Expected — tellr runs stateless (see section 3). If the endpoint also returns HTML or non-JSON, the deployment did not pick up the MCP router; redeploy and confirm `app.mount("/mcp", ...)` ran by looking for `MCP server mounted at /mcp` in the app logs. |
+| Intermittent HTTP 404 `Session not found` from a multi-worker deployment | Only applies if FastMCP is running stateful (`stateless_http=False`); a 3-step handshake can split across workers that don't share session state | Leave tellr in its default stateless mode (section 3). If you've deliberately flipped it back, either pin to a single worker (`UVICORN_WORKERS=1`) or re-enable stateless. |
 | Client receives HTML instead of JSON on the first POST | Target URL is `/mcp` (no trailing slash) and the client followed the 307 to a GET | Always POST to `/mcp/` directly |
 
 ---

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -87,7 +87,7 @@ Three common setups. Pick the one that matches where your code runs.
 
 When your app is itself a Databricks App running in the same workspace as tellr, the platform injects the end user's token into your app as `x-forwarded-access-token`. Extract that token and forward it as `Authorization: Bearer` on the outbound call to tellr. See section 7.3 for a complete code example.
 
-> **Deliberately unsupported: using your own service-principal token.** Do *not* call tellr with the service principal token that Databricks Apps also exposes to your backend. Decks created that way will be attributed to the SP, which will not match any real user in the tellr UI — they will be invisible to the people who asked for them, and permission checks on subsequent `get_deck_status` / `edit_deck` calls from a different identity will fail. Always forward the end user's `x-forwarded-access-token`.
+> **Service-principal calls: accepted, but attributed to the SP.** Calling tellr with the service principal token that Databricks Apps also exposes to your backend will succeed — the request is not blocked — but the resulting deck's `created_by` will be the SP. That means it will **not appear in any human user's tellr UI** (it is attributed to the SP in deck listings, logs, and MLflow), and any later `get_deck_status` / `edit_deck` call made under a different identity will fail the permission check. For user-initiated flows where the deck should surface to a specific user, forward the end user's `x-forwarded-access-token` instead. SP-authenticated calls remain legitimate for batch / automation use cases (scheduled report generation, test harnesses, shared-workspace pipelines) where no specific user needs the deck in their UI.
 
 #### B. External MCP client (Claude Code, Claude Desktop, Cursor, etc.)
 
@@ -226,7 +226,7 @@ Each tool subsection below mirrors the `@mcp.tool` descriptions in `src/api/mcp_
   "messages": [ { "role": "assistant", "content": "...",
                    "message_type": "reasoning", "created_at": "..." } ],
   "metadata": {
-    "tool_calls": [ ... ],
+    "tool_calls": 3,                                     // number of tool invocations during this generation
     "latency_ms": 47213,
     "experiment_url": "https://.../mlflow/...",
     "session_title": "Q3 renewals briefing"
@@ -506,7 +506,7 @@ The `.slide` wrapper invariant is preserved — tellr never emits a slide withou
 |-------|----------|
 | Polling cadence | Poll `get_deck_status` every 1–2 seconds with a small backoff if the server is under load. Do not poll faster than 500 ms — the endpoint is not optimised for sub-second polling and you will see the timeout sweeper cost in headroom. |
 | Error retry | Respect any `retry_after_seconds` hint on rate-limit responses; otherwise back off exponentially. `isError: true` on a tool result is *application* failure, not transport failure — do not retry blindly. |
-| Identity | Always forward the end user's OBO token (section 4.2 recipe A). Never call with a service-principal token if the deck should surface to a specific user. |
+| Identity | Forward the end user's OBO token (section 4.2 recipe A) for any user-initiated flow — it is the recommended path and guarantees the deck surfaces to that user. Service-principal tokens are accepted and legitimate for batch / automation use cases, but the resulting deck is attributed to the SP and will not appear in any human user's tellr UI. |
 | Correlation IDs | Pass a `correlation_id` on every `create_deck` / `edit_deck` call. It flows through server logs, worker state, and the chat request row, making cross-system traces trivial. |
 | Trailing slash | Always POST to `/mcp/`. `POST /mcp` returns `307 Temporary Redirect`, which some HTTP clients silently downgrade to `GET`. |
 | Handshake | After `initialize`, send `notifications/initialized` before any `tools/*` call. |
@@ -520,8 +520,8 @@ The `.slide` wrapper invariant is preserved — tellr never emits a slide withou
 | Symptom | Likely cause | What to try |
 |---------|--------------|-------------|
 | `401` / `Authentication failed` with a token that works elsewhere | Proxy or gateway stripped `Authorization` on the way in; or `x-forwarded-access-token` absent when the caller expected it | Log the exact headers the tellr process received; if you are running behind an extra proxy, ensure it preserves `Authorization` unmodified |
-| `status: running` never transitions to `ready` | Worker stuck or generation truly slow | The timeout sweeper marks jobs `failed` after 10 minutes (`JOB_HARD_TIMEOUT_SECONDS`). If you reliably exceed that, inspect server logs for the MLflow experiment URL in the `metadata` field of a successful call to see where the agent stalls. |
-| Deck generated via MCP does not appear in the tellr UI for the intended user | Caller forwarded a service-principal token instead of the user's OBO token | Switch to OBO forwarding (section 4.2 recipe A). Decks created under the SP identity are not visible to any workspace user. |
+| `status: running` never transitions to `ready` | Worker stuck or generation truly slow | The timeout sweeper automatically transitions stuck jobs to `failed` after 10 minutes (`JOB_HARD_TIMEOUT_SECONDS = 600s`) — no manual intervention needed. Once the job surfaces as `failed`, server logs (keyed on `correlation_id` / `request_id`) are the primary diagnosis surface; the tellr UI's Run Details link on the owning session also exposes the same information. Note: `metadata.experiment_url` only appears on *ready* responses — it is an observability aid for completed runs (MLflow traces, tool-call spans, latency breakdown), not a stuck-job probe. |
+| Deck generated via MCP does not appear in the tellr UI for the intended user | Caller forwarded a service-principal token, so the deck was attributed to the SP rather than the user | For user-initiated flows, switch to OBO forwarding (section 4.2 recipe A). SP-authenticated calls are accepted but the resulting deck is attributed to the SP — expected behavior for batch / automation use cases, but not what you want if a specific user needs the deck in their UI. |
 | `isError: true` with a "permission" message on `get_deck_status` / `edit_deck` / `get_deck` | Caller identity does not match the deck's `created_by` or any `DeckContributor` row | Check `created_by` on the session. Either call with that user's token or share the deck to the calling user via tellr's UI. |
 | Chart.js fails to load in an air-gapped environment | Default CDN unreachable | See section 8.3 — rewrite the CDN URL through a proxy; v1.1 will expose `chart_js_cdn` as a tool parameter. |
 | `initialize` returns no `mcp-session-id` header | Deployment did not pick up the MCP router | Redeploy tellr; check `/api/health`; confirm `app.mount("/mcp", ...)` ran by looking for `MCP server mounted at /mcp` in the app logs. |

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -141,7 +141,7 @@ Each tool subsection below mirrors the `@mcp.tool` descriptions in `src/api/mcp_
 |-------|------|----------|-------------|
 | `prompt` | string | yes | Natural-language description of the deck. Any length; longer prompts with explicit slide-by-slide structure tend to work best. |
 | `num_slides` | integer (1–50) | no | Target slide count. The agent is not strictly constrained; treat as a hint. |
-| `slide_style_id` | integer | no | ID of a `SlideStyle` row in tellr's config. Omit for default. |
+| `slide_style_id` | integer | no | ID of a `SlideStyle` row in tellr's config. Omit to use the system default — the row marked `is_default=true` in `slide_style_library`, settable by an admin at tellr's `/admin` page. MCP cannot see per-user browser-side overrides (localStorage). |
 | `deck_prompt_id` | integer | no | ID of a `DeckPrompt` row. Omit for default. |
 | `correlation_id` | string | no | Opaque ID echoed in server logs for cross-system trace correlation. |
 

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -546,7 +546,6 @@ The `.slide` wrapper invariant is preserved — tellr never emits a slide withou
 
 ## 12. Cross-References
 
-- [MCP server design spec](../superpowers/specs/2026-04-22-tellr-mcp-server-design.md) — architecture rationale, open verification items, and deferred feature list
 - [Backend Overview](./backend-overview.md) — FastAPI entry points, `ChatService`, `SessionManager`, `PermissionService`
 - [Real-Time Streaming](./real-time-streaming.md) — the polling + `chat_requests` infrastructure that MCP tools reuse
 - [Permissions Model](./permissions-model.md) — `can_view_deck` / `can_edit_deck` semantics and the `DeckContributor` rows

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -2,6 +2,8 @@
 
 **One-Line Summary:** Call tellr programmatically from other Databricks Apps or MCP-compatible agent tools over a FastMCP Streamable HTTP endpoint — create, poll, refine, and retrieve decks without touching the browser UI.
 
+> **Looking for a how-to?** This document is the protocol-level reference (tool schemas, JSON-RPC shapes, auth priority model). If you're integrating tellr into your own app or into an MCP client like Claude Code, start with the **[MCP Integration Guide](./mcp-integration-guide.md)** — it has complete worked examples for both paths plus the gotchas we learned during rollout.
+
 ---
 
 ## 1. Overview
@@ -83,11 +85,15 @@ The resolved identity is bound to request-scoped ContextVars (`current_user`, `u
 
 Three common setups. Pick the one that matches where your code runs.
 
-#### A. In-workspace Databricks App (OBO forwarding)
+#### A. In-workspace Databricks App (forwarded identity)
 
-When your app is itself a Databricks App running in the same workspace as tellr, the platform injects the end user's token into your app as `x-forwarded-access-token`. Extract that token and forward it as `Authorization: Bearer` on the outbound call to tellr. See section 7.3 for a complete code example.
+When your app is itself a Databricks App running in the same workspace as tellr, the Databricks Apps proxy **strips** any caller-supplied `Authorization` and `x-forwarded-access-token` headers on ingress (security hardening) and **injects** proxy-attested identity headers instead: `x-forwarded-email`, `x-forwarded-user`, `x-forwarded-preferred-username`.
 
-> **Service-principal calls: accepted, but attributed to the SP.** Calling tellr with the service principal token that Databricks Apps also exposes to your backend will succeed — the request is not blocked — but the resulting deck's `created_by` will be the SP. That means it will **not appear in any human user's tellr UI** (it is attributed to the SP in deck listings, logs, and MLflow), and any later `get_deck_status` / `edit_deck` call made under a different identity will fail the permission check. For user-initiated flows where the deck should surface to a specific user, forward the end user's `x-forwarded-access-token` instead. SP-authenticated calls remain legitimate for batch / automation use cases (scheduled report generation, test harnesses, shared-workspace pipelines) where no specific user needs the deck in their UI.
+Tellr accepts these identity headers as a third priority in `extract_mcp_identity` (gated on `TELLR_TRUST_FORWARDED_IDENTITY=true`, which production deployments set). No user token is available on this path; downstream Databricks API calls use tellr's own service principal, but deck attribution still reflects the real user via the forwarded email.
+
+**Your app should not send `Authorization` or `x-forwarded-access-token` on the outbound call — both will be stripped and sending them is misleading.** Just send the JSON-RPC body; the proxy adds identity headers automatically.
+
+For a complete worked example (Streamlit app, ~150 lines), see **[MCP Integration Guide Part A](./mcp-integration-guide.md#2-part-a--databricks-app--tellr)**.
 
 #### B. External MCP client (Claude Code, Claude Desktop, Cursor, etc.)
 

--- a/docs/user-guide/02-creating-profiles.md
+++ b/docs/user-guide/02-creating-profiles.md
@@ -28,7 +28,7 @@ Click the add button to browse available Genie spaces and MCP servers. Select on
 
 ### Step 03: Select Style and Prompt
 
-Use the AgentConfigBar to pick a slide style (visual appearance) and optionally a deck prompt (content template).
+Use the AgentConfigBar to pick a slide style (visual appearance) and optionally a deck prompt (content template). New sessions pre-fill with your personal default if you've set one, otherwise with the organization's corporate default — see [Creating Custom Slide Styles → Defaults: corporate vs. personal](./05-creating-custom-styles.md#defaults-corporate-vs-personal) for how those two levels work.
 
 ## Saving a Configuration as a Profile
 

--- a/docs/user-guide/05-creating-custom-styles.md
+++ b/docs/user-guide/05-creating-custom-styles.md
@@ -2,6 +2,15 @@
 
 This guide covers what goes into a Slide Style, what CSS is safe to include, and how to convert an existing slide template into a style configuration.
 
+## Defaults: corporate vs. personal
+
+Every new deck starts with a slide style applied. Where that style comes from depends on whether you've customized things for yourself.
+
+- **Corporate default (system-wide).** One slide style is marked as the organization's default. Every user who hasn't overridden it sees that style on every new deck — the same way a new document in your corporate Google Workspace picks up your company's template. Decks generated via the MCP API also use this default. Tellr admins set the corporate default from the hidden `/admin` page ("Slide Style" tab); there's no link in the main navigation — you need to know the URL.
+- **Personal override.** You can pin a different style as *your* default by clicking "Set as default" on any style in the Slide Styles page. Your choice is remembered in your current browser only and takes precedence over the corporate default for your new decks. (MCP decks still use the corporate default regardless of your personal choice.)
+
+For one-off decks, you can always change the style for a single session from the agent config bar without affecting either default.
+
 ## Overview
 
 A Slide Style is a text block that tells the AI how your slides should look. It can contain:

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -409,6 +409,11 @@ export const configApi = {
       method: 'DELETE',
     }),
 
+  setSlideStyleSystemDefault: (styleId: number): Promise<SlideStyle> =>
+    fetchJson(`${API_BASE}/slide-styles/${styleId}/set-default`, {
+      method: 'POST',
+    }),
+
 
   // Google OAuth Credentials (global, admin-only)
 

--- a/frontend/src/components/Admin/AdminPage.tsx
+++ b/frontend/src/components/Admin/AdminPage.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { FeedbackDashboard } from '../Feedback/FeedbackDashboard';
 import { GoogleSlidesAuthForm } from '../config/GoogleSlidesAuthForm';
+import { AdminSlideStyleDefault } from './AdminSlideStyleDefault';
 
-type TabId = 'feedback' | 'google_slides';
+type TabId = 'feedback' | 'google_slides' | 'slide_style';
 
 export const AdminPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<TabId>('feedback');
@@ -49,6 +50,20 @@ export const AdminPage: React.FC = () => {
           >
             Google Slides
           </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === 'slide_style'}
+            aria-controls="slide-style-panel"
+            id="slide-style-tab"
+            onClick={() => setActiveTab('slide_style')}
+            className={`px-4 py-2 font-medium text-sm border-b-2 transition-colors -mb-px ${
+              activeTab === 'slide_style'
+                ? 'border-blue-500 text-blue-600'
+                : 'border-transparent text-gray-600 hover:text-gray-900 hover:border-gray-300'
+            }`}
+          >
+            Slide Style
+          </button>
         </div>
 
         <div
@@ -69,6 +84,16 @@ export const AdminPage: React.FC = () => {
           className={activeTab !== 'google_slides' ? 'sr-only' : ''}
         >
           <GoogleSlidesAuthForm />
+        </div>
+
+        <div
+          role="tabpanel"
+          id="slide-style-panel"
+          aria-labelledby="slide-style-tab"
+          hidden={activeTab !== 'slide_style'}
+          className={activeTab !== 'slide_style' ? 'sr-only' : ''}
+        >
+          <AdminSlideStyleDefault />
         </div>
       </div>
     </div>

--- a/frontend/src/components/Admin/AdminSlideStyleDefault.tsx
+++ b/frontend/src/components/Admin/AdminSlideStyleDefault.tsx
@@ -1,19 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import { configApi } from '../../api/config';
 import type { SlideStyle } from '../../api/config';
+import { useToast } from '../../contexts/ToastContext';
 
 export const AdminSlideStyleDefault: React.FC = () => {
   const [styles, setStyles] = useState<SlideStyle[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<number | null>(null);
+  const { showToast } = useToast();
+
+  const load = async (): Promise<void> => {
+    const resp = await configApi.listSlideStyles();
+    setStyles(resp.styles);
+  };
 
   useEffect(() => {
     let cancelled = false;
-    configApi.listSlideStyles()
-      .then(resp => {
-        if (cancelled) return;
-        setStyles(resp.styles);
-      })
+    load()
       .catch(err => {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : String(err));
@@ -23,6 +27,20 @@ export const AdminSlideStyleDefault: React.FC = () => {
       });
     return () => { cancelled = true; };
   }, []);
+
+  const handleSet = async (id: number) => {
+    setSaving(id);
+    try {
+      await configApi.setSlideStyleSystemDefault(id);
+      await load();
+      showToast('System default slide style updated', 'success');
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      showToast(`Failed to set system default: ${message}`, 'error');
+    } finally {
+      setSaving(null);
+    }
+  };
 
   if (loading) {
     return <div className="text-sm text-gray-500">Loading slide styles…</div>;
@@ -41,13 +59,34 @@ export const AdminSlideStyleDefault: React.FC = () => {
       </p>
       <ul className="divide-y divide-gray-200 rounded border border-gray-200 bg-white">
         {styles.map(style => (
-          <li key={style.id} className="flex items-center justify-between px-4 py-3">
-            <div>
-              <div className="font-medium text-gray-900">{style.name}</div>
+          <li
+            key={style.id}
+            data-testid={`slide-style-row-${style.id}`}
+            className="flex items-center justify-between px-4 py-3 gap-4"
+          >
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-gray-900">{style.name}</span>
+                {style.is_default && (
+                  <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                    System default
+                  </span>
+                )}
+              </div>
               {style.description && (
                 <div className="text-xs text-gray-500 mt-0.5">{style.description}</div>
               )}
             </div>
+            {style.is_active && !style.is_default && (
+              <button
+                type="button"
+                disabled={saving === style.id}
+                onClick={() => void handleSet(style.id)}
+                className="shrink-0 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline disabled:cursor-not-allowed disabled:text-blue-300"
+              >
+                {saving === style.id ? 'Setting…' : 'Set as system default'}
+              </button>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/src/components/Admin/AdminSlideStyleDefault.tsx
+++ b/frontend/src/components/Admin/AdminSlideStyleDefault.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { configApi } from '../../api/config';
+import type { SlideStyle } from '../../api/config';
+
+export const AdminSlideStyleDefault: React.FC = () => {
+  const [styles, setStyles] = useState<SlideStyle[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    configApi.listSlideStyles()
+      .then(resp => {
+        if (cancelled) return;
+        setStyles(resp.styles);
+      })
+      .catch(err => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) {
+    return <div className="text-sm text-gray-500">Loading slide styles…</div>;
+  }
+  if (error) {
+    return <div className="text-sm text-red-600">Failed to load slide styles: {error}</div>;
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold text-gray-900 mb-2">System Default Slide Style</h2>
+      <p className="text-sm text-gray-500 mb-4">
+        The style marked as the system default applies to every new deck — including
+        those created via MCP — unless a user has chosen their own default from the
+        Slide Styles settings page.
+      </p>
+      <ul className="divide-y divide-gray-200 rounded border border-gray-200 bg-white">
+        {styles.map(style => (
+          <li key={style.id} className="flex items-center justify-between px-4 py-3">
+            <div>
+              <div className="font-medium text-gray-900">{style.name}</div>
+              {style.description && (
+                <div className="text-xs text-gray-500 mt-0.5">{style.description}</div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/src/components/Help/HelpPage.tsx
+++ b/frontend/src/components/Help/HelpPage.tsx
@@ -777,7 +777,31 @@ Use {{image:12}} as the background for the title slide.`}
 );
 
 // MCP Tab Content
-const MCPTab: React.FC = () => <div>TBD</div>;
+const MCPTab: React.FC = () => (
+  <div className="space-y-6">
+    <section>
+      <h2 className="text-lg font-semibold text-gray-800 mb-3">What is MCP?</h2>
+      <p className="text-gray-600">
+        The Model Context Protocol (MCP) exposes tellr's deck generator as a
+        programmatic endpoint. Agents like Claude Code, Claude Desktop, and
+        Cursor — and any HTTP-speaking client — can create, edit, and
+        retrieve decks without the browser UI. Decks generated over MCP land
+        in your tellr history exactly as if you'd made them interactively.
+      </p>
+    </section>
+
+    <section>
+      <h2 className="text-lg font-semibold text-gray-800 mb-3">Who's this for?</h2>
+      <p className="text-gray-600">
+        Developers and power users who want to automate deck creation — a CI
+        job that drops a weekly briefing into Slack, an internal app that
+        turns a CRM record into a pitch deck, an agent runtime that calls
+        tellr as one tool in a wider workflow. If you only need interactive
+        generation, stay on the main page.
+      </p>
+    </section>
+  </div>
+);
 
 // Reusable doc link component for tab footers
 const DocLink: React.FC<{ href: string; label: string }> = ({ href, label }) => (

--- a/frontend/src/components/Help/HelpPage.tsx
+++ b/frontend/src/components/Help/HelpPage.tsx
@@ -129,6 +129,7 @@ const OverviewTab: React.FC<{
         <QuickLinkButton tab="deck_prompts" label="Learn about Deck Prompts →" />
         <QuickLinkButton tab="slide_styles" label="Learn about Slide Styles →" />
         <QuickLinkButton tab="images" label="Learn about Images →" />
+        <QuickLinkButton tab="mcp" label="Learn about MCP →" />
       </div>
     </section>
 

--- a/frontend/src/components/Help/HelpPage.tsx
+++ b/frontend/src/components/Help/HelpPage.tsx
@@ -80,6 +80,7 @@ const OverviewTab: React.FC<{
         <li>Creates presentation slides from natural language using AI</li>
         <li>Pulls data from Databricks Genie spaces for data-driven presentations</li>
         <li>Supports iterative editing through conversational interface</li>
+        <li>Programmatic API via MCP — call tellr from agents, CI, or other apps</li>
       </ul>
     </section>
 

--- a/frontend/src/components/Help/HelpPage.tsx
+++ b/frontend/src/components/Help/HelpPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { FiMessageSquare, FiClock, FiSettings, FiInfo, FiShield, FiFileText, FiLayout, FiExternalLink, FiImage } from 'react-icons/fi';
 import { FaGavel } from 'react-icons/fa';
 import { DOCS_URLS } from '../../constants/docs';
+import { useToast } from '../../contexts/ToastContext';
 
 type HelpTab = 'overview' | 'generator' | 'history' | 'profiles' | 'deck_prompts' | 'slide_styles' | 'images' | 'verification' | 'mcp';
 
@@ -777,31 +778,72 @@ Use {{image:12}} as the background for the title slide.`}
 );
 
 // MCP Tab Content
-const MCPTab: React.FC = () => (
-  <div className="space-y-6">
-    <section>
-      <h2 className="text-lg font-semibold text-gray-800 mb-3">What is MCP?</h2>
-      <p className="text-gray-600">
-        The Model Context Protocol (MCP) exposes tellr's deck generator as a
-        programmatic endpoint. Agents like Claude Code, Claude Desktop, and
-        Cursor — and any HTTP-speaking client — can create, edit, and
-        retrieve decks without the browser UI. Decks generated over MCP land
-        in your tellr history exactly as if you'd made them interactively.
-      </p>
-    </section>
+const MCPTab: React.FC = () => {
+  const { showToast } = useToast();
+  const mcpEndpoint = `${window.location.origin}/mcp/`;
 
-    <section>
-      <h2 className="text-lg font-semibold text-gray-800 mb-3">Who's this for?</h2>
-      <p className="text-gray-600">
-        Developers and power users who want to automate deck creation — a CI
-        job that drops a weekly briefing into Slack, an internal app that
-        turns a CRM record into a pitch deck, an agent runtime that calls
-        tellr as one tool in a wider workflow. If you only need interactive
-        generation, stay on the main page.
-      </p>
-    </section>
-  </div>
-);
+  const copyEndpoint = async () => {
+    try {
+      await navigator.clipboard.writeText(mcpEndpoint);
+      showToast('MCP endpoint copied to clipboard', 'success');
+    } catch {
+      showToast(
+        `Unable to copy automatically — endpoint is ${mcpEndpoint}`,
+        'error',
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">What is MCP?</h2>
+        <p className="text-gray-600">
+          The Model Context Protocol (MCP) exposes tellr's deck generator as a
+          programmatic endpoint. Agents like Claude Code, Claude Desktop, and
+          Cursor — and any HTTP-speaking client — can create, edit, and
+          retrieve decks without the browser UI. Decks generated over MCP land
+          in your tellr history exactly as if you'd made them interactively.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Who's this for?</h2>
+        <p className="text-gray-600">
+          Developers and power users who want to automate deck creation — a CI
+          job that drops a weekly briefing into Slack, an internal app that
+          turns a CRM record into a pitch deck, an agent runtime that calls
+          tellr as one tool in a wider workflow. If you only need interactive
+          generation, stay on the main page.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Your endpoint</h2>
+        <div className="flex items-center gap-2 rounded bg-gray-50 border border-gray-200 p-3">
+          <code
+            data-testid="mcp-endpoint-url"
+            className="text-sm font-mono flex-1 break-all"
+          >
+            {mcpEndpoint}
+          </code>
+          <button
+            type="button"
+            onClick={() => void copyEndpoint()}
+            aria-label="Copy endpoint URL"
+            className="shrink-0 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+          >
+            Copy endpoint
+          </button>
+        </div>
+        <p className="text-xs text-gray-500 mt-2">
+          For production deployments behind a custom hostname, see the full
+          guide for how to resolve the correct URL.
+        </p>
+      </section>
+    </div>
+  );
+};
 
 // Reusable doc link component for tab footers
 const DocLink: React.FC<{ href: string; label: string }> = ({ href, label }) => (

--- a/frontend/src/components/Help/HelpPage.tsx
+++ b/frontend/src/components/Help/HelpPage.tsx
@@ -3,7 +3,7 @@ import { FiMessageSquare, FiClock, FiSettings, FiInfo, FiShield, FiFileText, FiL
 import { FaGavel } from 'react-icons/fa';
 import { DOCS_URLS } from '../../constants/docs';
 
-type HelpTab = 'overview' | 'generator' | 'history' | 'profiles' | 'deck_prompts' | 'slide_styles' | 'images' | 'verification';
+type HelpTab = 'overview' | 'generator' | 'history' | 'profiles' | 'deck_prompts' | 'slide_styles' | 'images' | 'verification' | 'mcp';
 
 export const HelpPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<HelpTab>('overview');
@@ -48,6 +48,7 @@ export const HelpPage: React.FC = () => {
         <TabButton tab="deck_prompts" label="Deck Prompts" icon={FiFileText} />
         <TabButton tab="slide_styles" label="Slide Styles" icon={FiLayout} />
         <TabButton tab="images" label="Images" icon={FiImage} />
+        <TabButton tab="mcp" label="MCP" icon={FiExternalLink} />
       </div>
 
       {/* Content area */}
@@ -60,6 +61,7 @@ export const HelpPage: React.FC = () => {
         {activeTab === 'deck_prompts' && <DeckPromptsTab />}
         {activeTab === 'slide_styles' && <SlideStylesTab />}
         {activeTab === 'images' && <ImagesTab />}
+        {activeTab === 'mcp' && <MCPTab />}
       </div>
     </div>
   );
@@ -773,6 +775,9 @@ Use {{image:12}} as the background for the title slide.`}
     <DocLink href={DOCS_URLS.uploadingImages} label="Uploading Images Guide" />
   </div>
 );
+
+// MCP Tab Content
+const MCPTab: React.FC = () => <div>TBD</div>;
 
 // Reusable doc link component for tab footers
 const DocLink: React.FC<{ href: string; label: string }> = ({ href, label }) => (

--- a/frontend/src/components/Help/HelpPage.tsx
+++ b/frontend/src/components/Help/HelpPage.tsx
@@ -841,6 +841,19 @@ const MCPTab: React.FC = () => {
           guide for how to resolve the correct URL.
         </p>
       </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Prerequisites</h2>
+        <ul className="list-disc list-inside text-gray-600 space-y-2">
+          <li>A Databricks user token (OAuth U2M or PAT)</li>
+          <li>
+            An MCP-capable client: Claude Code, Claude Desktop, Cursor, or a
+            raw HTTP library that speaks JSON-RPC 2.0
+          </li>
+        </ul>
+      </section>
+
+      <DocLink href={DOCS_URLS.mcpIntegrationGuide} label="MCP Integration Guide" />
     </div>
   );
 };

--- a/frontend/src/constants/docs.ts
+++ b/frontend/src/constants/docs.ts
@@ -13,6 +13,10 @@ export const DOCS_URLS = {
   exportingGoogleSlides: userGuide('exporting-to-google-slides'),
   retrievingFeedback: userGuide('retrieving-feedback'),
 
+  // MCP (technical reference + integration guide)
+  mcpServer: `${DOCS_BASE}/technical/mcp-server`,
+  mcpIntegrationGuide: `${DOCS_BASE}/technical/mcp-integration-guide`,
+
   customStylesCSS: userGuide('creating-custom-styles#raw-css'),
   customStylesCSSFeatures: userGuide('creating-custom-styles#css-features-that-work'),
   customStylesConstraints: userGuide('creating-custom-styles#fixed-constraints'),

--- a/frontend/tests/e2e/admin-page.spec.ts
+++ b/frontend/tests/e2e/admin-page.spec.ts
@@ -49,6 +49,115 @@ test.describe('Admin Page', () => {
     await expect(page.getByText('Corporate Theme', { exact: true })).toBeVisible();
   });
 
+  test('Slide Style tab marks the is_default row with a System default badge', async ({ page }) => {
+    await setupSlideStyleMocks(page);
+    await page.goto('/admin');
+    await page.getByRole('tab', { name: 'Slide Style' }).click();
+    // Row 1 ("System Default") is is_default=true in the fixture.
+    const defaultRow = page.getByTestId('slide-style-row-1');
+    await expect(defaultRow.getByText('System default', { exact: true })).toBeVisible();
+    // Row 2 ("Corporate Theme") must not carry the badge.
+    const otherRow = page.getByTestId('slide-style-row-2');
+    await expect(otherRow.getByText('System default', { exact: true })).toHaveCount(0);
+  });
+
+  test('Set as system default button shows only on non-default active rows', async ({ page }) => {
+    await setupSlideStyleMocks(page);
+    await page.goto('/admin');
+    await page.getByRole('tab', { name: 'Slide Style' }).click();
+    const defaultRow = page.getByTestId('slide-style-row-1');
+    const otherRow = page.getByTestId('slide-style-row-2');
+    // The current default row should not offer the action.
+    await expect(
+      defaultRow.getByRole('button', { name: 'Set as system default' }),
+    ).toHaveCount(0);
+    // Another active, non-default row should.
+    await expect(
+      otherRow.getByRole('button', { name: 'Set as system default' }),
+    ).toBeVisible();
+  });
+
+  test('Inactive slide styles do not show the Set as system default button', async ({ page }) => {
+    await setupSlideStyleMocks(page);
+    await page.goto('/admin');
+    await page.getByRole('tab', { name: 'Slide Style' }).click();
+    // Row 3 ("Archived Legacy") is is_active=false in the fixture.
+    const inactiveRow = page.getByTestId('slide-style-row-3');
+    await expect(
+      inactiveRow.getByRole('button', { name: 'Set as system default' }),
+    ).toHaveCount(0);
+  });
+
+  test('A failed Set as system default surfaces an error toast', async ({ page }) => {
+    await setupSlideStyleMocks(page);
+    await page.route('**/api/settings/slide-styles/*/set-default', (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'boom' }),
+      });
+    });
+
+    await page.goto('/admin');
+    await page.getByRole('tab', { name: 'Slide Style' }).click();
+    await page
+      .getByTestId('slide-style-row-2')
+      .getByRole('button', { name: 'Set as system default' })
+      .click();
+
+    const toast = page.getByTestId('toast');
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText(/failed|error|boom/i);
+  });
+
+  test('Clicking Set as system default calls the endpoint and moves the badge', async ({ page }) => {
+    // Track whether the set-default POST has fired. The list mock keys off
+    // this flag so strict-mode double-effect pre-click returns the initial
+    // state, and any re-fetch after the POST returns the post-change state.
+    let setDefaultUrl: string | null = null;
+    let setDefaultFired = false;
+    await page.route('**/api/settings/slide-styles/*/set-default', (route, req) => {
+      setDefaultUrl = req.url();
+      setDefaultFired = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSlideStyles.styles[1],
+          is_default: true,
+        }),
+      });
+    });
+    await page.route('**/api/settings/slide-styles', (route) => {
+      const styles = setDefaultFired
+        ? mockSlideStyles.styles.map(s => ({ ...s, is_default: s.id === 2 }))
+        : mockSlideStyles.styles;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ styles, total: styles.length }),
+      });
+    });
+
+    await page.goto('/admin');
+    await page.getByRole('tab', { name: 'Slide Style' }).click();
+    await page
+      .getByTestId('slide-style-row-2')
+      .getByRole('button', { name: 'Set as system default' })
+      .click();
+
+    // Exact id in the URL path.
+    await expect.poll(() => setDefaultUrl).toContain('/api/settings/slide-styles/2/set-default');
+    // Badge now on Corporate Theme.
+    await expect(
+      page.getByTestId('slide-style-row-2').getByText('System default', { exact: true }),
+    ).toBeVisible();
+    // Badge removed from System Default row.
+    await expect(
+      page.getByTestId('slide-style-row-1').getByText('System default', { exact: true }),
+    ).toHaveCount(0);
+  });
+
   test('Feedback tab renders FeedbackDashboard content', async ({ page }) => {
     await page.goto('/admin');
     await page.getByRole('tab', { name: 'Feedback' }).click();

--- a/frontend/tests/e2e/admin-page.spec.ts
+++ b/frontend/tests/e2e/admin-page.spec.ts
@@ -1,19 +1,52 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
+import { mockSlideStyles } from '../fixtures/mocks';
 
 /**
  * Admin Page E2E Tests
  *
- * Tests the consolidated admin page with Feedback and Google Slides tabs.
- * Frontend at baseURL (localhost:3000), backend at http://127.0.0.1:8000
+ * Tests the consolidated admin page with Feedback, Google Slides, and
+ * Slide Style tabs. Frontend at baseURL (localhost:3000), backend at
+ * http://127.0.0.1:8000.
  *
  * Run with: npx playwright test e2e/admin-page.spec.ts
  */
+
+// Mock the slide styles listing so the Slide Style tab renders a known
+// fixture without needing a running backend.
+async function setupSlideStyleMocks(page: Page) {
+  await page.route('**/api/settings/slide-styles', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockSlideStyles),
+    });
+  });
+}
 
 test.describe('Admin Page', () => {
   test('renders page with Feedback and Google Slides tabs', async ({ page }) => {
     await page.goto('/admin');
     await expect(page.getByRole('tab', { name: 'Feedback' })).toBeVisible();
     await expect(page.getByRole('tab', { name: 'Google Slides' })).toBeVisible();
+  });
+
+  test('renders Slide Style tab alongside Feedback and Google Slides', async ({ page }) => {
+    await setupSlideStyleMocks(page);
+    await page.goto('/admin');
+    await expect(page.getByRole('tab', { name: 'Slide Style' })).toBeVisible();
+  });
+
+  test('Slide Style tab renders each slide style name', async ({ page }) => {
+    await setupSlideStyleMocks(page);
+    await page.goto('/admin');
+    await page.getByRole('tab', { name: 'Slide Style' }).click();
+    await expect(
+      page.getByRole('heading', { name: 'System Default Slide Style' }),
+    ).toBeVisible();
+    // getByText resolves inside the active tabpanel; the other panels remain
+    // rendered but are hidden via the `hidden` attribute + `sr-only` class.
+    await expect(page.getByText('System Default', { exact: true })).toBeVisible();
+    await expect(page.getByText('Corporate Theme', { exact: true })).toBeVisible();
   });
 
   test('Feedback tab renders FeedbackDashboard content', async ({ page }) => {

--- a/frontend/tests/e2e/help-ui.spec.ts
+++ b/frontend/tests/e2e/help-ui.spec.ts
@@ -161,6 +161,11 @@ test.describe('HelpTabs', () => {
 
     await expect(page.getByRole('heading', { name: 'What are Slide Styles?' })).toBeVisible();
   });
+
+  test('MCP tab renders in the tab strip', async ({ page }) => {
+    await goToHelp(page);
+    await expect(getHelpTabButton(page, 'MCP')).toBeVisible();
+  });
 });
 
 // ============================================

--- a/frontend/tests/e2e/help-ui.spec.ts
+++ b/frontend/tests/e2e/help-ui.spec.ts
@@ -213,6 +213,12 @@ test.describe('HelpTabs', () => {
     // Default tab is Overview.
     await expect(page.getByText(/Programmatic API via MCP/)).toBeVisible();
   });
+
+  test('Overview Quick Link navigates to the MCP tab', async ({ page }) => {
+    await goToHelp(page);
+    await page.getByRole('button', { name: /Learn about MCP/ }).click();
+    await expect(page.getByRole('heading', { name: 'What is MCP?' })).toBeVisible();
+  });
 });
 
 // ============================================

--- a/frontend/tests/e2e/help-ui.spec.ts
+++ b/frontend/tests/e2e/help-ui.spec.ts
@@ -207,6 +207,12 @@ test.describe('HelpTabs', () => {
     const href = await link.getAttribute('href');
     expect(href).toContain('/technical/mcp-integration-guide');
   });
+
+  test('Overview tab shows MCP as a headline capability', async ({ page }) => {
+    await goToHelp(page);
+    // Default tab is Overview.
+    await expect(page.getByText(/Programmatic API via MCP/)).toBeVisible();
+  });
 });
 
 // ============================================

--- a/frontend/tests/e2e/help-ui.spec.ts
+++ b/frontend/tests/e2e/help-ui.spec.ts
@@ -173,6 +173,23 @@ test.describe('HelpTabs', () => {
     await expect(page.getByRole('heading', { name: 'What is MCP?' })).toBeVisible();
     await expect(page.getByRole('heading', { name: "Who's this for?" })).toBeVisible();
   });
+
+  test('MCP tab shows the live endpoint URL ending in /mcp/', async ({ page }) => {
+    await goToHelp(page);
+    await getHelpTabButton(page, 'MCP').click();
+
+    const endpointBlock = page.getByTestId('mcp-endpoint-url');
+    await expect(endpointBlock).toBeVisible();
+    await expect(endpointBlock).toContainText('/mcp/');
+  });
+
+  test('MCP tab has a copy endpoint button', async ({ page }) => {
+    await goToHelp(page);
+    await getHelpTabButton(page, 'MCP').click();
+    await expect(
+      page.getByRole('button', { name: /copy endpoint/i }),
+    ).toBeVisible();
+  });
 });
 
 // ============================================

--- a/frontend/tests/e2e/help-ui.spec.ts
+++ b/frontend/tests/e2e/help-ui.spec.ts
@@ -190,6 +190,23 @@ test.describe('HelpTabs', () => {
       page.getByRole('button', { name: /copy endpoint/i }),
     ).toBeVisible();
   });
+
+  test('MCP tab shows prerequisites', async ({ page }) => {
+    await goToHelp(page);
+    await getHelpTabButton(page, 'MCP').click();
+    await expect(page.getByRole('heading', { name: 'Prerequisites' })).toBeVisible();
+    await expect(page.getByText(/Databricks user token/i)).toBeVisible();
+  });
+
+  test('MCP tab links to the integration guide', async ({ page }) => {
+    await goToHelp(page);
+    await getHelpTabButton(page, 'MCP').click();
+
+    const link = page.getByRole('link', { name: /MCP Integration Guide/i });
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute('href');
+    expect(href).toContain('/technical/mcp-integration-guide');
+  });
 });
 
 // ============================================

--- a/frontend/tests/e2e/help-ui.spec.ts
+++ b/frontend/tests/e2e/help-ui.spec.ts
@@ -166,6 +166,13 @@ test.describe('HelpTabs', () => {
     await goToHelp(page);
     await expect(getHelpTabButton(page, 'MCP')).toBeVisible();
   });
+
+  test('MCP tab shows What is MCP and Who is this for sections', async ({ page }) => {
+    await goToHelp(page);
+    await getHelpTabButton(page, 'MCP').click();
+    await expect(page.getByRole('heading', { name: 'What is MCP?' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: "Who's this for?" })).toBeVisible();
+  });
 });
 
 // ============================================

--- a/frontend/tests/e2e/slide-styles-ui.spec.ts
+++ b/frontend/tests/e2e/slide-styles-ui.spec.ts
@@ -210,10 +210,10 @@ test.describe('SlideStyleList', () => {
   test('shows Preview button for all styles', async ({ page }) => {
     await goToSlideStyles(page);
 
-    // Both styles should have Preview button
+    // Every style (active or inactive) renders with a Preview button.
     const previewButtons = page.getByRole('button', { name: 'Preview' });
     await expect(previewButtons.first()).toBeVisible();
-    expect(await previewButtons.count()).toBe(2);
+    expect(await previewButtons.count()).toBe(3);
   });
 
   test('Preview button toggles to Hide when clicked', async ({ page }) => {

--- a/frontend/tests/fixtures/mocks.ts
+++ b/frontend/tests/fixtures/mocks.ts
@@ -106,6 +106,7 @@ export const mockSlideStyles = {
       style_content: "/* System default CSS */",
       is_active: true,
       is_system: true,
+      is_default: true,
       created_by: "system",
       created_at: "2026-01-08T20:10:28.692105",
       updated_by: "system",
@@ -119,13 +120,28 @@ export const mockSlideStyles = {
       style_content: "/* Databricks brand style CSS */",
       is_active: true,
       is_system: false,
+      is_default: false,
       created_by: "system",
       created_at: "2026-01-08T20:10:28.695640",
       updated_by: "system",
       updated_at: "2026-01-08T20:10:28.695641"
+    },
+    {
+      id: 3,
+      name: "Archived Legacy",
+      description: "Retired style kept for historical reference.",
+      category: "Brand",
+      style_content: "/* archived */",
+      is_active: false,
+      is_system: false,
+      is_default: false,
+      created_by: "system",
+      created_at: "2026-01-08T20:10:28.700000",
+      updated_by: "system",
+      updated_at: "2026-01-08T20:10:28.700000"
     }
   ],
-  total: 2
+  total: 3
 };
 
 // Sessions endpoint returns { sessions: [...], count: n }

--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "langchain-community==0.4.1",
     "langchain-text-splitters==1.0.0",
     "litellm==1.80.11",
+    "mcp==1.27.0",
     "mlflow==3.6.0",
     "opentelemetry-api==1.38.0",
     "opentelemetry-sdk==1.38.0",

--- a/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
+++ b/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
@@ -29,3 +29,9 @@ env:
     valueFrom: "system.databricks_host"
   - name: DATABRICKS_TOKEN
     valueFrom: "system.databricks_token"
+  # Opt-in to trust x-forwarded-email / x-forwarded-user on the MCP endpoint
+  # for app-to-app calls. Safe inside Databricks Apps because the proxy sets
+  # these headers itself and strips any caller-supplied versions. See
+  # src/api/mcp_auth.py and docs/technical/mcp-server.md section 4.2A.
+  - name: TELLR_TRUST_FORWARDED_IDENTITY
+    value: "true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "langchain-community>=0.0.1",
     "langchain-text-splitters>=0.0.1",
     "litellm==1.80.11",
+    "mcp>=1.0.0",
     "python-pptx>=0.6.0",
     "playwright>=1.40.0",
     "Pillow>=10.0.0",

--- a/scripts/mcp_smoke/README.md
+++ b/scripts/mcp_smoke/README.md
@@ -1,0 +1,44 @@
+# MCP Smoke Tests
+
+Manual verification scripts for the tellr MCP endpoint after deploy.
+These are NOT run in CI — they require a live deployed tellr app and
+a real Databricks user token.
+
+## `mcp_smoke_httpx.py`
+
+Runs the full `initialize → notifications/initialized → tools/list →
+create_deck → poll → ready` flow using raw `httpx`. Prints each
+step's outcome and exits 0 on success.
+
+### Running
+
+```bash
+export TELLR_URL=https://<your-tellr-app-url>
+export DATABRICKS_TOKEN=<a-databricks-user-token>
+python scripts/mcp_smoke/mcp_smoke_httpx.py
+```
+
+Expected output ends with:
+
+```
+Step 4: poll get_deck_status (up to 10 minutes)
+  status=running  (elapsed=2s)
+  status=ready  (elapsed=47s)
+  slide_count=3
+  deck_url=https://<your-tellr-app-url>/sessions/<id>/edit
+SUCCESS
+```
+
+### Notes
+
+- The script polls every 2 seconds with a 10-minute hard timeout that
+  matches the server-side `JOB_HARD_TIMEOUT_SECONDS`.
+- The MCP endpoint path has a mandatory trailing slash. The script
+  uses `/mcp/` directly to avoid the 307 redirect that `POST /mcp`
+  returns.
+- FastMCP responds with `text/event-stream` for some requests. The
+  script's `_decode_response` helper handles both JSON and SSE frames.
+- If `initialize` returns no `mcp-session-id` header, the deployment
+  did not pick up the MCP router — redeploy and check `/api/health`.
+- If auth fails with the token, try generating a fresh PAT or using
+  `databricks auth login` output.

--- a/scripts/mcp_smoke/README.md
+++ b/scripts/mcp_smoke/README.md
@@ -38,7 +38,9 @@ SUCCESS
   returns.
 - FastMCP responds with `text/event-stream` for some requests. The
   script's `_decode_response` helper handles both JSON and SSE frames.
-- If `initialize` returns no `mcp-session-id` header, the deployment
-  did not pick up the MCP router — redeploy and check `/api/health`.
+- tellr runs FastMCP in stateless mode, so `initialize` will not
+  return an `mcp-session-id` header — that's expected. If the endpoint
+  returns HTML instead of a JSON-RPC envelope, the deployment did not
+  pick up the MCP router — redeploy and check `/api/health`.
 - If auth fails with the token, try generating a fresh PAT or using
   `databricks auth login` output.

--- a/scripts/mcp_smoke/mcp_smoke_httpx.py
+++ b/scripts/mcp_smoke/mcp_smoke_httpx.py
@@ -79,13 +79,16 @@ def main() -> int:
     }
     resp = httpx.post(mcp_url, headers=headers_base, json=init_body, timeout=30)
     resp.raise_for_status()
+    # tellr's FastMCP is configured stateless (multi-worker safety), so the
+    # server doesn't emit mcp-session-id. Echo one if it happens to be
+    # present (stateful deployments) for forward compatibility.
     session_id = resp.headers.get("mcp-session-id")
-    if not session_id:
-        print(f"ERROR: no mcp-session-id in response headers: {dict(resp.headers)}")
-        return 1
-    print(f"  mcp-session-id: {session_id}")
-
-    mcp_headers = {**headers_base, "mcp-session-id": session_id}
+    if session_id:
+        print(f"  mcp-session-id: {session_id}")
+        mcp_headers = {**headers_base, "mcp-session-id": session_id}
+    else:
+        print("  stateless transport (no mcp-session-id issued)")
+        mcp_headers = headers_base
 
     # Step 1b: required notifications/initialized
     print("Step 1b: notifications/initialized")

--- a/scripts/mcp_smoke/mcp_smoke_httpx.py
+++ b/scripts/mcp_smoke/mcp_smoke_httpx.py
@@ -1,0 +1,216 @@
+"""Post-deploy smoke test for the tellr MCP endpoint.
+
+Runs a full create_deck -> poll -> ready flow against a deployed
+tellr Databricks App using a real user token. Prints each step's
+outcome.
+
+Usage:
+    export TELLR_URL=https://<your-tellr-app-url>
+    export DATABRICKS_TOKEN=<your-databricks-token>
+    python scripts/mcp_smoke/mcp_smoke_httpx.py
+
+Exits 0 on success, non-zero with an error message on failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+import httpx
+
+
+# The MCP endpoint path has a mandatory trailing slash; POST /mcp
+# returns 307 -> /mcp/.
+MCP_PATH_SUFFIX = "/mcp/"
+# MCP Streamable HTTP requires this Accept header to support the spec
+# revision the server advertises (negotiated during initialize).
+ACCEPT = "application/json, text/event-stream"
+
+
+def _decode_response(resp: httpx.Response) -> dict:
+    """Return the JSON-RPC response body, handling both plain JSON and SSE.
+
+    FastMCP replies with text/event-stream when the client Accept
+    includes it. Extract the first `data: {...}` frame.
+    """
+    ctype = resp.headers.get("content-type", "").lower()
+    if "event-stream" in ctype:
+        for line in resp.text.splitlines():
+            if line.startswith("data:"):
+                return json.loads(line[len("data:"):].strip())
+        raise RuntimeError(
+            f"SSE response without a data line:\n{resp.text[:500]}"
+        )
+    return resp.json()
+
+
+def main() -> int:
+    tellr_url = os.environ.get("TELLR_URL", "").rstrip("/")
+    token = os.environ.get("DATABRICKS_TOKEN", "")
+
+    if not tellr_url:
+        print("ERROR: TELLR_URL is required", file=sys.stderr)
+        return 2
+    if not token:
+        print("ERROR: DATABRICKS_TOKEN is required", file=sys.stderr)
+        return 2
+
+    mcp_url = f"{tellr_url}{MCP_PATH_SUFFIX}"
+    headers_base = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": ACCEPT,
+    }
+
+    print(f"Smoke-testing {mcp_url}")
+
+    # Step 1: initialize
+    print("Step 1: initialize")
+    init_body = {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "tellr-smoke", "version": "0.0.1"},
+        },
+    }
+    resp = httpx.post(mcp_url, headers=headers_base, json=init_body, timeout=30)
+    resp.raise_for_status()
+    session_id = resp.headers.get("mcp-session-id")
+    if not session_id:
+        print(f"ERROR: no mcp-session-id in response headers: {dict(resp.headers)}")
+        return 1
+    print(f"  mcp-session-id: {session_id}")
+
+    mcp_headers = {**headers_base, "mcp-session-id": session_id}
+
+    # Step 1b: required notifications/initialized
+    print("Step 1b: notifications/initialized")
+    notif_resp = httpx.post(
+        mcp_url,
+        headers=mcp_headers,
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        timeout=30,
+    )
+    # 200/202 are both acceptable for a notification ack.
+    if notif_resp.status_code >= 300:
+        print(
+            f"WARNING: notifications/initialized returned HTTP {notif_resp.status_code}; "
+            f"proceeding anyway"
+        )
+
+    # Step 2: tools/list
+    print("Step 2: tools/list")
+    resp = httpx.post(
+        mcp_url,
+        headers=mcp_headers,
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    body = _decode_response(resp)
+    tool_names = [t["name"] for t in body["result"]["tools"]]
+    print(f"  tools: {tool_names}")
+    expected = {"create_deck", "get_deck_status", "edit_deck", "get_deck"}
+    missing = expected - set(tool_names)
+    if missing:
+        print(f"ERROR: missing tools {missing}")
+        return 1
+
+    # Step 3: create_deck
+    print("Step 3: create_deck")
+    resp = httpx.post(
+        mcp_url,
+        headers=mcp_headers,
+        json={
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {
+                "name": "create_deck",
+                "arguments": {
+                    "prompt": "a three-slide smoke-test deck about the weather"
+                },
+            },
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+    body = _decode_response(resp)
+    result = body.get("result", {})
+    content = result.get("content") or []
+    text_block = content[0] if content else {}
+    payload_text = text_block.get("text", "{}") if isinstance(text_block, dict) else "{}"
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError:
+        payload = result
+    if result.get("isError"):
+        print(f"ERROR from create_deck: {payload_text}")
+        return 1
+    session_id_deck = payload["session_id"]
+    request_id = payload["request_id"]
+    print(
+        f"  session_id={session_id_deck}, request_id={request_id}, "
+        f"status={payload['status']}"
+    )
+
+    # Step 4: poll get_deck_status (up to 10 minutes)
+    print("Step 4: poll get_deck_status (up to 10 minutes)")
+    start = time.time()
+    last_status = None
+    while time.time() - start < 600:
+        resp = httpx.post(
+            mcp_url,
+            headers=mcp_headers,
+            json={
+                "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                "params": {
+                    "name": "get_deck_status",
+                    "arguments": {
+                        "session_id": session_id_deck,
+                        "request_id": request_id,
+                    },
+                },
+            },
+            timeout=60,
+        )
+        resp.raise_for_status()
+        body = _decode_response(resp)
+        result = body.get("result", {})
+        content = result.get("content") or []
+        payload_text = (
+            content[0].get("text", "{}") if content and isinstance(content[0], dict) else "{}"
+        )
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError:
+            payload = result
+
+        status = payload.get("status")
+        if status != last_status:
+            print(f"  status={status}  (elapsed={int(time.time() - start)}s)")
+            last_status = status
+
+        if status == "ready":
+            print(f"  slide_count={payload.get('slide_count')}")
+            print(f"  deck_url={payload.get('deck_url')}")
+            html_doc = payload.get("html_document", "")
+            if not html_doc.lower().startswith("<!doctype"):
+                print(f"ERROR: html_document does not start with <!doctype>")
+                return 1
+            print("SUCCESS")
+            return 0
+        if status == "failed":
+            print(f"FAILED: {payload.get('error')}")
+            return 1
+
+        time.sleep(2)
+
+    print("TIMEOUT: generation did not complete within 10 minutes")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -7,7 +7,7 @@ In production, also serves the React frontend as static files.
 import asyncio
 import logging
 import os
-from contextlib import ExitStack, asynccontextmanager
+from contextlib import AsyncExitStack, ExitStack, asynccontextmanager
 from importlib import resources
 from pathlib import Path
 
@@ -52,16 +52,44 @@ IS_TESTING = ENVIRONMENT == "test"
 _worker_task = None
 _export_worker_task = None
 _cleanup_task = None
+_timeout_task = None
 _frontend_assets_stack: ExitStack | None = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup/shutdown events."""
-    global _worker_task, _export_worker_task, _cleanup_task, _frontend_assets_stack
+    global _worker_task, _export_worker_task, _cleanup_task, _timeout_task, _frontend_assets_stack
 
     # Startup
     logger.info(f"Starting AI Slide Generator API (environment: {ENVIRONMENT})")
+
+    # The FastMCP streamable-HTTP transport spawns per-session async tasks
+    # inside a task group owned by its StreamableHTTPSessionManager. That
+    # task group is initialised by ``session_manager.run()`` and is
+    # required before ``handle_request`` will accept any POST. When the
+    # MCP app is nested under FastAPI via ``app.mount("/mcp", ...)``,
+    # Starlette does NOT run the nested app's lifespan, so we have to
+    # enter the session manager context here. AsyncExitStack guarantees
+    # clean teardown of the task group on shutdown alongside the other
+    # worker tasks below.
+    #
+    # Skipped under pytest: ``StreamableHTTPSessionManager.run()`` can
+    # only be entered once per process, and unit-test suites instantiate
+    # the ``TestClient`` (and therefore the lifespan) multiple times
+    # against the same module-level FastMCP singleton. MCP endpoint
+    # coverage lives in the integration tests, which set up their own
+    # session manager lifecycle.
+    mcp_lifespan_stack = AsyncExitStack()
+    if os.getenv("PYTEST_CURRENT_TEST") is None:
+        from src.api.mcp_server import mcp as tellr_mcp
+
+        await mcp_lifespan_stack.enter_async_context(
+            tellr_mcp.session_manager.run()
+        )
+        logger.info("MCP session manager started")
+    else:
+        logger.info("Pytest detected: skipping MCP session manager startup")
 
     # Start Lakebase token refresh if running in Databricks Apps
     # Must happen before init_db() so OAuth token is ready for database connections
@@ -111,6 +139,11 @@ async def lifespan(app: FastAPI):
         _export_worker_task = await start_export_worker()
         logger.info("Export job queue worker started")
 
+        # Start the MCP job timeout sweeper
+        from src.api.services.job_queue import mark_timed_out_jobs_loop
+        _timeout_task = asyncio.create_task(mark_timed_out_jobs_loop())
+        logger.info("MCP job timeout sweeper started")
+
         # Start the request log cleanup task
         from src.api.middleware.request_logging import request_log_cleanup_loop
         _cleanup_task = asyncio.create_task(request_log_cleanup_loop())
@@ -158,6 +191,19 @@ async def lifespan(app: FastAPI):
         except asyncio.CancelledError:
             pass
         logger.info("Request log cleanup task stopped")
+
+    if _timeout_task:
+        _timeout_task.cancel()
+        try:
+            await _timeout_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("MCP job timeout sweeper stopped")
+
+    # Tear down the FastMCP session manager's task group. Safe to call
+    # unconditionally — the stack was entered unconditionally at startup.
+    await mcp_lifespan_stack.aclose()
+    logger.info("MCP session manager stopped")
 
     if _frontend_assets_stack:
         _frontend_assets_stack.close()
@@ -359,6 +405,23 @@ app.include_router(contributors_router, prefix="/api/settings", tags=["settings"
 app.include_router(deck_prompts_router, prefix="/api/settings", tags=["settings"])
 app.include_router(identities_router, prefix="/api/settings", tags=["settings"])
 app.include_router(slide_styles_router, prefix="/api/settings", tags=["settings"])
+
+# MCP server — mount the FastMCP streamable-HTTP ASGI app at /mcp.
+# Must be registered before the SPA catch-all (which is added lazily by
+# ``_mount_frontend`` inside the lifespan when running in production),
+# otherwise JSON-RPC POSTs to /mcp would be swallowed by the SPA route
+# and return index.html instead of reaching the tool handlers.
+#
+# Set ``streamable_http_path = "/"`` so the sub-app's internal route is
+# ``/``; when Starlette mounts the sub-app at ``/mcp`` it strips the
+# ``/mcp`` prefix before forwarding, so an external POST to ``/mcp``
+# lands on the sub-app's ``/`` route. Without this, the sub-app's
+# default internal route would be ``/mcp`` and external requests would
+# need to hit ``/mcp/mcp``.
+from src.api.mcp_server import mcp as tellr_mcp  # noqa: E402
+tellr_mcp.settings.streamable_http_path = "/"
+app.mount("/mcp", tellr_mcp.streamable_http_app())
+logger.info("MCP server mounted at /mcp")
 
 
 @app.get("/api/health")

--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Iterator, Optional
 
 from fastapi import Request
@@ -44,7 +44,7 @@ class MCPAuthError(Exception):
 class MCPIdentity:
     user_id: Optional[str]
     user_name: str
-    token: str
+    token: str = field(repr=False)
     source: str  # "x-forwarded-access-token" or "authorization-bearer"
 
 

--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -1,0 +1,129 @@
+"""Dual-token authentication for the MCP endpoint.
+
+Accepts two token sources in priority order:
+
+1. ``x-forwarded-access-token`` — injected by the Databricks Apps proxy.
+   Highest trust; cannot be spoofed from outside the proxy.
+2. ``Authorization: Bearer <token>`` — fallback for external callers
+   (laptop MCP clients, agent tools) that are not behind the proxy.
+
+The resolved identity is bound into the same request-scoped ContextVars
+the browser flow uses (``set_current_user``, ``set_user_client``,
+``set_permission_context``), so downstream services (session manager,
+permission service, MLflow, Google OAuth) see the caller's identity
+without any MCP-specific plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+from fastapi import Request
+
+from src.core.databricks_client import (
+    get_or_create_user_client,
+    set_user_client,
+)
+from src.core.permission_context import (
+    build_permission_context,
+    set_permission_context,
+)
+from src.core.user_context import set_current_user
+
+logger = logging.getLogger(__name__)
+
+
+class MCPAuthError(Exception):
+    """Raised when a request to /mcp lacks valid authentication."""
+
+
+@dataclass
+class MCPIdentity:
+    user_id: Optional[str]
+    user_name: str
+    token: str
+    source: str  # "x-forwarded-access-token" or "authorization-bearer"
+
+
+def extract_mcp_identity(request: Request) -> MCPIdentity:
+    """Resolve the caller's identity from request headers.
+
+    Raises ``MCPAuthError`` if no valid token is found or if the token
+    cannot be resolved to an identity.
+    """
+    # Priority 1: proxy-injected token
+    token = request.headers.get("x-forwarded-access-token")
+    source = "x-forwarded-access-token"
+
+    if not token:
+        # Priority 2: Authorization: Bearer fallback
+        authz = (
+            request.headers.get("authorization")
+            or request.headers.get("Authorization")
+            or ""
+        )
+        if authz.lower().startswith("bearer "):
+            token = authz[len("Bearer "):].strip()
+            source = "authorization-bearer"
+        elif authz:
+            raise MCPAuthError(
+                "Unsupported Authorization scheme; expected 'Bearer <token>'"
+            )
+
+    if not token:
+        raise MCPAuthError("Authentication required: no credentials presented")
+
+    try:
+        user_client = get_or_create_user_client(token)
+        me = user_client.current_user.me()
+    except Exception as e:
+        logger.warning("MCP auth: identity resolution failed: %s", e)
+        raise MCPAuthError("Invalid or expired credentials") from e
+
+    return MCPIdentity(
+        user_id=getattr(me, "id", None),
+        user_name=getattr(me, "user_name", "") or "",
+        token=token,
+        source=source,
+    )
+
+
+@contextmanager
+def mcp_auth_scope(request: Request) -> Iterator[MCPIdentity]:
+    """Authenticate an MCP request and bind identity ContextVars for the block.
+
+    On entry: resolves identity, binds ``current_user``, ``user_client``,
+    and ``permission_context``.
+
+    On exit: clears all three ContextVars, even if the wrapped block raised.
+    """
+    identity = extract_mcp_identity(request)
+
+    user_client = get_or_create_user_client(identity.token)
+    permission_ctx = build_permission_context(
+        user_id=identity.user_id,
+        user_name=identity.user_name,
+        fetch_groups=False,
+    )
+
+    set_current_user(identity.user_name)
+    set_user_client(user_client)
+    set_permission_context(permission_ctx)
+
+    logger.debug(
+        "MCP auth scope entered",
+        extra={
+            "user_name": identity.user_name,
+            "token_source": identity.source,
+        },
+    )
+
+    try:
+        yield identity
+    finally:
+        set_current_user(None)
+        set_user_client(None)
+        set_permission_context(None)

--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -143,10 +143,6 @@ def extract_mcp_identity(request: Request) -> MCPIdentity:
                 source="x-forwarded-identity",
             )
 
-    logger.warning(
-        "MCP auth: no credentials presented; received header keys: %s",
-        sorted(request.headers.keys()),
-    )
     raise MCPAuthError("Authentication required: no credentials presented")
 
 

--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -74,6 +74,10 @@ def extract_mcp_identity(request: Request) -> MCPIdentity:
             )
 
     if not token:
+        logger.warning(
+            "MCP auth: no credentials presented; received header keys: %s",
+            sorted(request.headers.keys()),
+        )
         raise MCPAuthError("Authentication required: no credentials presented")
 
     try:

--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -1,11 +1,28 @@
 """Dual-token authentication for the MCP endpoint.
 
-Accepts two token sources in priority order:
+Accepts three identity sources, evaluated in priority order:
 
-1. ``x-forwarded-access-token`` — injected by the Databricks Apps proxy.
-   Highest trust; cannot be spoofed from outside the proxy.
+1. ``x-forwarded-access-token`` — injected by the Databricks Apps proxy
+   when a user hits tellr's own ``/mcp`` endpoint directly. Highest trust;
+   cannot be spoofed from outside the proxy.
 2. ``Authorization: Bearer <token>`` — fallback for external callers
-   (laptop MCP clients, agent tools) that are not behind the proxy.
+   (laptop MCP clients, Claude Code, CI scripts) that are not behind the
+   Databricks Apps proxy at all.
+3. ``x-forwarded-email`` + ``x-forwarded-user`` — the identity-only path
+   used by **app-to-app calls** in the Databricks Apps platform. The
+   calling app's OBO token does not survive the proxy hop: the proxy
+   strips ``Authorization`` and ``x-forwarded-access-token`` from inbound
+   app-to-app traffic and replaces them with proxy-attested ``X-Forwarded-*``
+   identity headers. The receiving app (tellr) trusts those headers
+   because the same proxy sets them, strips any caller-supplied versions,
+   and cannot be bypassed by external traffic. This path has no user
+   token, so downstream Databricks API calls use tellr's own service
+   principal credentials; attribution (``created_by`` on decks, etc.)
+   remains the real user via ``user_name``.
+
+The priority-3 path is gated on ``TELLR_TRUST_FORWARDED_IDENTITY=true``
+so the behaviour is explicit at deploy time. Production Databricks Apps
+deployments enable it; local dev does not.
 
 The resolved identity is bound into the same request-scoped ContextVars
 the browser flow uses (``set_current_user``, ``set_user_client``,
@@ -17,6 +34,7 @@ without any MCP-specific plumbing.
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Iterator, Optional
@@ -25,6 +43,7 @@ from fastapi import Request
 
 from src.core.databricks_client import (
     get_or_create_user_client,
+    get_system_client,
     set_user_client,
 )
 from src.core.permission_context import (
@@ -36,6 +55,19 @@ from src.core.user_context import set_current_user
 logger = logging.getLogger(__name__)
 
 
+def _trust_forwarded_identity() -> bool:
+    """Deploy-time opt-in for the priority-3 identity-header path.
+
+    Enabled by setting ``TELLR_TRUST_FORWARDED_IDENTITY`` to a truthy
+    value in the app environment. Off by default so local runs and
+    non-Databricks-Apps deployments behave identically to the prior
+    dual-token model.
+    """
+    return os.getenv("TELLR_TRUST_FORWARDED_IDENTITY", "").lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
 class MCPAuthError(Exception):
     """Raised when a request to /mcp lacks valid authentication."""
 
@@ -44,17 +76,17 @@ class MCPAuthError(Exception):
 class MCPIdentity:
     user_id: Optional[str]
     user_name: str
-    token: str = field(repr=False)
-    source: str  # "x-forwarded-access-token" or "authorization-bearer"
+    token: Optional[str] = field(repr=False)
+    source: str  # "x-forwarded-access-token" | "authorization-bearer" | "x-forwarded-identity"
 
 
 def extract_mcp_identity(request: Request) -> MCPIdentity:
     """Resolve the caller's identity from request headers.
 
-    Raises ``MCPAuthError`` if no valid token is found or if the token
-    cannot be resolved to an identity.
+    Raises ``MCPAuthError`` if no valid identity source is found or if a
+    presented token cannot be resolved to an identity.
     """
-    # Priority 1: proxy-injected token
+    # Priority 1: proxy-injected user OBO token
     token = request.headers.get("x-forwarded-access-token")
     source = "x-forwarded-access-token"
 
@@ -73,26 +105,49 @@ def extract_mcp_identity(request: Request) -> MCPIdentity:
                 "Unsupported Authorization scheme; expected 'Bearer <token>'"
             )
 
-    if not token:
-        logger.warning(
-            "MCP auth: no credentials presented; received header keys: %s",
-            sorted(request.headers.keys()),
+    if token:
+        try:
+            user_client = get_or_create_user_client(token)
+            me = user_client.current_user.me()
+        except Exception as e:
+            logger.warning("MCP auth: identity resolution failed: %s", e)
+            raise MCPAuthError("Invalid or expired credentials") from e
+
+        return MCPIdentity(
+            user_id=getattr(me, "id", None),
+            user_name=getattr(me, "user_name", "") or "",
+            token=token,
+            source=source,
         )
-        raise MCPAuthError("Authentication required: no credentials presented")
 
-    try:
-        user_client = get_or_create_user_client(token)
-        me = user_client.current_user.me()
-    except Exception as e:
-        logger.warning("MCP auth: identity resolution failed: %s", e)
-        raise MCPAuthError("Invalid or expired credentials") from e
+    # Priority 3: proxy-attested forwarded identity (no token).
+    # Only honored when TELLR_TRUST_FORWARDED_IDENTITY is set at deploy time
+    # so non-Apps deployments (local dev, bare VMs) fail closed rather than
+    # trusting freely-caller-supplied headers.
+    if _trust_forwarded_identity():
+        email = request.headers.get("x-forwarded-email")
+        forwarded_user = request.headers.get("x-forwarded-user") or ""
+        if email:
+            # The proxy formats x-forwarded-user as "<user_id>@<workspace_id>".
+            # Extract the user_id; if the format is unexpected, fall back to
+            # None rather than surfacing a corrupt ID downstream.
+            user_id = (
+                forwarded_user.split("@", 1)[0]
+                if "@" in forwarded_user
+                else None
+            )
+            return MCPIdentity(
+                user_id=user_id,
+                user_name=email,
+                token=None,
+                source="x-forwarded-identity",
+            )
 
-    return MCPIdentity(
-        user_id=getattr(me, "id", None),
-        user_name=getattr(me, "user_name", "") or "",
-        token=token,
-        source=source,
+    logger.warning(
+        "MCP auth: no credentials presented; received header keys: %s",
+        sorted(request.headers.keys()),
     )
+    raise MCPAuthError("Authentication required: no credentials presented")
 
 
 @contextmanager
@@ -103,10 +158,24 @@ def mcp_auth_scope(request: Request) -> Iterator[MCPIdentity]:
     and ``permission_context``.
 
     On exit: clears all three ContextVars, even if the wrapped block raised.
+
+    When the identity was resolved via priority 3 (no user token), the
+    bound ``user_client`` is tellr's service-principal client — downstream
+    services still function, but any SDK calls are made with SP credentials
+    rather than the user's own. Attribution (``created_by``) is unaffected:
+    it uses ``user_name`` from the forwarded identity headers, which the
+    proxy attests.
     """
     identity = extract_mcp_identity(request)
 
-    user_client = get_or_create_user_client(identity.token)
+    if identity.token is not None:
+        user_client = get_or_create_user_client(identity.token)
+    else:
+        # Priority-3 path: no user token, so downstream Databricks API
+        # calls use tellr's service principal. Safe because the app-to-app
+        # model explicitly delegates credentialing to the receiving app.
+        user_client = get_system_client()
+
     permission_ctx = build_permission_context(
         user_id=identity.user_id,
         user_name=identity.user_name,

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -15,10 +15,17 @@ the caller-facing integration guide.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+from typing import Any, Optional
 
-from mcp.server.fastmcp import FastMCP
+from fastapi import Request
+from mcp.server.fastmcp import Context, FastMCP
+
+from src.api.mcp_auth import MCPAuthError, mcp_auth_scope
+from src.api.services.job_queue import enqueue_job
+from src.api.services.session_manager import get_session_manager
 
 logger = logging.getLogger(__name__)
 
@@ -38,4 +45,250 @@ def _public_app_url() -> str:
     return os.getenv("TELLR_APP_URL", "").rstrip("/")
 
 
-# Tool implementations are added in subsequent tasks.
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+
+class MCPToolError(Exception):
+    """Raised when an MCP tool cannot complete its operation.
+
+    FastMCP renders these as tool results with ``isError: true`` rather
+    than as JSON-RPC protocol errors, per MCP convention for tool
+    execution failures.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Async submission helper
+# ---------------------------------------------------------------------------
+
+
+async def enqueue_create_job(
+    session_id: str,
+    prompt: str,
+    mode: str = "generate",
+    slide_context: Optional[dict] = None,
+    correlation_id: Optional[str] = None,
+) -> str:
+    """Submit a generate or edit job to tellr's existing chat async queue.
+
+    Mirrors the behaviour of ``POST /api/chat/async`` without re-using the
+    FastAPI route so the MCP call path stays framework-free: the route
+    depends on ``ChatRequest`` (Pydantic) and ``get_db`` (FastAPI), neither
+    of which is natural to call from a FastMCP tool handler. Instead we
+    invoke the underlying primitives directly:
+
+    1. Acquire the session processing lock.
+    2. Create a ``ChatRequest`` row (returns ``request_id``).
+    3. Persist the user's prompt as a ``session_messages`` row so the
+       chat history reflects the MCP call.
+    4. Enqueue the payload on the in-memory job queue; the worker picks
+       it up and runs the agent via ``ChatService.send_message_streaming``.
+
+    Tests patch this helper at a single call site rather than patching
+    the four primitives above, keeping the tool handler test focused on
+    the handler's own logic. Returns the generated ``request_id``.
+
+    Raises:
+        MCPToolError: If the session is already processing another request.
+    """
+    session_manager = get_session_manager()
+
+    # The caller is already authenticated and their identity is bound on
+    # the request-scoped ContextVars by mcp_auth_scope (see mcp_auth.py).
+    # create_chat_request's ``created_by`` kwarg is only consulted on the
+    # auto-create branch of SessionManager.create_chat_request; by the
+    # time we get here the session already exists (the tool handler created
+    # it just before calling this helper), so passing None is correct.
+    from src.core.user_context import get_current_user
+
+    locked = await asyncio.to_thread(
+        session_manager.acquire_session_lock, session_id
+    )
+    if not locked:
+        raise MCPToolError(
+            "Session is currently processing another request"
+        )
+
+    try:
+        request_id = await asyncio.to_thread(
+            session_manager.create_chat_request,
+            session_id,
+            get_current_user(),
+        )
+
+        # Match the /api/chat/async flow: capture first-message flag BEFORE
+        # persisting the user message (add_message increments message_count).
+        session_data = await asyncio.to_thread(
+            session_manager.get_session, session_id
+        )
+        is_first_message = session_data.get("message_count", 0) == 0
+
+        # Persist the user's prompt so MCP-initiated sessions have a chat
+        # transcript identical in shape to browser-initiated ones.
+        await asyncio.to_thread(
+            session_manager.add_message,
+            session_id=session_id,
+            role="user",
+            content=prompt,
+            message_type="user_query",
+            request_id=request_id,
+        )
+
+        await enqueue_job(
+            request_id,
+            {
+                "session_id": session_id,
+                "message": prompt,
+                "slide_context": slide_context,
+                "is_first_message": is_first_message,
+                "image_ids": None,
+                # Forward-looking: mode and correlation_id flow into the
+                # payload so the worker (and logs) can see them even
+                # though v1 only executes generate-mode jobs.
+                "mode": mode,
+                "correlation_id": correlation_id,
+            },
+        )
+
+        return request_id
+    except Exception:
+        # Ensure the session lock is released on any failure before the
+        # worker gets a chance to see the job (matches /api/chat/async).
+        await asyncio.to_thread(
+            session_manager.release_session_lock, session_id
+        )
+        raise
+
+
+# ---------------------------------------------------------------------------
+# create_deck
+# ---------------------------------------------------------------------------
+
+
+def _request_from_context(ctx: Context) -> Request:
+    """Extract the underlying Starlette/FastAPI Request from an MCP Context.
+
+    When FastMCP is mounted inside FastAPI via the Streamable HTTP transport,
+    the HTTP request is attached to the JSON-RPC RequestContext as
+    ``request_context.request``. We access it through this helper so the
+    tool handlers can stay declarative (they just ask for a Context) while
+    the impl functions accept a plain ``Request`` and remain trivially
+    testable without the MCP framework.
+
+    Raises:
+        MCPToolError: If no Request is attached (e.g., unexpected transport).
+    """
+    req = getattr(ctx.request_context, "request", None)
+    if req is None:
+        raise MCPToolError(
+            "MCP tool requires an HTTP request context; "
+            "unsupported transport"
+        )
+    return req
+
+
+@mcp.tool(
+    name="create_deck",
+    description=(
+        "Generate a new slide deck from a natural-language prompt. Returns a "
+        "session_id and a request_id; the caller polls get_deck_status for "
+        "completion. The resulting deck is attributed to the calling user and "
+        "appears in their tellr UI. v1 runs prompt-only: the agent does not "
+        "invoke Genie, Vector Search, or other tools. Callers that want data-"
+        "backed decks should gather the data themselves and include it in the "
+        "prompt."
+    ),
+)
+async def create_deck(
+    ctx: Context,
+    prompt: str,
+    num_slides: Optional[int] = None,
+    slide_style_id: Optional[int] = None,
+    deck_prompt_id: Optional[int] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    return await _create_deck_impl(
+        request=_request_from_context(ctx),
+        prompt=prompt,
+        num_slides=num_slides,
+        slide_style_id=slide_style_id,
+        deck_prompt_id=deck_prompt_id,
+        correlation_id=correlation_id,
+    )
+
+
+async def _create_deck_impl(
+    request: Request,
+    prompt: str,
+    num_slides: Optional[int] = None,
+    slide_style_id: Optional[int] = None,
+    deck_prompt_id: Optional[int] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    """Implementation, separated from the decorated tool for testability."""
+    if not prompt or not prompt.strip():
+        raise MCPToolError("prompt must be a non-empty string")
+    if num_slides is not None and not (1 <= num_slides <= 50):
+        raise MCPToolError("num_slides must be between 1 and 50")
+
+    try:
+        with mcp_auth_scope(request) as identity:
+            agent_config: dict[str, Any] = {"tools": []}
+            if slide_style_id is not None:
+                agent_config["slide_style_id"] = slide_style_id
+            if deck_prompt_id is not None:
+                agent_config["deck_prompt_id"] = deck_prompt_id
+            if num_slides is not None:
+                agent_config["num_slides"] = num_slides
+
+            session_manager = get_session_manager()
+            session = session_manager.create_session(
+                created_by=identity.user_name,
+                agent_config=agent_config,
+            )
+            # create_session returns a dict (see SessionManager.create_session);
+            # guard against a model-object return defensively so this stays
+            # robust if the service ever switches to returning a Pydantic model.
+            session_id = (
+                session["session_id"]
+                if isinstance(session, dict)
+                else session.session_id
+            )
+
+            request_id = await enqueue_create_job(
+                session_id=session_id,
+                prompt=prompt,
+                mode="generate",
+                slide_context=None,
+                correlation_id=correlation_id,
+            )
+
+            logger.info(
+                "MCP create_deck submitted",
+                extra={
+                    "event": "mcp_tool_invoked",
+                    "tool_name": "create_deck",
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "user_name": identity.user_name,
+                    "token_source": identity.source,
+                    "correlation_id": correlation_id,
+                },
+            )
+
+            return {
+                "session_id": session_id,
+                "request_id": request_id,
+                "status": "pending",
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP create_deck failed")
+        raise MCPToolError(
+            f"Internal error (correlation_id={correlation_id}): {e}"
+        ) from e

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -126,7 +126,19 @@ permission_service = _PermissionServiceFacade()
 
 # FastMCP instance — one per process. Tools are registered via decorators
 # added in subsequent tasks (create_deck, get_deck_status, edit_deck, get_deck).
-mcp = FastMCP("tellr")
+#
+# stateless_http=True: tellr runs multiple uvicorn workers
+# (UVICORN_WORKERS=4 on Databricks Apps), and FastMCP's default stateful
+# session store is an in-memory dict on each worker process. Without
+# session affinity at the proxy layer, the three requests of a normal
+# handshake (initialize → notifications/initialized → tools/call) can
+# land on different workers, producing HTTP 404 "Session not found"
+# intermittently — especially on longer generate+poll loops where many
+# handshakes happen. Stateless mode sidesteps this entirely: each HTTP
+# request is self-contained, no server-side session lookup, no
+# possibility of session-not-found. This is the mode the MCP spec
+# (2025-03-26) prescribes for multi-node deployments.
+mcp = FastMCP("tellr", stateless_http=True)
 
 
 def _public_app_url() -> str:

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -24,10 +24,68 @@ from fastapi import Request
 from mcp.server.fastmcp import Context, FastMCP
 
 from src.api.mcp_auth import MCPAuthError, mcp_auth_scope
-from src.api.services.job_queue import enqueue_job
+from src.api.services.job_queue import enqueue_job, get_job_status
 from src.api.services.session_manager import get_session_manager
+from src.core.database import get_db_session
+from src.core.permission_context import get_permission_context
+from src.domain.slide import Slide
+from src.domain.slide_deck import SlideDeck
+from src.services.permission_service import get_permission_service
 
 logger = logging.getLogger(__name__)
+
+
+class _PermissionServiceFacade:
+    """Module-level facade exposing a simplified permission-check API.
+
+    The underlying ``PermissionService.can_view_deck`` requires a DB session
+    and a set of identity kwargs; the MCP tool handlers only have a string
+    ``session_id`` and rely on the identity ContextVars that
+    ``mcp_auth_scope`` already bound. This facade bridges the two so tool
+    implementations can call ``permission_service.can_view_deck(session_id)``
+    without re-plumbing auth context. Unit tests replace this facade by
+    patching ``src.api.mcp_server.permission_service`` with a MagicMock, so
+    the facade is not exercised in test paths.
+    """
+
+    def can_view_deck(self, session_id: str) -> bool:
+        """Return True if the current MCP caller has view access on the deck.
+
+        Resolves the string ``session_id`` to the underlying ``UserSession.id``
+        (integer PK), then delegates to the shared ``PermissionService``. The
+        caller's identity is read from the request-scoped permission
+        ContextVar populated by ``mcp_auth_scope``.
+        """
+        ctx = get_permission_context()
+        if ctx is None:
+            return False
+        svc = get_permission_service()
+        with get_db_session() as db:
+            from src.database.models.session import UserSession
+
+            session = (
+                db.query(UserSession)
+                .filter(UserSession.session_id == session_id)
+                .first()
+            )
+            if session is None:
+                return False
+            # Creator always has view access (mirrors PermissionService's
+            # get_deck_permission creator check, done here on the string-id
+            # fast path so a brand-new session the caller just created is
+            # viewable even before any DeckContributor row exists).
+            if session.created_by and session.created_by == ctx.user_name:
+                return True
+            return svc.can_view_deck(
+                db,
+                session.id,
+                user_id=ctx.user_id,
+                user_name=ctx.user_name,
+                group_ids=ctx.group_ids,
+            )
+
+
+permission_service = _PermissionServiceFacade()
 
 # FastMCP instance — one per process. Tools are registered via decorators
 # added in subsequent tasks (create_deck, get_deck_status, edit_deck, get_deck).
@@ -292,3 +350,158 @@ async def _create_deck_impl(
         raise MCPToolError(
             f"Internal error (correlation_id={correlation_id}): {e}"
         ) from e
+
+
+# ---------------------------------------------------------------------------
+# Deck response serializer (shared by get_deck_status and get_deck)
+# ---------------------------------------------------------------------------
+
+
+def _render_deck_response(session: dict, base_url: str) -> dict:
+    """Serialize a session's deck into the MCP response fields.
+
+    Returns a dict carrying ``slide_count``, ``title``, ``deck``,
+    ``html_document``, ``deck_url``, and ``deck_view_url``. The input
+    ``session`` is expected to carry a ``deck_json`` payload (the
+    structured deck dict persisted by the worker) plus a ``title`` and
+    ``session_id``. This helper is extracted so ``get_deck`` (Task 9)
+    can reuse the exact same shape without drift between the two tools.
+
+    ``SlideDeck`` has no ``from_dict`` constructor, so the deck is
+    rebuilt by constructing ``Slide`` instances for each entry in
+    ``deck_json["slides"]`` and handing them to ``SlideDeck.__init__``
+    together with the stored title, CSS, external scripts, and head
+    metadata.
+    """
+    deck_json = session.get("deck_json") or {}
+    if deck_json:
+        slides = [
+            Slide(
+                html=s.get("html", ""),
+                scripts=s.get("scripts", ""),
+                slide_id=s.get("slide_id"),
+                created_by=s.get("created_by"),
+                created_at=s.get("created_at"),
+                modified_by=s.get("modified_by"),
+                modified_at=s.get("modified_at"),
+            )
+            for s in deck_json.get("slides", [])
+        ]
+        deck = SlideDeck(
+            title=deck_json.get("title") or session.get("title"),
+            css=deck_json.get("css", ""),
+            external_scripts=list(deck_json.get("external_scripts") or []),
+            slides=slides,
+            head_meta=dict(deck_json.get("head_meta") or {}),
+        )
+    else:
+        deck = SlideDeck(title=session.get("title"))
+
+    session_id = session["session_id"]
+    deck_url = (
+        f"{base_url}/sessions/{session_id}/edit"
+        if base_url
+        else f"/sessions/{session_id}/edit"
+    )
+    deck_view_url = (
+        f"{base_url}/sessions/{session_id}/view"
+        if base_url
+        else f"/sessions/{session_id}/view"
+    )
+    return {
+        "slide_count": len(deck.slides),
+        "title": session.get("title") or deck.title,
+        "deck": deck.to_dict(),
+        "html_document": deck.to_html_document(),
+        "deck_url": deck_url,
+        "deck_view_url": deck_view_url,
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_deck_status
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="get_deck_status",
+    description=(
+        "Poll the status of a deck generation or edit job. Returns "
+        "lightweight status while pending/running; when ready, returns the "
+        "complete deck as structured slide data, a standalone HTML "
+        "document, and URLs into tellr's full editor and view-only surfaces."
+    ),
+)
+async def get_deck_status(
+    ctx: Context,
+    session_id: str,
+    request_id: str,
+) -> dict:
+    return await _get_deck_status_impl(
+        request=_request_from_context(ctx),
+        session_id=session_id,
+        request_id=request_id,
+    )
+
+
+async def _get_deck_status_impl(
+    request: Request, session_id: str, request_id: str
+) -> dict:
+    """Implementation, separated from the decorated tool for testability."""
+    try:
+        with mcp_auth_scope(request):
+            if not permission_service.can_view_deck(session_id):
+                raise MCPToolError(
+                    "Deck not found or you do not have permission to view it"
+                )
+
+            status = get_job_status(request_id)
+            if status is None:
+                raise MCPToolError(f"Unknown request_id: {request_id}")
+
+            job_status = status.get("status", "pending")
+
+            if job_status in ("pending", "running"):
+                return {
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "status": job_status,
+                    "progress": status.get("progress"),
+                }
+
+            if job_status in ("failed", "error"):
+                return {
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "status": "failed",
+                    "error": status.get("error", "Generation failed"),
+                }
+
+            # status == "ready" (MCP-layer contract; mapped from the worker's
+            # completion signal by the caller of get_job_status).
+            session_manager = get_session_manager()
+            session = session_manager.get_session(session_id)
+            base = _public_app_url()
+            deck_fields = _render_deck_response(session, base)
+
+            return {
+                "session_id": session_id,
+                "request_id": request_id,
+                "status": "ready",
+                **deck_fields,
+                "replacement_info": status.get("replacement_info"),
+                "messages": status.get("messages") or [],
+                "metadata": {
+                    "mode": status.get("mode"),
+                    "tool_calls": status.get("tool_calls"),
+                    "latency_ms": status.get("latency_ms"),
+                    "correlation_id": status.get("correlation_id"),
+                },
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP get_deck_status failed")
+        raise MCPToolError(f"Internal error: {e}") from e

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -84,6 +84,42 @@ class _PermissionServiceFacade:
                 group_ids=ctx.group_ids,
             )
 
+    def can_edit_deck(self, session_id: str) -> bool:
+        """Return True if the current MCP caller has edit access on the deck.
+
+        Mirrors ``can_view_deck`` but gates on CAN_EDIT (or higher) rather
+        than any access. Resolves the string ``session_id`` to the
+        underlying ``UserSession.id`` (integer PK) and delegates to the
+        shared ``PermissionService``. The session creator is short-
+        circuited to True — creators implicitly hold CAN_MANAGE, which
+        includes edit — on the string-id fast path so a session the
+        caller just created is editable before any DeckContributor row
+        exists.
+        """
+        ctx = get_permission_context()
+        if ctx is None:
+            return False
+        svc = get_permission_service()
+        with get_db_session() as db:
+            from src.database.models.session import UserSession
+
+            session = (
+                db.query(UserSession)
+                .filter(UserSession.session_id == session_id)
+                .first()
+            )
+            if session is None:
+                return False
+            if session.created_by and session.created_by == ctx.user_name:
+                return True
+            return svc.can_edit_deck(
+                db,
+                session.id,
+                user_id=ctx.user_id,
+                user_name=ctx.user_name,
+                group_ids=ctx.group_ids,
+            )
+
 
 permission_service = _PermissionServiceFacade()
 
@@ -608,4 +644,147 @@ async def _get_deck_status_impl(
         raise MCPToolError(f"Authentication failed: {e}") from e
     except Exception as e:
         logger.exception("MCP get_deck_status failed")
+        raise MCPToolError(f"Internal error: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# edit_deck
+# ---------------------------------------------------------------------------
+
+
+def _check_contiguous(indices: list[int]) -> None:
+    """Raise MCPToolError unless indices form a contiguous run.
+
+    The edit pipeline's ``_parse_slide_replacements`` / ``_apply_slide_
+    replacements`` helpers assume the caller-supplied slide range is a
+    single contiguous slice so replacement output can be spliced back in
+    at a single index. Callers that want to edit disjoint slides should
+    issue one ``edit_deck`` call per slice.
+    """
+    if not indices:
+        return
+    sorted_idx = sorted(indices)
+    for a, b in zip(sorted_idx, sorted_idx[1:]):
+        if b - a != 1:
+            raise MCPToolError(
+                "slide_indices must be contiguous (e.g. [2, 3, 4], not [2, 4])"
+            )
+
+
+@mcp.tool(
+    name="edit_deck",
+    description=(
+        "Refine an existing deck through a natural-language instruction. "
+        "Optionally target specific contiguous slides via slide_indices. "
+        "The edit is applied in-place; the session_id and deck_url stay "
+        "stable across edits. Returns a request_id; the caller polls "
+        "get_deck_status for completion and receives the updated deck "
+        "plus replacement_info summarizing what changed."
+    ),
+)
+async def edit_deck(
+    ctx: Context,
+    session_id: str,
+    instruction: str,
+    slide_indices: Optional[list[int]] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    return await _edit_deck_impl(
+        request=_request_from_context(ctx),
+        session_id=session_id,
+        instruction=instruction,
+        slide_indices=slide_indices,
+        correlation_id=correlation_id,
+    )
+
+
+async def _edit_deck_impl(
+    request: Request,
+    session_id: str,
+    instruction: str,
+    slide_indices: Optional[list[int]] = None,
+    correlation_id: Optional[str] = None,
+) -> dict:
+    """Implementation, separated from the decorated tool for testability.
+
+    Reuses ``enqueue_create_job`` with ``mode="edit"`` so the worker
+    dispatches to the existing ChatService edit path (slide_context
+    present => editing_mode in ``agent.chat_async_streaming``). When
+    ``slide_indices`` is provided we pull the current slide HTMLs via
+    ``SessionManager.get_slide_deck`` and bundle them into the
+    ``slide_context`` dict the agent's ``_format_slide_context`` helper
+    expects (``{"indices": [...], "slide_htmls": [...]}``). Without
+    ``slide_indices`` the job is submitted with ``slide_context=None``
+    — still edit-mode, but the agent will operate against the full deck.
+    """
+    if not instruction or not instruction.strip():
+        raise MCPToolError("instruction must be a non-empty string")
+    if slide_indices is not None:
+        _check_contiguous(slide_indices)
+
+    try:
+        with mcp_auth_scope(request) as identity:
+            if not permission_service.can_edit_deck(session_id):
+                raise MCPToolError(
+                    "Deck not found or you do not have permission to edit it"
+                )
+
+            slide_context: Optional[dict] = None
+            if slide_indices:
+                sm = get_session_manager()
+                deck = sm.get_slide_deck(session_id)
+                if deck is None:
+                    raise MCPToolError(
+                        f"Deck not found for session_id: {session_id}"
+                    )
+                all_slides = deck.get("slides") or []
+                try:
+                    slide_htmls = [
+                        all_slides[i]["html"] for i in slide_indices
+                    ]
+                except IndexError as e:
+                    raise MCPToolError(
+                        f"slide_indices contains out-of-range index: {e}"
+                    ) from e
+                except (TypeError, KeyError) as e:
+                    raise MCPToolError(
+                        f"Failed to read slide html at index: {e}"
+                    ) from e
+                slide_context = {
+                    "indices": slide_indices,
+                    "slide_htmls": slide_htmls,
+                }
+
+            request_id = await enqueue_create_job(
+                session_id=session_id,
+                prompt=instruction,
+                mode="edit",
+                slide_context=slide_context,
+                correlation_id=correlation_id,
+            )
+
+            logger.info(
+                "MCP edit_deck submitted",
+                extra={
+                    "event": "mcp_tool_invoked",
+                    "tool_name": "edit_deck",
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "user_name": identity.user_name,
+                    "slide_indices": slide_indices,
+                    "correlation_id": correlation_id,
+                },
+            )
+
+            return {
+                "session_id": session_id,
+                "request_id": request_id,
+                "status": "pending",
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP edit_deck failed")
         raise MCPToolError(f"Internal error: {e}") from e

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -357,24 +357,36 @@ async def _create_deck_impl(
 # ---------------------------------------------------------------------------
 
 
-def _render_deck_response(session: dict, base_url: str) -> dict:
+def _render_deck_response(
+    deck_dict: Optional[dict], session: dict, base_url: str
+) -> dict:
     """Serialize a session's deck into the MCP response fields.
 
     Returns a dict carrying ``slide_count``, ``title``, ``deck``,
-    ``html_document``, ``deck_url``, and ``deck_view_url``. The input
-    ``session`` is expected to carry a ``deck_json`` payload (the
-    structured deck dict persisted by the worker) plus a ``title`` and
-    ``session_id``. This helper is extracted so ``get_deck`` (Task 9)
-    can reuse the exact same shape without drift between the two tools.
+    ``html_document``, ``deck_url``, and ``deck_view_url``. This helper
+    is extracted so ``get_deck_status`` and ``get_deck`` (Task 9) produce
+    identical response shapes without drift between the two tools.
+
+    Args:
+        deck_dict: Structured deck payload as returned by
+            ``SessionManager.get_slide_deck(session_id)``. Typically has
+            ``title``, ``slides``, ``css``, ``external_scripts``, and
+            ``head_meta`` keys. May be ``None`` when the session has no
+            deck yet (empty deck is rendered in that case).
+        session: Session info from ``SessionManager.get_session(session_id)``.
+            Used for ``session_id`` (required for URL construction) and
+            ``title`` fallback when the deck has no title.
+        base_url: Public app URL prefix for building deck URLs. Empty
+            string yields relative URLs.
 
     ``SlideDeck`` has no ``from_dict`` constructor, so the deck is
     rebuilt by constructing ``Slide`` instances for each entry in
-    ``deck_json["slides"]`` and handing them to ``SlideDeck.__init__``
+    ``deck_dict["slides"]`` and handing them to ``SlideDeck.__init__``
     together with the stored title, CSS, external scripts, and head
     metadata.
     """
-    deck_json = session.get("deck_json") or {}
-    if deck_json:
+    deck_dict = deck_dict or {}
+    if deck_dict:
         slides = [
             Slide(
                 html=s.get("html", ""),
@@ -385,14 +397,14 @@ def _render_deck_response(session: dict, base_url: str) -> dict:
                 modified_by=s.get("modified_by"),
                 modified_at=s.get("modified_at"),
             )
-            for s in deck_json.get("slides", [])
+            for s in deck_dict.get("slides", [])
         ]
         deck = SlideDeck(
-            title=deck_json.get("title") or session.get("title"),
-            css=deck_json.get("css", ""),
-            external_scripts=list(deck_json.get("external_scripts") or []),
+            title=deck_dict.get("title") or session.get("title"),
+            css=deck_dict.get("css", ""),
+            external_scripts=list(deck_dict.get("external_scripts") or []),
             slides=slides,
-            head_meta=dict(deck_json.get("head_meta") or {}),
+            head_meta=dict(deck_dict.get("head_meta") or {}),
         )
     else:
         deck = SlideDeck(title=session.get("title"))
@@ -447,7 +459,17 @@ async def get_deck_status(
 async def _get_deck_status_impl(
     request: Request, session_id: str, request_id: str
 ) -> dict:
-    """Implementation, separated from the decorated tool for testability."""
+    """Implementation, separated from the decorated tool for testability.
+
+    Mirrors the data-access pattern of ``GET /api/chat/poll/{request_id}``:
+    the in-memory ``jobs`` dict is authoritative for pending/running/failed
+    state, but worker completion pops the in-memory entry (see
+    ``job_queue.process_chat_request``'s ``finally`` clause). To see the
+    ready/error terminal state we have to fall back to the persisted
+    ``chat_request`` DB row, then re-fetch the deck via
+    ``SessionManager.get_slide_deck`` since neither ``get_job_status``
+    nor ``get_session`` carry the structured deck payload.
+    """
     try:
         with mcp_auth_scope(request):
             if not permission_service.can_view_deck(session_id):
@@ -455,47 +477,129 @@ async def _get_deck_status_impl(
                     "Deck not found or you do not have permission to view it"
                 )
 
-            status = get_job_status(request_id)
-            if status is None:
+            session_manager = get_session_manager()
+
+            # Phase 1: in-memory fast path. The worker updates this dict as
+            # it transitions pending -> running, and the timeout sweeper
+            # flips stuck jobs to "failed". On successful completion the
+            # worker pops the entry, so "completed"/"success" are not
+            # normally observed here — but we still treat them as a
+            # fall-through signal in case a caller observes a race.
+            entry = get_job_status(request_id)
+            if entry is not None:
+                job_status = entry.get("status", "pending")
+
+                if job_status in ("pending", "running"):
+                    return {
+                        "session_id": session_id,
+                        "request_id": request_id,
+                        "status": job_status,
+                        "progress": entry.get("progress"),
+                    }
+
+                if job_status == "failed":
+                    return {
+                        "session_id": session_id,
+                        "request_id": request_id,
+                        "status": "failed",
+                        "error": entry.get("error", "Generation failed"),
+                    }
+                # Any other status ("error", "completed", "success",
+                # unexpected values): fall through to DB for authoritative
+                # state. Worker-raised errors also land in the DB via
+                # update_chat_request_status(request_id, "error", ...).
+
+            # Phase 2: DB fallback. ``get_chat_request`` returns a dict with
+            # ``status``, ``error_message``, ``result`` (the JSON blob the
+            # worker stored via ``set_chat_request_result`` — slides,
+            # raw_html, replacement_info, experiment_url, metadata,
+            # session_title), plus timestamps and the INTEGER session_id.
+            chat_request = session_manager.get_chat_request(request_id)
+            if chat_request is None:
                 raise MCPToolError(f"Unknown request_id: {request_id}")
 
-            job_status = status.get("status", "pending")
+            # Cross-check: the request must belong to the session the caller
+            # supplied. ``chat_request["session_id"]`` is the integer PK, so
+            # resolve it to the string form for comparison. Without this,
+            # a caller with view access on any deck could probe for
+            # messages/metadata of arbitrary other requests.
+            owning_session_id = session_manager.get_session_id_for_request(
+                request_id
+            )
+            if owning_session_id != session_id:
+                raise MCPToolError(f"Unknown request_id: {request_id}")
 
-            if job_status in ("pending", "running"):
+            db_status = chat_request.get("status")
+
+            if db_status in ("pending", "running"):
                 return {
                     "session_id": session_id,
                     "request_id": request_id,
-                    "status": job_status,
-                    "progress": status.get("progress"),
+                    "status": db_status,
+                    "progress": None,
                 }
 
-            if job_status in ("failed", "error"):
+            if db_status == "error":
                 return {
                     "session_id": session_id,
                     "request_id": request_id,
                     "status": "failed",
-                    "error": status.get("error", "Generation failed"),
+                    "error": chat_request.get("error_message")
+                    or "Generation failed",
                 }
 
-            # status == "ready" (MCP-layer contract; mapped from the worker's
-            # completion signal by the caller of get_job_status).
-            session_manager = get_session_manager()
+            if db_status != "completed":
+                # Unknown terminal state — surface as failure so callers
+                # aren't left polling forever.
+                return {
+                    "session_id": session_id,
+                    "request_id": request_id,
+                    "status": "failed",
+                    "error": f"Unknown job status: {db_status!r}",
+                }
+
+            # Ready path. The worker stored the deck via
+            # SessionManager.save_slide_deck (from inside send_message_streaming)
+            # before calling set_chat_request_result, so get_slide_deck is
+            # authoritative.
             session = session_manager.get_session(session_id)
+            deck_dict = session_manager.get_slide_deck(session_id)
             base = _public_app_url()
-            deck_fields = _render_deck_response(session, base)
+            deck_fields = _render_deck_response(deck_dict, session, base)
+
+            # ``result`` is a JSON blob the worker wrote. Per
+            # job_queue.process_chat_request, keys are: slides, raw_html,
+            # replacement_info, experiment_url, metadata, session_title.
+            result = chat_request.get("result") or {}
+            result_metadata = result.get("metadata") or {}
+
+            # Messages for this turn: the worker persists each streamed
+            # event as a SessionMessage tagged with the request_id, so
+            # get_messages_for_request gives us the turn's transcript.
+            db_messages = session_manager.get_messages_for_request(request_id)
+            messages = [
+                {
+                    "role": m.get("role"),
+                    "content": m.get("content"),
+                    "message_type": m.get("message_type"),
+                    "created_at": m.get("created_at"),
+                }
+                for m in db_messages
+            ]
 
             return {
                 "session_id": session_id,
                 "request_id": request_id,
                 "status": "ready",
                 **deck_fields,
-                "replacement_info": status.get("replacement_info"),
-                "messages": status.get("messages") or [],
+                "replacement_info": result.get("replacement_info"),
+                "messages": messages,
                 "metadata": {
-                    "mode": status.get("mode"),
-                    "tool_calls": status.get("tool_calls"),
-                    "latency_ms": status.get("latency_ms"),
-                    "correlation_id": status.get("correlation_id"),
+                    "tool_calls": result_metadata.get("tool_calls"),
+                    "latency_ms": result_metadata.get("latency_ms")
+                    or result_metadata.get("latency_seconds"),
+                    "experiment_url": result.get("experiment_url"),
+                    "session_title": result.get("session_title"),
                 },
             }
     except MCPToolError:

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -1,0 +1,41 @@
+"""MCP (Model Context Protocol) server for tellr.
+
+Exposes tellr's deck-generation capabilities as a set of MCP tools so
+external Databricks Apps and MCP-compatible agent tools (e.g., Claude
+Code) can programmatically create, edit, and retrieve slide decks.
+
+The tools are thin wrappers over existing services (ChatService,
+SessionManager, SlideDeck, permission_service) — no re-implementation
+of the agent pipeline.
+
+See docs/superpowers/specs/2026-04-22-tellr-mcp-server-design.md for
+the design rationale and docs/technical/mcp-server.md (added later) for
+the caller-facing integration guide.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+# FastMCP instance — one per process. Tools are registered via decorators
+# added in subsequent tasks (create_deck, get_deck_status, edit_deck, get_deck).
+mcp = FastMCP("tellr")
+
+
+def _public_app_url() -> str:
+    """Return the base URL for constructing deck_url / deck_view_url.
+
+    Reads TELLR_APP_URL from the environment; this is set at deploy time
+    by the Databricks App platform or by local dev config. Returns an
+    empty string if unset — tool handlers should treat empty as "build
+    relative URLs" rather than fail hard.
+    """
+    return os.getenv("TELLR_APP_URL", "").rstrip("/")
+
+
+# Tool implementations are added in subsequent tasks.

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -788,3 +788,65 @@ async def _edit_deck_impl(
     except Exception as e:
         logger.exception("MCP edit_deck failed")
         raise MCPToolError(f"Internal error: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# get_deck
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="get_deck",
+    description=(
+        "Retrieve the current state of a deck without submitting new work. "
+        "Returns structured slide data, a standalone HTML document, and "
+        "URLs into tellr's editor — same payload as a ready get_deck_status "
+        "response, without status/request_id/messages. Idempotent; no job "
+        "queue interaction. Use when you have a session_id from earlier and "
+        "want to re-render without polling."
+    ),
+)
+async def get_deck(ctx: Context, session_id: str) -> dict:
+    return await _get_deck_impl(
+        request=_request_from_context(ctx),
+        session_id=session_id,
+    )
+
+
+async def _get_deck_impl(request: Request, session_id: str) -> dict:
+    """Implementation, separated from the decorated tool for testability.
+
+    Idempotent read-only counterpart to ``get_deck_status``'s ready branch:
+    no job-queue interaction, no ``request_id``/``status``/``messages`` in
+    the response. Reuses ``_render_deck_response`` so the deck-shaped
+    fields stay identical to those in a ready ``get_deck_status`` reply.
+    """
+    try:
+        with mcp_auth_scope(request):
+            if not permission_service.can_view_deck(session_id):
+                raise MCPToolError(
+                    "Deck not found or you do not have permission to view it"
+                )
+
+            sm = get_session_manager()
+            session = sm.get_session(session_id)
+            if session is None:
+                raise MCPToolError(
+                    f"Deck not found: session_id={session_id}"
+                )
+            deck_dict = sm.get_slide_deck(session_id) or {}
+            base = _public_app_url()
+
+            deck_fields = _render_deck_response(deck_dict, session, base)
+
+            return {
+                "session_id": session_id,
+                **deck_fields,
+            }
+    except MCPToolError:
+        raise
+    except MCPAuthError as e:
+        raise MCPToolError(f"Authentication failed: {e}") from e
+    except Exception as e:
+        logger.exception("MCP get_deck failed")
+        raise MCPToolError(f"Internal error: {e}") from e

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -131,12 +131,14 @@ mcp = FastMCP("tellr")
 def _public_app_url() -> str:
     """Return the base URL for constructing deck_url / deck_view_url.
 
-    Reads TELLR_APP_URL from the environment; this is set at deploy time
-    by the Databricks App platform or by local dev config. Returns an
-    empty string if unset — tool handlers should treat empty as "build
-    relative URLs" rather than fail hard.
+    Reads DATABRICKS_APP_URL from the environment. The Databricks Apps
+    platform injects this automatically on production deployments, so no
+    manual configuration is required. Returns an empty string if unset
+    (e.g., local dev) — tool handlers treat empty as "build relative URLs"
+    rather than fail hard, and the browser resolves the resulting paths
+    against whatever host is serving the page.
     """
-    return os.getenv("TELLR_APP_URL", "").rstrip("/")
+    return os.getenv("DATABRICKS_APP_URL", "").rstrip("/")
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -28,6 +28,7 @@ from src.api.services.job_queue import enqueue_job, get_job_status
 from src.api.services.session_manager import get_session_manager
 from src.core.database import get_db_session
 from src.core.permission_context import get_permission_context
+from src.core.settings_db import get_default_slide_style_id
 from src.domain.slide import Slide
 from src.domain.slide_deck import SlideDeck
 from src.services.permission_service import get_permission_service
@@ -332,8 +333,16 @@ async def _create_deck_impl(
     try:
         with mcp_auth_scope(request) as identity:
             agent_config: dict[str, Any] = {"tools": []}
-            if slide_style_id is not None:
-                agent_config["slide_style_id"] = slide_style_id
+            # Mirror the browser chat flow: if the caller didn't specify a
+            # style, fall back to the tellr-configured default
+            # (slide_style_library.is_default=True) rather than the
+            # hardcoded DEFAULT_SLIDE_STYLE constant that agent_factory
+            # uses when agent_config.slide_style_id is absent.
+            effective_style_id = slide_style_id
+            if effective_style_id is None:
+                effective_style_id = get_default_slide_style_id()
+            if effective_style_id is not None:
+                agent_config["slide_style_id"] = effective_style_id
             if deck_prompt_id is not None:
                 agent_config["deck_prompt_id"] = deck_prompt_id
             if num_slides is not None:

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -30,6 +30,7 @@ from src.api.services.session_manager import SessionNotFoundError, get_session_m
 from src.core.context_utils import run_in_thread_with_context
 from src.core.database import get_db
 from src.core.permission_context import get_permission_context
+from src.core.settings_db import get_default_slide_style_id
 from src.core.user_context import get_current_user
 from src.database.models.profile_contributor import PermissionLevel
 from src.services.permission_service import get_permission_service, PERMISSION_PRIORITY
@@ -37,40 +38,6 @@ from src.services.permission_service import get_permission_service, PERMISSION_P
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["chat"])
-
-
-def _get_default_style_id() -> int | None:
-    """Return the ID of the default slide style (is_default=True, is_active=True), or None."""
-    from src.core.database import get_db_session
-    from src.database.models import SlideStyleLibrary
-
-    try:
-        with get_db_session() as db:
-            # Primary: explicit default
-            style = (
-                db.query(SlideStyleLibrary.id)
-                .filter(
-                    SlideStyleLibrary.is_default == True,  # noqa: E712
-                    SlideStyleLibrary.is_active == True,  # noqa: E712
-                )
-                .first()
-            )
-            if style:
-                return style.id
-
-            # Fallback: system style (defensive, for mid-migration)
-            style = (
-                db.query(SlideStyleLibrary.id)
-                .filter(
-                    SlideStyleLibrary.is_system == True,  # noqa: E712
-                    SlideStyleLibrary.is_active == True,  # noqa: E712
-                )
-                .first()
-            )
-            return style.id if style else None
-    except Exception:
-        # Column may not exist yet (pre-migration)
-        return None
 
 
 def _check_chat_permission(session_id: str, db: DBSession) -> None:
@@ -155,7 +122,7 @@ def _maybe_create_session(request: ChatRequest, session_manager) -> bool:
     # Build full agent_config_data with defaults (used for session creation)
     agent_config_data = explicit_config or AgentConfig().model_dump()
     if agent_config_data.get("slide_style_id") is None:
-        default_id = _get_default_style_id()
+        default_id = get_default_slide_style_id()
         if default_id is not None:
             agent_config_data["slide_style_id"] = default_id
 

--- a/src/api/services/job_queue.py
+++ b/src/api/services/job_queue.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 jobs: Dict[str, Dict[str, Any]] = {}
 job_queue: asyncio.Queue = asyncio.Queue()
 
+# Maximum duration (seconds) a chat request can stay in "running" before the
+# hard-timeout sweeper marks it failed. Belt-and-suspenders on top of the
+# startup recover_stuck_requests() pass: the sweeper runs continuously while
+# the app is up, whereas recovery only runs at process boot. Gives MCP callers
+# a predictable upper bound on poll duration independent of deploy cadence.
+JOB_HARD_TIMEOUT_SECONDS = 600
+
 
 async def enqueue_job(request_id: str, payload: dict) -> None:
     """Add a job to the queue.
@@ -276,4 +283,78 @@ async def recover_stuck_requests() -> int:
             logger.info(f"Recovered {count} stuck requests")
 
     return count
+
+
+async def mark_timed_out_jobs_once() -> int:
+    """Single sweep: mark running jobs older than JOB_HARD_TIMEOUT_SECONDS as failed.
+
+    Examines the in-memory ``jobs`` dict. For any entry whose ``status`` is
+    ``"running"`` and whose ``started_at`` is older than the timeout, flips
+    the status to ``"failed"`` and records an explanatory error. Jobs with
+    no ``started_at`` are left untouched (we cannot determine age).
+
+    Does NOT cancel the underlying worker coroutine — it only marks the
+    in-memory record. A stuck worker slot remains occupied until the next
+    app restart. See the spec's Error Handling section for the reasoning
+    behind this choice.
+
+    Returns:
+        Number of jobs marked failed in this sweep (useful for logging).
+    """
+    now = datetime.utcnow()
+    cutoff = now - timedelta(seconds=JOB_HARD_TIMEOUT_SECONDS)
+    marked = 0
+
+    for request_id, entry in list(jobs.items()):
+        if entry.get("status") != "running":
+            continue
+        started_at = entry.get("started_at")
+        if started_at is None:
+            continue
+        if started_at > cutoff:
+            continue
+
+        entry["status"] = "failed"
+        entry["error"] = (
+            f"Generation exceeded maximum duration "
+            f"({JOB_HARD_TIMEOUT_SECONDS // 60} minutes)"
+        )
+        entry["ended_at"] = now
+        marked += 1
+        logger.warning(
+            "Marked job as timed-out",
+            extra={
+                "request_id": request_id,
+                "session_id": entry.get("session_id"),
+                "age_seconds": (now - started_at).total_seconds(),
+            },
+        )
+
+    return marked
+
+
+async def mark_timed_out_jobs_loop() -> None:
+    """Background loop: runs ``mark_timed_out_jobs_once()`` every 60 seconds.
+
+    Started in the FastAPI lifespan alongside the existing chat/export workers
+    and request-log cleanup loop. Survives its own exceptions so a single
+    transient failure does not take the loop down for the lifetime of the
+    process. Responds to ``asyncio.CancelledError`` for clean shutdown.
+    """
+    while True:
+        try:
+            await asyncio.sleep(60)
+            marked = await mark_timed_out_jobs_once()
+            if marked:
+                logger.info(
+                    "Timeout sweep marked %d job(s) as failed", marked
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(
+                "Timeout sweep iteration failed",
+                exc_info=True,
+                extra={"error": str(e)},
+            )
 

--- a/src/api/services/job_queue.py
+++ b/src/api/services/job_queue.py
@@ -213,6 +213,7 @@ async def worker() -> None:
         try:
             request_id, payload = await job_queue.get()
             jobs[request_id]["status"] = "running"
+            jobs[request_id]["started_at"] = datetime.utcnow()
 
             try:
                 await process_chat_request(request_id, payload)

--- a/src/api/services/job_queue.py
+++ b/src/api/services/job_queue.py
@@ -27,6 +27,11 @@ job_queue: asyncio.Queue = asyncio.Queue()
 # a predictable upper bound on poll duration independent of deploy cadence.
 JOB_HARD_TIMEOUT_SECONDS = 600
 
+# How often the timeout sweeper loop wakes up to scan for stuck jobs.
+# Shorter values catch stuck jobs faster but scan more often; 60 is
+# the sweet spot given the 10-minute stuck-job cutoff.
+TIMEOUT_SWEEP_INTERVAL_SECONDS = 60
+
 
 async def enqueue_job(request_id: str, payload: dict) -> None:
     """Add a job to the queue.
@@ -344,7 +349,7 @@ async def mark_timed_out_jobs_loop() -> None:
     """
     while True:
         try:
-            await asyncio.sleep(60)
+            await asyncio.sleep(TIMEOUT_SWEEP_INTERVAL_SECONDS)
             marked = await mark_timed_out_jobs_once()
             if marked:
                 logger.info(

--- a/src/core/settings_db.py
+++ b/src/core/settings_db.py
@@ -27,6 +27,46 @@ logger = logging.getLogger(__name__)
 _active_profile_id: Optional[int] = None
 
 
+def get_default_slide_style_id() -> Optional[int]:
+    """Return the ID of the tellr-configured default slide style, or ``None``.
+
+    Resolves the primary ``is_default=True`` row from ``slide_style_library``;
+    falls back to ``is_system=True`` as a defensive mid-migration safety net.
+    Used by both the browser chat flow and the MCP ``create_deck`` tool so new
+    sessions pick up the user-configured default when no explicit
+    ``slide_style_id`` is supplied.
+    """
+    from src.database.models import SlideStyleLibrary
+
+    try:
+        with get_db_session() as db:
+            # Primary: explicit default
+            style = (
+                db.query(SlideStyleLibrary.id)
+                .filter(
+                    SlideStyleLibrary.is_default == True,  # noqa: E712
+                    SlideStyleLibrary.is_active == True,  # noqa: E712
+                )
+                .first()
+            )
+            if style:
+                return style.id
+
+            # Fallback: system style (defensive, for mid-migration)
+            style = (
+                db.query(SlideStyleLibrary.id)
+                .filter(
+                    SlideStyleLibrary.is_system == True,  # noqa: E712
+                    SlideStyleLibrary.is_active == True,  # noqa: E712
+                )
+                .first()
+            )
+            return style.id if style else None
+    except Exception:
+        # Column may not exist yet (pre-migration)
+        return None
+
+
 class GenieSettings(BaseSettings):
     """Genie configuration settings."""
 

--- a/src/domain/slide_deck.py
+++ b/src/domain/slide_deck.py
@@ -484,9 +484,64 @@ class SlideDeck:
             'slides': slides_list,
         }
 
+    def to_html_document(self, chart_js_cdn: str = None) -> str:
+        """Serialize the deck as a standalone renderable HTML document.
+
+        Produces a complete <!doctype html> page with the deck's CSS, external
+        scripts (with the Chart.js CDN URL overridable for air-gapped
+        environments), all slide HTML in order, and per-slide scripts
+        aggregated at the bottom.
+
+        Args:
+            chart_js_cdn: Override for the Chart.js CDN URL. If provided,
+                replaces the default Chart.js entry in external_scripts for
+                this serialization only (does NOT mutate the deck).
+
+        Returns:
+            A complete HTML document string, renderable in any modern browser.
+        """
+        title = self.title or "Slide Deck"
+
+        # Build external scripts list, applying the Chart.js CDN override
+        # without mutating self.external_scripts.
+        scripts_list: list[str] = []
+        replaced_default = False
+        for s in self.external_scripts:
+            if chart_js_cdn is not None and s == self.CHART_JS_URL:
+                scripts_list.append(chart_js_cdn)
+                replaced_default = True
+            else:
+                scripts_list.append(s)
+        # If no default was present but caller specified an override, append it.
+        if chart_js_cdn is not None and not replaced_default and chart_js_cdn not in scripts_list:
+            scripts_list.append(chart_js_cdn)
+
+        external_script_tags = "\n".join(
+            f'  <script src="{src}"></script>' for src in scripts_list
+        )
+
+        slide_html = "\n".join(slide.html for slide in self.slides)
+        aggregated_scripts = self.scripts  # IIFE-wrapped per existing property
+
+        return (
+            "<!doctype html>\n"
+            "<html>\n"
+            "<head>\n"
+            '  <meta charset="utf-8">\n'
+            f"  <title>{title}</title>\n"
+            f"  <style>\n{self.css}\n  </style>\n"
+            f"{external_script_tags}\n"
+            "</head>\n"
+            "<body>\n"
+            f"{slide_html}\n"
+            f"<script>\n{aggregated_scripts}\n</script>\n"
+            "</body>\n"
+            "</html>\n"
+        )
+
     def __len__(self) -> int:
         """Return number of slides.
-        
+
         Returns:
             Number of slides in the deck
         """

--- a/src/domain/slide_deck.py
+++ b/src/domain/slide_deck.py
@@ -566,9 +566,10 @@ class SlideDeck:
 
         html_parts: List[str] = [
             "<!doctype html>",
-            "<html>",
+            '<html lang="en">',
             "<head>",
             '  <meta charset="utf-8">',
+            '  <meta name="viewport" content="width=device-width, initial-scale=1">',
             f"  <title>{title}</title>",
         ]
 

--- a/src/domain/slide_deck.py
+++ b/src/domain/slide_deck.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import html
+import logging
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 from bs4 import BeautifulSoup
 
@@ -484,13 +489,17 @@ class SlideDeck:
             'slides': slides_list,
         }
 
-    def to_html_document(self, chart_js_cdn: str = None) -> str:
+    def to_html_document(self, chart_js_cdn: Optional[str] = None) -> str:
         """Serialize the deck as a standalone renderable HTML document.
 
         Produces a complete <!doctype html> page with the deck's CSS, external
         scripts (with the Chart.js CDN URL overridable for air-gapped
         environments), all slide HTML in order, and per-slide scripts
         aggregated at the bottom.
+
+        All caller-supplied and LLM-generated content is escaped before
+        interpolation to prevent XSS propagation through the MCP layer to
+        downstream consumers (Stride, Vibe, etc.).
 
         Args:
             chart_js_cdn: Override for the Chart.js CDN URL. If provided,
@@ -500,11 +509,14 @@ class SlideDeck:
         Returns:
             A complete HTML document string, renderable in any modern browser.
         """
-        title = self.title or "Slide Deck"
+        # Issue 1: Escape title to prevent XSS via </title><script>... injection.
+        title = html.escape(self.title or "Slide Deck")
+
+        # Issue 8: chart_js_cdn is Optional[str] (annotation fixed in signature above).
 
         # Build external scripts list, applying the Chart.js CDN override
         # without mutating self.external_scripts.
-        scripts_list: list[str] = []
+        scripts_list: List[str] = []
         replaced_default = False
         for s in self.external_scripts:
             if chart_js_cdn is not None and s == self.CHART_JS_URL:
@@ -516,28 +528,64 @@ class SlideDeck:
         if chart_js_cdn is not None and not replaced_default and chart_js_cdn not in scripts_list:
             scripts_list.append(chart_js_cdn)
 
-        external_script_tags = "\n".join(
-            f'  <script src="{src}"></script>' for src in scripts_list
-        )
+        # Issue 3: Escape and validate each src URL before interpolating into
+        # the attribute, to prevent attribute-escape XSS (e.g. src with embedded
+        # quote + onerror handler). Also skip non-http(s) URLs as an extra
+        # defense-in-depth measure.
+        script_tag_parts: List[str] = []
+        for src in scripts_list:
+            if not (src.startswith("http://") or src.startswith("https://")):
+                logger.warning(
+                    "to_html_document: skipping external script URL with unexpected "
+                    "scheme (expected http/https): %r",
+                    src,
+                )
+                continue
+            escaped_src = html.escape(src, quote=True)
+            script_tag_parts.append(f'  <script src="{escaped_src}"></script>')
+        external_script_tags = "\n".join(script_tag_parts)
+
+        # Issue 2: Strip any HTML tags from CSS before embedding in the style block,
+        # to prevent LLM-generated CSS from breaking out of the style element and
+        # injecting arbitrary markup. A </style> closes the style block; any other
+        # HTML tag (e.g. <script>) inside CSS is also illegitimate and must be removed.
+        safe_css = re.sub(r"</?\s*\w[^>]*>", "", self.css, flags=re.IGNORECASE)
 
         slide_html = "\n".join(slide.html for slide in self.slides)
         aggregated_scripts = self.scripts  # IIFE-wrapped per existing property
 
-        return (
-            "<!doctype html>\n"
-            "<html>\n"
-            "<head>\n"
-            '  <meta charset="utf-8">\n'
-            f"  <title>{title}</title>\n"
-            f"  <style>\n{self.css}\n  </style>\n"
-            f"{external_script_tags}\n"
-            "</head>\n"
-            "<body>\n"
-            f"{slide_html}\n"
-            f"<script>\n{aggregated_scripts}\n</script>\n"
-            "</body>\n"
-            "</html>\n"
-        )
+        html_parts: List[str] = [
+            "<!doctype html>",
+            "<html>",
+            "<head>",
+            '  <meta charset="utf-8">',
+            f"  <title>{title}</title>",
+        ]
+
+        # Issue 5: Only emit the <style> block when css is non-empty (matches knit()).
+        if safe_css:
+            html_parts.append(f"  <style>\n{safe_css}\n  </style>")
+
+        if external_script_tags:
+            html_parts.append(external_script_tags)
+
+        html_parts.extend([
+            "</head>",
+            "<body>",
+            slide_html,
+        ])
+
+        # Issue 4: Only emit the <script> block when there are actual scripts (matches knit()).
+        if aggregated_scripts:
+            html_parts.append(f"<script>\n{aggregated_scripts}\n</script>")
+
+        html_parts.extend([
+            "</body>",
+            "</html>",
+            "",  # trailing newline
+        ])
+
+        return "\n".join(html_parts)
 
     def __len__(self) -> int:
         """Return number of slides.

--- a/src/domain/slide_deck.py
+++ b/src/domain/slide_deck.py
@@ -8,14 +8,23 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-logger = logging.getLogger(__name__)
-
 from bs4 import BeautifulSoup
 
 from src.utils.css_utils import merge_css
 from src.utils.html_utils import split_script_by_canvas
 
 from .slide import Slide
+
+logger = logging.getLogger(__name__)
+
+# Surgical sanitizer for CSS embedded inside a <style> element. The only
+# HTML sequence that can break out of a <style> element during parsing is
+# the element's end tag, because <style> is a raw-text element (per the
+# HTML Standard). Anything else — <script>, <img>, inline-SVG markup, etc.
+# — is treated as CSS text by the parser and cannot escape. Stripping
+# tag-shaped substrings more broadly would corrupt legitimate CSS such as
+# `content: '<foo>'` and data-URI SVGs (`url('data:image/svg+xml,<svg></svg>')`).
+_STYLE_CLOSER_RE = re.compile(r"</\s*style\s*>", re.IGNORECASE)
 
 
 class SlideDeck:
@@ -545,11 +554,12 @@ class SlideDeck:
             script_tag_parts.append(f'  <script src="{escaped_src}"></script>')
         external_script_tags = "\n".join(script_tag_parts)
 
-        # Issue 2: Strip any HTML tags from CSS before embedding in the style block,
-        # to prevent LLM-generated CSS from breaking out of the style element and
-        # injecting arbitrary markup. A </style> closes the style block; any other
-        # HTML tag (e.g. <script>) inside CSS is also illegitimate and must be removed.
-        safe_css = re.sub(r"</?\s*\w[^>]*>", "", self.css, flags=re.IGNORECASE)
+        # Issue 2 (narrowed): Strip only </style> closers from CSS before embedding
+        # in the <style> block. Broader tag stripping would corrupt legitimate CSS
+        # content such as string literals (`content: '<foo>'`) and inline-SVG data
+        # URIs; it is also unnecessary because <style> is a raw-text element and
+        # </style> is the only sequence that can end it. See _STYLE_CLOSER_RE.
+        safe_css = _STYLE_CLOSER_RE.sub("", self.css) if self.css else ""
 
         slide_html = "\n".join(slide.html for slide in self.slides)
         aggregated_scripts = self.scripts  # IIFE-wrapped per existing property

--- a/tests/integration/test_mcp_endpoint.py
+++ b/tests/integration/test_mcp_endpoint.py
@@ -69,9 +69,11 @@ def _mcp_headers(session_id: str | None = None, with_auth: bool = True) -> dict:
 
     The transport demands ``Accept`` include both ``application/json``
     and ``text/event-stream`` so the server can choose its response
-    encoding. ``mcp-session-id`` is echoed back on ``initialize`` and
-    must be replayed on every subsequent JSON-RPC call in the same
-    session (including the required ``notifications/initialized``).
+    encoding. tellr runs FastMCP in stateless mode (see
+    ``src/api/mcp_server.py``), so the server never issues an
+    ``mcp-session-id`` header; callers may send one and the server
+    ignores it. We keep the ``session_id`` parameter for compatibility
+    with tests that still want to pass a value.
 
     ``Host`` is set to a value that matches FastMCP's DNS rebinding
     allowed-list wildcards. FastMCP auto-enables protection when its
@@ -157,20 +159,20 @@ def _is_tool_error(body: dict) -> bool:
     return bool(result.get("isError"))
 
 
-def _initialize_session(client: TestClient) -> str:
-    """Run the MCP initialize handshake and return the session id.
+def _initialize_session(client: TestClient) -> str | None:
+    """Run the MCP initialize handshake and return the session id (or None).
 
-    Also sends the required ``notifications/initialized`` callback that
-    FastMCP expects before tool calls will be processed.
+    Also sends the ``notifications/initialized`` callback. FastMCP runs
+    in stateless mode here so no ``mcp-session-id`` is issued and the
+    notification is effectively a no-op, but we keep the sequence to
+    exercise the same shape of handshake real clients send.
     """
     init = client.post(MCP_PATH, headers=_mcp_headers(), json=_init_payload())
     assert init.status_code == 200, (
         f"initialize returned {init.status_code}: {init.text!r}"
     )
     session_id = init.headers.get("mcp-session-id")
-    assert session_id, "server did not issue mcp-session-id on initialize"
 
-    # Required per MCP spec: clients must signal readiness before tool calls.
     client.post(
         MCP_PATH,
         headers=_mcp_headers(session_id=session_id),
@@ -280,13 +282,17 @@ def client():
 # ---------------------------------------------------------------------------
 
 
-def test_initialize_returns_session_id(client, mock_identity_client):
-    """The MCP initialize handshake succeeds and issues a session id."""
+def test_initialize_succeeds(client, mock_identity_client):
+    """The MCP initialize handshake returns a 200 JSON-RPC envelope.
+
+    tellr runs FastMCP in stateless mode so no ``mcp-session-id`` is
+    emitted; we just verify the endpoint is wired up and capabilities
+    negotiation works.
+    """
     resp = client.post(MCP_PATH, headers=_mcp_headers(), json=_init_payload())
     assert resp.status_code == 200, resp.text
-    assert resp.headers.get("mcp-session-id"), (
-        "server did not return an mcp-session-id header on initialize"
-    )
+    body = _decode_mcp_response(resp)
+    assert "result" in body, f"unexpected envelope: {body!r}"
 
 
 def test_tools_list_returns_four_tools(client, mock_identity_client):
@@ -390,12 +396,10 @@ def test_rejects_request_without_auth(client):
     )
 
     session_id = init.headers.get("mcp-session-id")
-    assert session_id, (
-        "initialize succeeded but no mcp-session-id header was issued"
-    )
 
-    # Send the initialized notification so the server will accept a
-    # follow-up tool call (still no auth header).
+    # Send the initialized notification to mimic a real client handshake
+    # shape (still no auth header). In stateless mode the server ignores
+    # the session_id; we pass it through if one happened to be issued.
     client.post(
         MCP_PATH,
         headers=_mcp_headers(session_id=session_id, with_auth=False),

--- a/tests/integration/test_mcp_endpoint.py
+++ b/tests/integration/test_mcp_endpoint.py
@@ -1,0 +1,474 @@
+"""End-to-end integration tests for the /mcp endpoint.
+
+Uses FastAPI TestClient against the full app. LLM generation, the
+Databricks identity client, and the job queue are mocked; the MCP
+tool handlers themselves, FastMCP request routing, JSON-RPC envelope
+handling, and ``/mcp`` mount wiring are all exercised for real.
+
+Two SDK-specific gotchas to keep in mind when reading these tests:
+
+1. ``FastMCP.streamable_http_app()`` returns a Starlette sub-app whose
+   lifespan initializes a task group required by ``handle_request``.
+   Starlette does NOT run mounted sub-app lifespans, so the parent
+   FastAPI lifespan in ``src/api/main.py`` enters the session manager
+   via ``AsyncExitStack`` — but only when ``PYTEST_CURRENT_TEST`` is
+   unset (since ``StreamableHTTPSessionManager.run()`` can only be
+   entered once per instance, and unit-test suites repeatedly
+   instantiate the lifespan). Integration tests therefore pop the
+   env var during TestClient setup so the real guarded code runs,
+   and patch ``init_db`` + migration helpers to no-ops so no DB is
+   touched during lifespan.
+
+2. ``POST /mcp`` returns a 307 redirect to ``/mcp/``. Hitting the
+   trailing-slash path directly avoids TestClient's redirect handling
+   (which may or may not follow redirects automatically depending on
+   the httpx version).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# Trailing slash: the FastMCP streamable-HTTP transport internally
+# mounts its route at "/", and main.py mounts that sub-app at "/mcp".
+# External POST to "/mcp" returns a 307 to "/mcp/"; going straight to
+# the slashed form bypasses that round trip.
+MCP_PATH = "/mcp/"
+
+
+def _jsonrpc(method: str, params: dict | None = None, rid: int = 1) -> dict:
+    """Build a minimal JSON-RPC 2.0 request body for the MCP transport."""
+    body: dict[str, Any] = {"jsonrpc": "2.0", "id": rid, "method": method}
+    if params is not None:
+        body["params"] = params
+    return body
+
+
+def _init_payload() -> dict:
+    """Standard MCP ``initialize`` call payload."""
+    return _jsonrpc(
+        "initialize",
+        {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "integration-test", "version": "0.0.0"},
+        },
+    )
+
+
+def _mcp_headers(session_id: str | None = None, with_auth: bool = True) -> dict:
+    """Build the header set FastMCP's streamable-HTTP transport requires.
+
+    The transport demands ``Accept`` include both ``application/json``
+    and ``text/event-stream`` so the server can choose its response
+    encoding. ``mcp-session-id`` is echoed back on ``initialize`` and
+    must be replayed on every subsequent JSON-RPC call in the same
+    session (including the required ``notifications/initialized``).
+
+    ``Host`` is set to a value that matches FastMCP's DNS rebinding
+    allowed-list wildcards. FastMCP auto-enables protection when its
+    ``host`` is ``127.0.0.1``/``localhost``/``::1`` (the default for
+    our ``FastMCP("tellr")`` instance) and allows hosts matching
+    ``["127.0.0.1:*", "localhost:*", "[::1]:*"]``. The wildcard match
+    requires a port component (see ``TransportSecurityMiddleware.
+    _validate_host``), so we send a dummy port. TestClient defaults to
+    ``testserver`` which FastMCP rejects with HTTP 421.
+    """
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Host": "127.0.0.1:8000",
+    }
+    if with_auth:
+        headers["Authorization"] = "Bearer fake-tok"
+    if session_id is not None:
+        headers["mcp-session-id"] = session_id
+    return headers
+
+
+def _decode_mcp_response(resp) -> dict:
+    """Decode a FastMCP streamable-HTTP response to a JSON-RPC envelope.
+
+    The streamable transport picks its response encoding based on the
+    ``Accept`` header: when the client accepts both ``application/json``
+    and ``text/event-stream`` (as we do), FastMCP defaults to SSE. An
+    SSE frame for a single JSON-RPC reply looks like:
+
+        event: message
+        data: {"jsonrpc":"2.0","id":1,"result":{...}}
+
+    with a trailing blank line. We extract the first ``data:`` line and
+    decode it as JSON. When the server instead chose raw JSON (e.g., for
+    a 202 Accepted notification ack) we pass that through unchanged.
+    """
+    ct = resp.headers.get("content-type", "")
+    body = resp.text
+    if "text/event-stream" in ct:
+        for line in body.splitlines():
+            if line.startswith("data:"):
+                return json.loads(line[len("data:"):].strip())
+        # Malformed SSE (no data line) — surface as empty envelope so
+        # downstream assertions produce a clear failure.
+        return {}
+    # Plain JSON response.
+    if not body.strip():
+        return {}
+    return json.loads(body)
+
+
+def _parse_tool_result(body: dict) -> dict:
+    """Extract the tool's structured return value from a JSON-RPC response.
+
+    FastMCP serializes tools with a ``-> dict`` return annotation into two
+    places on the CallToolResult: ``structuredContent`` (the dict verbatim,
+    per the output schema) and ``content`` (a list whose first entry is a
+    ``TextContent`` block containing the JSON-encoded dict). Prefer
+    ``structuredContent`` when present so the test doesn't depend on the
+    text serialization choice; fall back to decoding ``content[0].text``.
+    """
+    result = body.get("result") or {}
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        return structured
+    content = result.get("content") or []
+    if content:
+        text = content[0].get("text", "{}")
+        return json.loads(text) if isinstance(text, str) else text
+    return {}
+
+
+def _is_tool_error(body: dict) -> bool:
+    """Return True if the JSON-RPC response represents a tool-level error.
+
+    Accepts both shapes FastMCP may produce: a JSON-RPC protocol error
+    (``error`` at top level) and a tool-call result with ``isError: true``.
+    """
+    if "error" in body:
+        return True
+    result = body.get("result") or {}
+    return bool(result.get("isError"))
+
+
+def _initialize_session(client: TestClient) -> str:
+    """Run the MCP initialize handshake and return the session id.
+
+    Also sends the required ``notifications/initialized`` callback that
+    FastMCP expects before tool calls will be processed.
+    """
+    init = client.post(MCP_PATH, headers=_mcp_headers(), json=_init_payload())
+    assert init.status_code == 200, (
+        f"initialize returned {init.status_code}: {init.text!r}"
+    )
+    session_id = init.headers.get("mcp-session-id")
+    assert session_id, "server did not issue mcp-session-id on initialize"
+
+    # Required per MCP spec: clients must signal readiness before tool calls.
+    client.post(
+        MCP_PATH,
+        headers=_mcp_headers(session_id=session_id),
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+    return session_id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_identity_client():
+    """Patch the MCP auth's ``get_or_create_user_client`` to a fake client.
+
+    ``mcp_auth.extract_mcp_identity`` calls ``get_or_create_user_client(token)``
+    then ``client.current_user.me()`` to resolve the caller's identity from
+    the Bearer token. For integration tests we short-circuit both so the
+    auth layer returns a stable ``MCPIdentity`` without any real Databricks
+    API call.
+    """
+    client = MagicMock()
+    me = MagicMock()
+    me.id = "user-alice"
+    me.user_name = "alice@example.com"
+    client.current_user.me.return_value = me
+
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=client,
+    ):
+        yield client
+
+
+@contextmanager
+def _pytest_env_var_context():
+    """Temporarily unset ``PYTEST_CURRENT_TEST`` and restore on exit.
+
+    ``src/api/main.py`` gates the FastMCP session-manager startup on
+    ``PYTEST_CURRENT_TEST`` being unset (pytest sets it for every test).
+    We pop it just for the window where TestClient runs the FastAPI
+    lifespan, so the session manager actually starts and later tool
+    calls have the task group they need. Restore immediately — other
+    tests and conftest fixtures may rely on pytest-provided state.
+    """
+    saved = os.environ.pop("PYTEST_CURRENT_TEST", None)
+    try:
+        yield
+    finally:
+        if saved is not None and "PYTEST_CURRENT_TEST" not in os.environ:
+            os.environ["PYTEST_CURRENT_TEST"] = saved
+
+
+@pytest.fixture(scope="module")
+def client():
+    """TestClient that triggers the full FastAPI lifespan, reused across tests.
+
+    MUST be module-scoped. FastMCP's ``StreamableHTTPSessionManager.run()``
+    has a hard ``_has_started`` flag that prevents re-entry; since
+    ``src.api.mcp_server.mcp`` is a module-level singleton, once any
+    test's lifespan starts its task group there's no way to start it
+    again within the same process. A per-test ``TestClient`` would
+    therefore raise ``RuntimeError: .run() can only be called once``
+    on the second test. Module scope means the lifespan runs once,
+    all tests in this file share the running session manager, and
+    teardown happens when pytest exits this module.
+
+    Three things have to be true at lifespan-enter for MCP calls to
+    work end-to-end in integration tests:
+
+    1. The ``PYTEST_CURRENT_TEST`` guard in ``main.lifespan`` must
+       evaluate to None so the session manager context is entered.
+    2. ``init_db``/``get_session_local``/migration helpers must be
+       no-ops (with the env var popped, main.py's ``is_pytest`` check
+       also flips false and it would try to talk to a real Postgres).
+    3. ``TestClient`` must be used as a context manager (``with ...``)
+       so the lifespan runs at all — bare ``TestClient(app)`` skips
+       it and tool calls return HTTP 500 from the un-initialized
+       session manager.
+    """
+    from src.api.main import app
+
+    # Patch namespaces MUST match main.py's imports: ``init_db`` and
+    # ``get_session_local`` are imported at module load
+    # (``from src.core.database import init_db, get_session_local, ...``),
+    # so both are bound into ``src.api.main``'s namespace. Same for
+    # the migration helpers ``migrate_profiles`` and ``backfill_sessions``
+    # which come from ``src.core.migrate_profiles_to_agent_config``.
+    #
+    # Note: ``migrate_profiles(get_session_local())`` evaluates its
+    # argument first, so patching only ``migrate_profiles`` still lets
+    # ``get_session_local()`` call into the real DB engine. We patch
+    # both to keep the lifespan DB-free.
+    with patch("src.api.main.init_db"), \
+         patch("src.api.main.get_session_local", return_value=MagicMock()), \
+         patch("src.api.main.migrate_profiles", return_value=0), \
+         patch("src.api.main.backfill_sessions", return_value=0), \
+         _pytest_env_var_context(), \
+         TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_returns_session_id(client, mock_identity_client):
+    """The MCP initialize handshake succeeds and issues a session id."""
+    resp = client.post(MCP_PATH, headers=_mcp_headers(), json=_init_payload())
+    assert resp.status_code == 200, resp.text
+    assert resp.headers.get("mcp-session-id"), (
+        "server did not return an mcp-session-id header on initialize"
+    )
+
+
+def test_tools_list_returns_four_tools(client, mock_identity_client):
+    """``tools/list`` enumerates exactly the four tellr MCP tools."""
+    session_id = _initialize_session(client)
+
+    resp = client.post(
+        MCP_PATH,
+        headers=_mcp_headers(session_id=session_id),
+        json=_jsonrpc("tools/list"),
+    )
+    assert resp.status_code == 200, resp.text
+    body = _decode_mcp_response(resp)
+
+    # FastMCP returns a JSON-RPC envelope with ``result.tools``; the
+    # transport may wrap it in SSE (see ``_decode_mcp_response``).
+    assert "result" in body, f"unexpected envelope: {body!r}"
+    tool_names = {t["name"] for t in body["result"]["tools"]}
+    assert tool_names == {
+        "create_deck",
+        "get_deck_status",
+        "edit_deck",
+        "get_deck",
+    }, f"unexpected tool set: {tool_names}"
+
+
+def test_create_deck_returns_pending(client, mock_identity_client):
+    """Calling ``create_deck`` end-to-end returns a pending job envelope.
+
+    The MCP tool handler, mcp_auth_scope, and FastMCP's JSON-RPC routing
+    all run for real. The session manager's ``create_session`` and the
+    job-queue ``enqueue_create_job`` are the only pieces stubbed, so a
+    success return of ``{session_id, request_id, status: pending}``
+    exercises the whole tool pipeline without touching Databricks or
+    the LLM.
+    """
+    session_id = _initialize_session(client)
+
+    async def _fake_enqueue(**kwargs):
+        return "req-int-1"
+
+    # ``get_session_manager`` returns a module-level singleton; patching
+    # the name in ``mcp_server`` intercepts the call site inside
+    # ``_create_deck_impl``. ``enqueue_create_job`` is an async helper;
+    # we patch with ``side_effect`` so the coroutine is awaited correctly.
+    with patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch(
+             "src.api.mcp_server.enqueue_create_job",
+             side_effect=_fake_enqueue,
+         ):
+        sm = MagicMock()
+        sm.create_session.return_value = {"session_id": "sess-int-1"}
+        get_sm.return_value = sm
+
+        resp = client.post(
+            MCP_PATH,
+            headers=_mcp_headers(session_id=session_id),
+            json=_jsonrpc(
+                "tools/call",
+                {
+                    "name": "create_deck",
+                    "arguments": {"prompt": "integration test deck"},
+                },
+            ),
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = _decode_mcp_response(resp)
+    assert not _is_tool_error(body), f"tool reported error: {body!r}"
+    parsed = _parse_tool_result(body)
+    assert parsed["session_id"] == "sess-int-1"
+    assert parsed["request_id"] == "req-int-1"
+    assert parsed["status"] == "pending"
+
+
+def test_rejects_request_without_auth(client):
+    """A ``tools/call`` without any credential header is rejected.
+
+    ``initialize`` itself doesn't invoke the identity resolver (no tool
+    handler runs), so it may succeed. The meaningful check is on a
+    follow-up ``tools/call``: ``mcp_auth_scope`` raises ``MCPAuthError``
+    when neither ``x-forwarded-access-token`` nor ``Authorization``
+    headers are present, and the tool wraps that as ``MCPToolError``,
+    which FastMCP surfaces as a tool-level error (isError: true) or a
+    JSON-RPC protocol error depending on the failure path. Accept both
+    shapes.
+    """
+    # Step 1: initialize without auth. Expected to succeed (no tool
+    # handler runs) but we handle the case where it doesn't.
+    init = client.post(
+        MCP_PATH,
+        headers=_mcp_headers(with_auth=False),
+        json=_init_payload(),
+    )
+    if init.status_code in (401, 403):
+        return  # transport rejected unauthenticated init — acceptable
+    if init.status_code == 200 and "error" in _decode_mcp_response(init):
+        return  # initialize returned JSON-RPC error — acceptable
+    assert init.status_code == 200, (
+        f"unexpected initialize status: {init.status_code} {init.text!r}"
+    )
+
+    session_id = init.headers.get("mcp-session-id")
+    assert session_id, (
+        "initialize succeeded but no mcp-session-id header was issued"
+    )
+
+    # Send the initialized notification so the server will accept a
+    # follow-up tool call (still no auth header).
+    client.post(
+        MCP_PATH,
+        headers=_mcp_headers(session_id=session_id, with_auth=False),
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+
+    # Step 2: the actual test — a tool call without credentials must fail.
+    resp = client.post(
+        MCP_PATH,
+        headers=_mcp_headers(session_id=session_id, with_auth=False),
+        json=_jsonrpc(
+            "tools/call",
+            {"name": "create_deck", "arguments": {"prompt": "x"}},
+        ),
+    )
+
+    body = _decode_mcp_response(resp)
+    assert _is_tool_error(body), (
+        f"expected auth failure to surface as tool error; got: {body!r}"
+    )
+
+    # If it came through as a tool-level error, the message should
+    # reference authentication/credentials — useful signal that the
+    # error came from mcp_auth_scope and not from some unrelated bug.
+    result = body.get("result") or {}
+    if result.get("isError"):
+        content = result.get("content") or []
+        text = content[0].get("text", "") if content else ""
+        assert (
+            "auth" in text.lower() or "credentials" in text.lower()
+        ), f"tool-error content didn't mention auth: {text!r}"
+
+
+def test_permission_denied_on_other_users_deck(client, mock_identity_client):
+    """``get_deck`` on a deck the caller can't view surfaces a tool error.
+
+    The permission facade ``src.api.mcp_server.permission_service`` is
+    the single gate the MCP tool consults before returning deck data.
+    Patching ``can_view_deck`` to False bypasses the DB-backed
+    ``PermissionService`` and lets us test the MCP-side denial path
+    without seeding a real deck. The tool handler raises ``MCPToolError``
+    which FastMCP renders as a tool-level error result.
+    """
+    session_id = _initialize_session(client)
+
+    with patch(
+        "src.api.mcp_server.permission_service.can_view_deck",
+        return_value=False,
+    ):
+        resp = client.post(
+            MCP_PATH,
+            headers=_mcp_headers(session_id=session_id),
+            json=_jsonrpc(
+                "tools/call",
+                {
+                    "name": "get_deck",
+                    "arguments": {"session_id": "someone-elses-deck"},
+                },
+            ),
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = _decode_mcp_response(resp)
+    assert _is_tool_error(body), (
+        f"expected permission denial to surface as tool error; got: {body!r}"
+    )
+
+    # Confirm the error message reflects the permission/not-found wording
+    # the handler produces, not some unrelated crash.
+    result = body.get("result") or {}
+    content = result.get("content") or []
+    text = content[0].get("text", "") if content else ""
+    lowered = text.lower()
+    assert (
+        "permission" in lowered or "not found" in lowered
+    ), f"denial error didn't mention permission/not-found: {text!r}"

--- a/tests/unit/test_job_queue_timeout_sweeper.py
+++ b/tests/unit/test_job_queue_timeout_sweeper.py
@@ -1,0 +1,122 @@
+"""Tests for the 10-minute hard-timeout sweeper on chat jobs."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.api.services import job_queue
+
+
+@pytest.fixture(autouse=True)
+def _clean_jobs():
+    """Ensure an empty in-memory jobs dict between tests."""
+    job_queue.jobs.clear()
+    yield
+    job_queue.jobs.clear()
+
+
+def test_timeout_constant_is_600_seconds():
+    assert job_queue.JOB_HARD_TIMEOUT_SECONDS == 600
+
+
+@pytest.mark.asyncio
+async def test_sweep_marks_old_running_job_as_failed():
+    now = datetime.utcnow()
+    job_queue.jobs["req-old"] = {
+        "status": "running",
+        "session_id": "s1",
+        "started_at": now - timedelta(seconds=700),
+    }
+
+    marked = await job_queue.mark_timed_out_jobs_once()
+
+    entry = job_queue.jobs["req-old"]
+    assert entry["status"] == "failed"
+    error = entry.get("error", "")
+    assert "10 minutes" in error or "600" in error
+    assert marked == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_young_running_job_alone():
+    now = datetime.utcnow()
+    job_queue.jobs["req-young"] = {
+        "status": "running",
+        "session_id": "s2",
+        "started_at": now - timedelta(seconds=60),
+    }
+
+    marked = await job_queue.mark_timed_out_jobs_once()
+
+    assert job_queue.jobs["req-young"]["status"] == "running"
+    assert marked == 0
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_pending_job_alone():
+    now = datetime.utcnow()
+    job_queue.jobs["req-pending"] = {
+        "status": "pending",
+        "session_id": "s3",
+        "queued_at": now - timedelta(seconds=1200),
+    }
+
+    marked = await job_queue.mark_timed_out_jobs_once()
+
+    assert job_queue.jobs["req-pending"]["status"] == "pending"
+    assert marked == 0
+
+
+@pytest.mark.asyncio
+async def test_sweep_idempotent_on_already_failed():
+    now = datetime.utcnow()
+    job_queue.jobs["req-already-failed"] = {
+        "status": "failed",
+        "session_id": "s4",
+        "started_at": now - timedelta(hours=1),
+        "error": "Existing error",
+    }
+
+    marked = await job_queue.mark_timed_out_jobs_once()
+
+    entry = job_queue.jobs["req-already-failed"]
+    assert entry["status"] == "failed"
+    assert entry["error"] == "Existing error"
+    assert marked == 0
+
+
+@pytest.mark.asyncio
+async def test_sweep_handles_missing_started_at():
+    """Sweeper must not crash if a running job has no started_at timestamp."""
+    job_queue.jobs["req-no-ts"] = {
+        "status": "running",
+        "session_id": "s5",
+    }
+
+    marked = await job_queue.mark_timed_out_jobs_once()
+
+    assert job_queue.jobs["req-no-ts"]["status"] == "running"
+    assert marked == 0
+
+
+@pytest.mark.asyncio
+async def test_sweep_marks_multiple_timed_out_jobs():
+    now = datetime.utcnow()
+    for i in range(3):
+        job_queue.jobs[f"req-{i}"] = {
+            "status": "running",
+            "session_id": f"s{i}",
+            "started_at": now - timedelta(seconds=900),
+        }
+    job_queue.jobs["req-fresh"] = {
+        "status": "running",
+        "session_id": "s-fresh",
+        "started_at": now - timedelta(seconds=10),
+    }
+
+    marked = await job_queue.mark_timed_out_jobs_once()
+
+    assert marked == 3
+    assert job_queue.jobs["req-fresh"]["status"] == "running"
+    for i in range(3):
+        assert job_queue.jobs[f"req-{i}"]["status"] == "failed"

--- a/tests/unit/test_job_queue_timeout_sweeper.py
+++ b/tests/unit/test_job_queue_timeout_sweeper.py
@@ -120,3 +120,71 @@ async def test_sweep_marks_multiple_timed_out_jobs():
     assert job_queue.jobs["req-fresh"]["status"] == "running"
     for i in range(3):
         assert job_queue.jobs[f"req-{i}"]["status"] == "failed"
+
+
+# ---- Integration: worker populates started_at correctly --------------------
+
+
+@pytest.mark.asyncio
+async def test_job_entry_gets_started_at_when_worker_marks_running():
+    """
+    Integration-style test: when the worker flips a job to running, started_at
+    must be populated so the timeout sweeper can judge its age.
+
+    The actual status flip to "running" happens inside worker() (not
+    process_chat_request), because process_chat_request only updates the DB
+    row via session_manager. The in-memory jobs dict — which the sweeper
+    reads — is flipped inline in the worker loop. This test captures the
+    entry state at the moment process_chat_request is invoked (via an
+    AsyncMock side_effect), which is immediately after the worker has
+    flipped status to "running" — the exact point the sweeper cares about.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    request_id = "req-integ-1"
+    captured: dict = {}
+
+    async def _capture_entry(_rid, _payload):
+        # Snapshot the jobs entry exactly when the worker hands off to
+        # process_chat_request — i.e., right after the status flip.
+        captured["entry"] = dict(job_queue.jobs[_rid])
+
+    with patch(
+        "src.api.services.job_queue.process_chat_request",
+        new=AsyncMock(side_effect=_capture_entry),
+    ):
+        await job_queue.enqueue_job(
+            request_id,
+            {
+                "session_id": "sess-integ",
+                "message": "hello",
+            },
+        )
+
+        worker_task = asyncio.create_task(job_queue.worker())
+        try:
+            # Wait for the worker to drain our single queued item. join()
+            # resolves once task_done() has been called for every queued
+            # item, which in worker() happens after process_chat_request
+            # returns (i.e., after our capture ran).
+            await asyncio.wait_for(job_queue.job_queue.join(), timeout=2.0)
+        finally:
+            worker_task.cancel()
+            try:
+                await worker_task
+            except asyncio.CancelledError:
+                pass
+
+    entry = captured.get("entry")
+    assert entry is not None, (
+        "worker should have invoked process_chat_request for the enqueued job"
+    )
+    assert entry.get("status") == "running", (
+        "worker must flip status to running before calling process_chat_request"
+    )
+    assert "started_at" in entry, (
+        "worker must populate started_at when the job enters the running "
+        "state, so the timeout sweeper can age it"
+    )
+    assert isinstance(entry["started_at"], datetime)

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -111,6 +111,83 @@ def test_bearer_extraction_trims_whitespace(fake_user_client):
     assert identity.token == "tok-spaced"
 
 
+# ---- Priority 3: x-forwarded-identity (app-to-app) ------------------------
+
+
+def test_forwarded_identity_resolved_when_env_var_enabled(monkeypatch):
+    monkeypatch.setenv("TELLR_TRUST_FORWARDED_IDENTITY", "true")
+    req = _FakeRequest(
+        headers={
+            "x-forwarded-email": "alice@example.com",
+            "x-forwarded-user": "12345@99999",
+        }
+    )
+    identity = extract_mcp_identity(req)
+
+    assert identity.user_name == "alice@example.com"
+    assert identity.user_id == "12345"
+    assert identity.token is None
+    assert identity.source == "x-forwarded-identity"
+
+
+def test_forwarded_identity_rejected_when_env_var_disabled(monkeypatch):
+    monkeypatch.delenv("TELLR_TRUST_FORWARDED_IDENTITY", raising=False)
+    req = _FakeRequest(
+        headers={
+            "x-forwarded-email": "alice@example.com",
+            "x-forwarded-user": "12345@99999",
+        }
+    )
+    with pytest.raises(MCPAuthError):
+        extract_mcp_identity(req)
+
+
+def test_token_takes_precedence_over_forwarded_identity(
+    monkeypatch, fake_user_client
+):
+    """Even with TELLR_TRUST_FORWARDED_IDENTITY on, a presented token wins."""
+    monkeypatch.setenv("TELLR_TRUST_FORWARDED_IDENTITY", "true")
+    req = _FakeRequest(
+        headers={
+            "authorization": "Bearer tok-bearer",
+            "x-forwarded-email": "alice@example.com",
+            "x-forwarded-user": "12345@99999",
+        }
+    )
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.token == "tok-bearer"
+    assert identity.source == "authorization-bearer"
+
+
+def test_forwarded_identity_handles_malformed_user_header(monkeypatch):
+    """x-forwarded-user without '@' yields user_id=None, not a crash."""
+    monkeypatch.setenv("TELLR_TRUST_FORWARDED_IDENTITY", "true")
+    req = _FakeRequest(
+        headers={
+            "x-forwarded-email": "alice@example.com",
+            "x-forwarded-user": "bare-user-id",  # no @workspace suffix
+        }
+    )
+    identity = extract_mcp_identity(req)
+
+    assert identity.user_name == "alice@example.com"
+    assert identity.user_id is None
+    assert identity.source == "x-forwarded-identity"
+
+
+def test_forwarded_identity_requires_email(monkeypatch):
+    """x-forwarded-user without x-forwarded-email is insufficient."""
+    monkeypatch.setenv("TELLR_TRUST_FORWARDED_IDENTITY", "true")
+    req = _FakeRequest(headers={"x-forwarded-user": "12345@99999"})
+    with pytest.raises(MCPAuthError):
+        extract_mcp_identity(req)
+
+
 # ---- mcp_auth_scope context manager --------------------------------------
 
 
@@ -147,6 +224,35 @@ def test_scope_clears_context_even_on_exception(fake_user_client):
         assert set_user.call_args_list[-1].args[0] is None
         assert set_client.call_args_list[-1].args[0] is None
         assert set_perm.call_args_list[-1].args[0] is None
+
+
+def test_scope_uses_system_client_for_forwarded_identity(monkeypatch):
+    """Priority 3 path binds tellr's SP client (no user token available)."""
+    monkeypatch.setenv("TELLR_TRUST_FORWARDED_IDENTITY", "true")
+    req = _FakeRequest(
+        headers={
+            "x-forwarded-email": "alice@example.com",
+            "x-forwarded-user": "12345@99999",
+        }
+    )
+    sp_client = MagicMock(name="sp_client")
+
+    with patch("src.api.mcp_auth.get_system_client", return_value=sp_client), \
+         patch("src.api.mcp_auth.get_or_create_user_client") as user_client_factory, \
+         patch("src.api.mcp_auth.set_user_client") as set_client:
+
+        with mcp_auth_scope(req) as identity:
+            assert identity.source == "x-forwarded-identity"
+            assert identity.token is None
+
+        # User-client factory should never be touched (no token to pass)
+        user_client_factory.assert_not_called()
+        # SP client was bound on entry
+        bound_clients = [
+            call.args[0] for call in set_client.call_args_list
+            if call.args[0] is not None
+        ]
+        assert bound_clients == [sp_client]
 
 
 def test_mcp_identity_repr_does_not_leak_token():

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -147,3 +147,21 @@ def test_scope_clears_context_even_on_exception(fake_user_client):
         assert set_user.call_args_list[-1].args[0] is None
         assert set_client.call_args_list[-1].args[0] is None
         assert set_perm.call_args_list[-1].args[0] is None
+
+
+def test_mcp_identity_repr_does_not_leak_token():
+    """The dataclass repr must not include the raw bearer token, so the
+    identity object is safe to log even if someone writes
+    ``logger.info("id=%s", identity)`` in the future."""
+    from src.api.mcp_auth import MCPIdentity
+    identity = MCPIdentity(
+        user_id="u-1",
+        user_name="alice@example.com",
+        token="super-secret-bearer-token",
+        source="authorization-bearer",
+    )
+    rendered = repr(identity)
+    assert "super-secret-bearer-token" not in rendered
+    # user_name and source still in repr (useful for debugging)
+    assert "alice@example.com" in rendered
+    assert "authorization-bearer" in rendered

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1,0 +1,149 @@
+"""Tests for the dual-token MCP auth helper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.api.mcp_auth import (
+    MCPAuthError,
+    extract_mcp_identity,
+    mcp_auth_scope,
+)
+
+
+class _FakeRequest:
+    """Minimal Request stand-in with a headers dict."""
+
+    def __init__(self, headers: dict):
+        self.headers = headers
+
+
+@pytest.fixture
+def fake_user_client():
+    client = MagicMock()
+    me = MagicMock()
+    me.id = "user-abc"
+    me.user_name = "alice@example.com"
+    client.current_user.me.return_value = me
+    return client
+
+
+# ---- extract_mcp_identity -------------------------------------------------
+
+
+def test_extracts_from_x_forwarded_access_token_when_present(fake_user_client):
+    req = _FakeRequest(headers={"x-forwarded-access-token": "tok-xfa"})
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.user_id == "user-abc"
+    assert identity.user_name == "alice@example.com"
+    assert identity.token == "tok-xfa"
+    assert identity.source == "x-forwarded-access-token"
+
+
+def test_falls_back_to_authorization_bearer(fake_user_client):
+    req = _FakeRequest(headers={"authorization": "Bearer tok-bearer"})
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.token == "tok-bearer"
+    assert identity.source == "authorization-bearer"
+
+
+def test_x_forwarded_wins_over_authorization_when_both_present(fake_user_client):
+    req = _FakeRequest(
+        headers={
+            "x-forwarded-access-token": "tok-xfa",
+            "authorization": "Bearer tok-bearer",
+        }
+    )
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.token == "tok-xfa"
+    assert identity.source == "x-forwarded-access-token"
+
+
+def test_raises_on_missing_credentials():
+    req = _FakeRequest(headers={})
+    with pytest.raises(MCPAuthError) as exc:
+        extract_mcp_identity(req)
+    msg = str(exc.value).lower()
+    assert "authentication" in msg or "credentials" in msg
+
+
+def test_raises_on_malformed_authorization_header():
+    req = _FakeRequest(headers={"authorization": "Basic abcd"})
+    with pytest.raises(MCPAuthError):
+        extract_mcp_identity(req)
+
+
+def test_raises_when_identity_resolution_fails():
+    req = _FakeRequest(headers={"authorization": "Bearer tok-bad"})
+    bad_client = MagicMock()
+    bad_client.current_user.me.side_effect = Exception("token invalid")
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=bad_client,
+    ):
+        with pytest.raises(MCPAuthError):
+            extract_mcp_identity(req)
+
+
+def test_bearer_extraction_trims_whitespace(fake_user_client):
+    req = _FakeRequest(headers={"authorization": "Bearer    tok-spaced   "})
+    with patch(
+        "src.api.mcp_auth.get_or_create_user_client",
+        return_value=fake_user_client,
+    ):
+        identity = extract_mcp_identity(req)
+
+    assert identity.token == "tok-spaced"
+
+
+# ---- mcp_auth_scope context manager --------------------------------------
+
+
+def test_scope_sets_and_clears_context_vars(fake_user_client):
+    req = _FakeRequest(headers={"x-forwarded-access-token": "tok"})
+
+    with patch("src.api.mcp_auth.get_or_create_user_client", return_value=fake_user_client), \
+         patch("src.api.mcp_auth.set_current_user") as set_user, \
+         patch("src.api.mcp_auth.set_user_client") as set_client, \
+         patch("src.api.mcp_auth.set_permission_context") as set_perm:
+
+        with mcp_auth_scope(req) as identity:
+            assert identity.user_name == "alice@example.com"
+
+        # After exit: all three setters were called with None for teardown
+        assert set_user.call_args_list[-1].args[0] is None
+        assert set_client.call_args_list[-1].args[0] is None
+        assert set_perm.call_args_list[-1].args[0] is None
+
+
+def test_scope_clears_context_even_on_exception(fake_user_client):
+    req = _FakeRequest(headers={"x-forwarded-access-token": "tok"})
+
+    with patch("src.api.mcp_auth.get_or_create_user_client", return_value=fake_user_client), \
+         patch("src.api.mcp_auth.set_current_user") as set_user, \
+         patch("src.api.mcp_auth.set_user_client") as set_client, \
+         patch("src.api.mcp_auth.set_permission_context") as set_perm:
+
+        with pytest.raises(RuntimeError):
+            with mcp_auth_scope(req):
+                raise RuntimeError("boom")
+
+        # Context was still cleared
+        assert set_user.call_args_list[-1].args[0] is None
+        assert set_client.call_args_list[-1].args[0] is None
+        assert set_perm.call_args_list[-1].args[0] is None

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -140,3 +140,148 @@ async def test_create_deck_surfaces_auth_error_as_tool_error(fake_request):
                 prompt="foo",
             )
         assert "auth" in str(exc.value).lower() or "credentials" in str(exc.value).lower()
+
+
+# ---- get_deck_status ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_returns_pending_shape(fake_request, identity):
+    from src.api import mcp_server
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_job_status") as get_status, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = True
+        get_status.return_value = {"status": "pending", "session_id": "sess-1"}
+
+        result = await mcp_server._get_deck_status_impl(
+            request=fake_request,
+            session_id="sess-1",
+            request_id="req-1",
+        )
+
+        assert result == {
+            "session_id": "sess-1",
+            "request_id": "req-1",
+            "status": "pending",
+            "progress": None,
+        }
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_returns_ready_with_full_deck(fake_request, identity):
+    from src.api import mcp_server
+
+    fake_session = {
+        "session_id": "sess-1",
+        "title": "Q3 Pitch",
+        "deck_json": {
+            "title": "Q3 Pitch",
+            "slides": [{"html": "<div class='slide'>A</div>", "scripts": ""}],
+            "css": "",
+            "external_scripts": ["https://cdn.jsdelivr.net/npm/chart.js"],
+            "head_meta": {},
+        },
+    }
+
+    fake_turn_messages = [
+        {"role": "user", "content": "make Q3 deck"},
+        {"role": "assistant", "content": "I created 1 slide..."},
+    ]
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_job_status") as get_status, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server._public_app_url", return_value="https://t.example"):
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = True
+        get_status.return_value = {
+            "status": "ready",
+            "session_id": "sess-1",
+            "messages": fake_turn_messages,
+            "replacement_info": None,
+            "mode": "generate",
+            "latency_ms": 10000,
+            "tool_calls": 0,
+            "correlation_id": None,
+        }
+
+        sm = MagicMock()
+        sm.get_session.return_value = fake_session
+        get_sm.return_value = sm
+
+        result = await mcp_server._get_deck_status_impl(
+            request=fake_request,
+            session_id="sess-1",
+            request_id="req-1",
+        )
+
+        assert result["status"] == "ready"
+        assert result["session_id"] == "sess-1"
+        assert result["slide_count"] == 1
+        assert result["title"] == "Q3 Pitch"
+        assert "deck" in result and "slides" in result["deck"]
+        assert result["html_document"].lower().startswith("<!doctype")
+        assert result["deck_url"] == "https://t.example/sessions/sess-1/edit"
+        assert result["deck_view_url"] == "https://t.example/sessions/sess-1/view"
+        assert result["messages"] == fake_turn_messages
+        assert result["replacement_info"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_returns_failed_with_error(fake_request, identity):
+    from src.api import mcp_server
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_job_status") as get_status, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = True
+        get_status.return_value = {
+            "status": "failed",
+            "session_id": "sess-1",
+            "error": "Generation exceeded maximum duration (10 minutes)",
+        }
+
+        result = await mcp_server._get_deck_status_impl(
+            request=fake_request,
+            session_id="sess-1",
+            request_id="req-1",
+        )
+
+        assert result["status"] == "failed"
+        assert "10 minutes" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_denies_when_not_permitted(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        perm_svc.can_view_deck.return_value = False
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._get_deck_status_impl(
+                request=fake_request,
+                session_id="sess-other",
+                request_id="req-1",
+            )
+        assert "permission" in str(exc.value).lower() or "not found" in str(exc.value).lower()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -147,6 +147,7 @@ async def test_create_deck_surfaces_auth_error_as_tool_error(fake_request):
 
 @pytest.mark.asyncio
 async def test_get_deck_status_returns_pending_shape(fake_request, identity):
+    """In-memory fast path: job is queued but hasn't started yet."""
     from src.api import mcp_server
 
     with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
@@ -175,48 +176,70 @@ async def test_get_deck_status_returns_pending_shape(fake_request, identity):
 
 @pytest.mark.asyncio
 async def test_get_deck_status_returns_ready_with_full_deck(fake_request, identity):
+    """DB ready path: worker finished and popped the in-memory job, so the
+    MCP tool reads the completed ``chat_request`` row and re-fetches the
+    deck via ``SessionManager.get_slide_deck``."""
     from src.api import mcp_server
 
-    fake_session = {
-        "session_id": "sess-1",
+    fake_session = {"session_id": "sess-1", "title": "Q3 Pitch"}
+    fake_deck = {
         "title": "Q3 Pitch",
-        "deck_json": {
-            "title": "Q3 Pitch",
-            "slides": [{"html": "<div class='slide'>A</div>", "scripts": ""}],
-            "css": "",
-            "external_scripts": ["https://cdn.jsdelivr.net/npm/chart.js"],
-            "head_meta": {},
+        "slides": [{"html": "<div class='slide'>A</div>", "scripts": ""}],
+        "css": "",
+        "external_scripts": ["https://cdn.jsdelivr.net/npm/chart.js"],
+        "head_meta": {},
+    }
+    fake_chat_request = {
+        "request_id": "req-1",
+        "session_id": 42,  # integer PK, real session_manager returns this
+        "status": "completed",
+        "error_message": None,
+        "created_at": "2026-04-22T12:00:00",
+        "completed_at": "2026-04-22T12:00:10",
+        "result": {
+            "slides": fake_deck["slides"],
+            "raw_html": "<html>...</html>",
+            "replacement_info": None,
+            "experiment_url": "https://mlflow.example/exp/123",
+            "metadata": {"tool_calls": 0, "latency_ms": 10000},
+            "session_title": "Q3 Pitch",
         },
     }
-
     fake_turn_messages = [
-        {"role": "user", "content": "make Q3 deck"},
-        {"role": "assistant", "content": "I created 1 slide..."},
+        {
+            "id": 1,
+            "role": "user",
+            "content": "make Q3 deck",
+            "message_type": "user_query",
+            "created_at": "2026-04-22T12:00:00",
+            "metadata": None,
+        },
+        {
+            "id": 2,
+            "role": "assistant",
+            "content": "I created 1 slide...",
+            "message_type": None,
+            "created_at": "2026-04-22T12:00:09",
+            "metadata": None,
+        },
     ]
 
     with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
-         patch("src.api.mcp_server.get_job_status") as get_status, \
+         patch("src.api.mcp_server.get_job_status", return_value=None), \
          patch("src.api.mcp_server.permission_service") as perm_svc, \
          patch("src.api.mcp_server.get_session_manager") as get_sm, \
          patch("src.api.mcp_server._public_app_url", return_value="https://t.example"):
 
         auth_scope.return_value.__enter__.return_value = identity
         auth_scope.return_value.__exit__.return_value = False
-
         perm_svc.can_view_deck.return_value = True
-        get_status.return_value = {
-            "status": "ready",
-            "session_id": "sess-1",
-            "messages": fake_turn_messages,
-            "replacement_info": None,
-            "mode": "generate",
-            "latency_ms": 10000,
-            "tool_calls": 0,
-            "correlation_id": None,
-        }
 
         sm = MagicMock()
+        sm.get_chat_request.return_value = fake_chat_request
+        sm.get_session_id_for_request.return_value = "sess-1"
+        sm.get_slide_deck.return_value = fake_deck
         sm.get_session.return_value = fake_session
+        sm.get_messages_for_request.return_value = fake_turn_messages
         get_sm.return_value = sm
 
         result = await mcp_server._get_deck_status_impl(
@@ -233,12 +256,19 @@ async def test_get_deck_status_returns_ready_with_full_deck(fake_request, identi
         assert result["html_document"].lower().startswith("<!doctype")
         assert result["deck_url"] == "https://t.example/sessions/sess-1/edit"
         assert result["deck_view_url"] == "https://t.example/sessions/sess-1/view"
-        assert result["messages"] == fake_turn_messages
         assert result["replacement_info"] is None
+        assert result["metadata"]["latency_ms"] == 10000
+        assert result["metadata"]["experiment_url"] == "https://mlflow.example/exp/123"
+        # Messages come from the DB turn transcript, not from the job dict.
+        assert len(result["messages"]) == 2
+        assert result["messages"][0]["role"] == "user"
+        assert result["messages"][0]["content"] == "make Q3 deck"
 
 
 @pytest.mark.asyncio
 async def test_get_deck_status_returns_failed_with_error(fake_request, identity):
+    """In-memory failed path: the timeout sweeper flipped a stuck job to
+    ``failed`` before the worker could complete it."""
     from src.api import mcp_server
 
     with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
@@ -285,3 +315,94 @@ async def test_get_deck_status_denies_when_not_permitted(fake_request, identity)
                 request_id="req-1",
             )
         assert "permission" in str(exc.value).lower() or "not found" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_get_deck_status_falls_back_to_db_when_job_popped_from_memory(
+    fake_request, identity
+):
+    """When a worker completes, its in-memory job entry is popped. The
+    MCP tool must fall back to the DB chat_request row to reconstruct
+    the ready state, fetching the deck via ``get_slide_deck`` rather
+    than assuming it was baked into ``get_session`` output."""
+    from src.api import mcp_server
+
+    fake_session = {"session_id": "sess-1", "title": "Q3 Pitch"}
+    fake_deck = {
+        "title": "Q3 Pitch",
+        "slides": [{"html": "<div class='slide'>A</div>", "scripts": ""}],
+        "css": "",
+        "external_scripts": ["https://cdn.jsdelivr.net/npm/chart.js"],
+        "head_meta": {},
+    }
+    fake_chat_request = {
+        "request_id": "req-1",
+        "session_id": 42,  # integer PK, real session_manager returns this
+        "status": "completed",
+        "error_message": None,
+        "created_at": "2026-04-22T12:00:00",
+        "completed_at": "2026-04-22T12:00:15",
+        "result": {
+            "slides": fake_deck["slides"],
+            "raw_html": "<html>...</html>",
+            "replacement_info": None,
+            "experiment_url": None,
+            "metadata": {"tool_calls": 0, "latency_ms": 15000},
+        },
+    }
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_job_status", return_value=None) as get_status, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server._public_app_url", return_value="https://t.example"):
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_view_deck.return_value = True
+
+        sm = MagicMock()
+        sm.get_chat_request.return_value = fake_chat_request
+        sm.get_session_id_for_request.return_value = "sess-1"
+        sm.get_slide_deck.return_value = fake_deck
+        sm.get_session.return_value = fake_session
+        sm.get_messages_for_request.return_value = [
+            {
+                "id": 1,
+                "role": "user",
+                "content": "make Q3 deck",
+                "message_type": "user_query",
+                "created_at": "2026-04-22T12:00:00",
+                "metadata": None,
+            },
+            {
+                "id": 2,
+                "role": "assistant",
+                "content": "Done.",
+                "message_type": None,
+                "created_at": "2026-04-22T12:00:14",
+                "metadata": None,
+            },
+        ]
+        get_sm.return_value = sm
+
+        result = await mcp_server._get_deck_status_impl(
+            request=fake_request,
+            session_id="sess-1",
+            request_id="req-1",
+        )
+
+        # Confirm the in-memory fast path saw None (worker popped the entry).
+        get_status.assert_called_once_with("req-1")
+        # Confirm the DB was consulted next.
+        sm.get_chat_request.assert_called_once_with("req-1")
+        # Confirm the deck was re-fetched via the dedicated method, not
+        # read from session.get_session output.
+        sm.get_slide_deck.assert_called_once_with("sess-1")
+
+        assert result["status"] == "ready"
+        assert result["slide_count"] == 1
+        assert "deck" in result
+        assert result["html_document"].lower().startswith("<!doctype")
+        assert result["deck_url"] == "https://t.example/sessions/sess-1/edit"
+        assert result["metadata"]["latency_ms"] == 15000

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -406,3 +406,137 @@ async def test_get_deck_status_falls_back_to_db_when_job_popped_from_memory(
         assert result["html_document"].lower().startswith("<!doctype")
         assert result["deck_url"] == "https://t.example/sessions/sess-1/edit"
         assert result["metadata"]["latency_ms"] == 15000
+
+
+# ---- edit_deck ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_submits_with_slide_context(fake_request, identity):
+    from src.api import mcp_server
+
+    # session_manager.get_slide_deck returns the deck dict
+    fake_deck = {
+        "title": "x",
+        "slides": [
+            {"html": "<div class='slide'>0</div>", "scripts": ""},
+            {"html": "<div class='slide'>1</div>", "scripts": ""},
+            {"html": "<div class='slide'>2</div>", "scripts": ""},
+        ],
+        "css": "",
+        "external_scripts": [],
+        "head_meta": {},
+    }
+
+    async def _fake_enqueue(**kwargs):
+        return "req-edit-1"
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job", side_effect=_fake_enqueue) as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = True
+
+        sm = MagicMock()
+        sm.get_slide_deck.return_value = fake_deck
+        get_sm.return_value = sm
+
+        result = await mcp_server._edit_deck_impl(
+            request=fake_request,
+            session_id="sess-1",
+            instruction="make slide 2 more exciting",
+            slide_indices=[1],
+        )
+
+        enqueue.assert_called_once()
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["session_id"] == "sess-1"
+        assert kwargs["prompt"] == "make slide 2 more exciting"
+        assert kwargs["mode"] == "edit"
+        assert kwargs["slide_context"]["indices"] == [1]
+        assert kwargs["slide_context"]["slide_htmls"] == ["<div class='slide'>1</div>"]
+
+        assert result == {
+            "session_id": "sess-1",
+            "request_id": "req-edit-1",
+            "status": "pending",
+        }
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_submits_without_slide_context_when_indices_omitted(
+    fake_request, identity
+):
+    from src.api import mcp_server
+
+    async def _fake_enqueue(**kwargs):
+        return "req-edit-2"
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job", side_effect=_fake_enqueue) as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = True
+
+        sm = MagicMock()
+        # If slide_indices is omitted, get_slide_deck should NOT be called
+        sm.get_slide_deck.return_value = None
+        get_sm.return_value = sm
+
+        await mcp_server._edit_deck_impl(
+            request=fake_request,
+            session_id="sess-1",
+            instruction="make it more exciting",
+        )
+
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["mode"] == "edit"
+        assert kwargs["slide_context"] is None
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_rejects_non_contiguous_indices(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = True
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._edit_deck_impl(
+                request=fake_request,
+                session_id="sess-1",
+                instruction="edit",
+                slide_indices=[0, 2],  # not contiguous
+            )
+        assert "contiguous" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_deck_denies_without_edit_permission(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_edit_deck.return_value = False
+
+        with pytest.raises(MCPToolError):
+            await mcp_server._edit_deck_impl(
+                request=fake_request,
+                session_id="sess-other",
+                instruction="edit",
+            )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,142 @@
+"""Unit tests for MCP tool handlers.
+
+Each handler is tested in isolation with mocked services. Integration
+behavior (full JSON-RPC round trip, FastMCP routing) lives in
+tests/integration/test_mcp_endpoint.py (added in Task 11).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.api.mcp_auth import MCPIdentity
+
+
+@pytest.fixture
+def identity():
+    return MCPIdentity(
+        user_id="user-abc",
+        user_name="alice@example.com",
+        token="tok",
+        source="x-forwarded-access-token",
+    )
+
+
+@pytest.fixture
+def fake_request():
+    req = MagicMock()
+    req.headers = {"x-forwarded-access-token": "tok"}
+    return req
+
+
+# ---- create_deck --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_deck_creates_session_and_submits_job(fake_request, identity):
+    from src.api import mcp_server
+
+    mock_session = {"session_id": "sess-123"}
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.enqueue_create_job") as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        sm = MagicMock()
+        sm.create_session.return_value = mock_session
+        get_sm.return_value = sm
+
+        async def _fake_enqueue(**kwargs):
+            return "req-777"
+
+        enqueue.side_effect = _fake_enqueue
+
+        result = await mcp_server._create_deck_impl(
+            request=fake_request,
+            prompt="make a deck about Q3",
+            num_slides=7,
+            slide_style_id=4,
+            deck_prompt_id=2,
+            correlation_id="vibe-xyz",
+        )
+
+        sm.create_session.assert_called_once()
+        create_kwargs = sm.create_session.call_args.kwargs
+        assert create_kwargs["created_by"] == "alice@example.com"
+        agent_config = create_kwargs["agent_config"]
+        assert agent_config["tools"] == []
+        assert agent_config["slide_style_id"] == 4
+        assert agent_config["deck_prompt_id"] == 2
+        assert agent_config["num_slides"] == 7
+
+        enqueue.assert_called_once()
+        assert enqueue.call_args.kwargs["session_id"] == "sess-123"
+        assert enqueue.call_args.kwargs["prompt"] == "make a deck about Q3"
+        assert enqueue.call_args.kwargs["mode"] == "generate"
+        assert enqueue.call_args.kwargs["correlation_id"] == "vibe-xyz"
+
+        assert result == {
+            "session_id": "sess-123",
+            "request_id": "req-777",
+            "status": "pending",
+        }
+
+
+@pytest.mark.asyncio
+async def test_create_deck_rejects_empty_prompt(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope:
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="",
+            )
+        assert "prompt" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_create_deck_rejects_num_slides_out_of_range(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope:
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        with pytest.raises(MCPToolError):
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="foo",
+                num_slides=0,
+            )
+        with pytest.raises(MCPToolError):
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="foo",
+                num_slides=51,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_deck_surfaces_auth_error_as_tool_error(fake_request):
+    from src.api import mcp_server
+    from src.api.mcp_auth import MCPAuthError
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope:
+        auth_scope.return_value.__enter__.side_effect = MCPAuthError("no creds")
+
+        with pytest.raises(MCPToolError) as exc:
+            await mcp_server._create_deck_impl(
+                request=fake_request,
+                prompt="foo",
+            )
+        assert "auth" in str(exc.value).lower() or "credentials" in str(exc.value).lower()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -540,3 +540,69 @@ async def test_edit_deck_denies_without_edit_permission(fake_request, identity):
                 session_id="sess-other",
                 instruction="edit",
             )
+
+
+# ---- get_deck -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_deck_returns_deck_without_job(fake_request, identity):
+    from src.api import mcp_server
+
+    fake_session = {"session_id": "sess-1", "title": "Existing Deck"}
+    fake_deck = {
+        "title": "Existing Deck",
+        "slides": [{"html": "<div class='slide'>1</div>", "scripts": ""}],
+        "css": "",
+        "external_scripts": ["https://cdn.jsdelivr.net/npm/chart.js"],
+        "head_meta": {},
+    }
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server._public_app_url", return_value="https://t.example"):
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_view_deck.return_value = True
+
+        sm = MagicMock()
+        sm.get_session.return_value = fake_session
+        sm.get_slide_deck.return_value = fake_deck
+        get_sm.return_value = sm
+
+        result = await mcp_server._get_deck_impl(
+            request=fake_request,
+            session_id="sess-1",
+        )
+
+        assert result["session_id"] == "sess-1"
+        assert result["slide_count"] == 1
+        assert result["title"] == "Existing Deck"
+        assert "deck" in result
+        assert result["html_document"].lower().startswith("<!doctype")
+        assert result["deck_url"] == "https://t.example/sessions/sess-1/edit"
+        assert result["deck_view_url"] == "https://t.example/sessions/sess-1/view"
+        # Fields tied to a job/turn are absent
+        for absent_key in ("status", "request_id", "messages", "replacement_info", "metadata"):
+            assert absent_key not in result
+
+
+@pytest.mark.asyncio
+async def test_get_deck_denies_without_view_permission(fake_request, identity):
+    from src.api import mcp_server
+    from src.api.mcp_server import MCPToolError
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.permission_service") as perm_svc:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+        perm_svc.can_view_deck.return_value = False
+
+        with pytest.raises(MCPToolError):
+            await mcp_server._get_deck_impl(
+                request=fake_request,
+                session_id="sess-other",
+            )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -86,6 +86,85 @@ async def test_create_deck_creates_session_and_submits_job(fake_request, identit
 
 
 @pytest.mark.asyncio
+async def test_create_deck_falls_back_to_tellr_default_slide_style(
+    fake_request, identity
+):
+    """When the caller omits slide_style_id, create_deck should populate
+    agent_config with the tellr-configured default (slide_style_library.
+    is_default=True) so MCP-initiated sessions pick up the same style the
+    browser flow does.
+    """
+    from src.api import mcp_server
+
+    mock_session = {"session_id": "sess-123"}
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.get_default_slide_style_id") as get_default, \
+         patch("src.api.mcp_server.enqueue_create_job") as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        sm = MagicMock()
+        sm.create_session.return_value = mock_session
+        get_sm.return_value = sm
+
+        get_default.return_value = 17
+
+        async def _fake_enqueue(**kwargs):
+            return "req-42"
+
+        enqueue.side_effect = _fake_enqueue
+
+        await mcp_server._create_deck_impl(
+            request=fake_request,
+            prompt="a deck about widgets",
+        )
+
+        get_default.assert_called_once()
+        agent_config = sm.create_session.call_args.kwargs["agent_config"]
+        assert agent_config["slide_style_id"] == 17
+
+
+@pytest.mark.asyncio
+async def test_create_deck_skips_default_lookup_when_slide_style_id_provided(
+    fake_request, identity
+):
+    """An explicit slide_style_id should short-circuit the default lookup."""
+    from src.api import mcp_server
+
+    mock_session = {"session_id": "sess-123"}
+
+    with patch("src.api.mcp_server.mcp_auth_scope") as auth_scope, \
+         patch("src.api.mcp_server.get_session_manager") as get_sm, \
+         patch("src.api.mcp_server.get_default_slide_style_id") as get_default, \
+         patch("src.api.mcp_server.enqueue_create_job") as enqueue:
+
+        auth_scope.return_value.__enter__.return_value = identity
+        auth_scope.return_value.__exit__.return_value = False
+
+        sm = MagicMock()
+        sm.create_session.return_value = mock_session
+        get_sm.return_value = sm
+
+        async def _fake_enqueue(**kwargs):
+            return "req-42"
+
+        enqueue.side_effect = _fake_enqueue
+
+        await mcp_server._create_deck_impl(
+            request=fake_request,
+            prompt="a deck about widgets",
+            slide_style_id=9,
+        )
+
+        get_default.assert_not_called()
+        agent_config = sm.create_session.call_args.kwargs["agent_config"]
+        assert agent_config["slide_style_id"] == 9
+
+
+@pytest.mark.asyncio
 async def test_create_deck_rejects_empty_prompt(fake_request, identity):
     from src.api import mcp_server
     from src.api.mcp_server import MCPToolError

--- a/tests/unit/test_slide_deck_to_html_document.py
+++ b/tests/unit/test_slide_deck_to_html_document.py
@@ -148,3 +148,11 @@ def test_to_html_document_escapes_chart_js_cdn_attribute():
     # dropping it. The input URL contains two literal quotes (the attribute-
     # breakout and the opening of the injected onerror); both get escaped.
     assert "chart.js&quot; onerror=&quot;alert(1)" in out
+
+
+def test_to_html_document_includes_lang_and_viewport(minimal_deck):
+    """Output should declare language (a11y) and viewport (mobile)."""
+    out = minimal_deck.to_html_document()
+    assert 'lang="en"' in out
+    assert 'name="viewport"' in out
+    assert "width=device-width" in out

--- a/tests/unit/test_slide_deck_to_html_document.py
+++ b/tests/unit/test_slide_deck_to_html_document.py
@@ -1,5 +1,7 @@
 """Tests for SlideDeck.to_html_document() serializer."""
 
+import re
+
 import pytest
 
 from src.domain.slide import Slide
@@ -95,17 +97,54 @@ def test_to_html_document_escapes_title():
 
 
 def test_to_html_document_strips_style_closer_from_css():
-    """CSS containing </style> must not be able to break out of the style block."""
-    malicious_css = "body { color: red; }</style><script>alert(1)</script><style>"
+    """CSS containing </style> must not be able to break out of the style block.
+
+    Uses only a surgical strip of </style> tags; everything else (including
+    legitimate CSS with <, and any non-</style> HTML-shaped text inside CSS
+    string/data-URI contexts) must survive.
+    """
+    malicious_css = (
+        "body { color: red; }"
+        "</style>"
+        "<script>alert(1)</script>"
+        "<style>"
+    )
     deck = SlideDeck(title="X", css=malicious_css)
     out = deck.to_html_document()
-    # The injected script tag should not appear as executable markup
-    assert "<script>alert(1)</script>" not in out
+
+    # Legitimate CSS survives
+    assert "body { color: red; }" in out
+
+    # The </style> that would break out of our style element is stripped
+    # (case-insensitive). After stripping, exactly ONE </style> remains
+    # in the output — the one we emit ourselves as the closer.
+    closers = len(re.findall(r"</\s*style\s*>", out, flags=re.IGNORECASE))
+    assert closers == 1, f"expected exactly 1 </style>, saw {closers}"
+
+
+def test_to_html_document_preserves_legitimate_css_with_angle_brackets():
+    """CSS containing <> in string literals or data URIs must be preserved."""
+    legit_css = (
+        "p::before { content: '<foo>'; }\n"
+        "div { background: url('data:image/svg+xml,<svg></svg>'); }"
+    )
+    deck = SlideDeck(title="X", css=legit_css)
+    out = deck.to_html_document()
+    assert "content: '<foo>';" in out
+    assert "data:image/svg+xml,<svg></svg>" in out
 
 
 def test_to_html_document_escapes_chart_js_cdn_attribute():
     """A CDN URL that tries to break out of the src attribute must be neutralized."""
     deck = SlideDeck(title="X")
-    out = deck.to_html_document(chart_js_cdn='https://ok.cdn/chart.js" onerror="alert(1)')
-    # Unescaped onerror attribute should NOT appear
+    malicious_cdn = 'https://ok.cdn/chart.js" onerror="alert(1)'
+    out = deck.to_html_document(chart_js_cdn=malicious_cdn)
+
+    # Unescaped onerror attribute must not appear
     assert 'onerror="alert(1)"' not in out
+
+    # Escaped form (both " in the URL escaped to &quot;) appears — proving
+    # we emitted the tag with the URL, just safely escaped, rather than
+    # dropping it. The input URL contains two literal quotes (the attribute-
+    # breakout and the opening of the injected onerror); both get escaped.
+    assert "chart.js&quot; onerror=&quot;alert(1)" in out

--- a/tests/unit/test_slide_deck_to_html_document.py
+++ b/tests/unit/test_slide_deck_to_html_document.py
@@ -43,7 +43,7 @@ def test_to_html_document_includes_deck_css(minimal_deck):
 
 def test_to_html_document_includes_chart_js_cdn(minimal_deck):
     out = minimal_deck.to_html_document()
-    assert "chart.js" in out
+    assert f'<script src="{SlideDeck.CHART_JS_URL}">' in out
 
 
 def test_to_html_document_includes_all_slide_html(minimal_deck):
@@ -75,3 +75,37 @@ def test_to_html_document_is_deterministic(minimal_deck):
     a = minimal_deck.to_html_document()
     b = minimal_deck.to_html_document()
     assert a == b
+
+
+def test_to_html_document_does_not_mutate_external_scripts(minimal_deck):
+    original = list(minimal_deck.external_scripts)
+    minimal_deck.to_html_document(chart_js_cdn="https://other.cdn/chart.js")
+    assert minimal_deck.external_scripts == original
+
+
+def test_to_html_document_escapes_title():
+    """Title with HTML/script content must not break out of the <title> element."""
+    malicious_title = '</title><script>alert(1)</script><title>X'
+    deck = SlideDeck(title=malicious_title)
+    out = deck.to_html_document()
+    # The exact <script> tag should NOT appear unescaped
+    assert "<script>alert(1)</script>" not in out
+    # Escaped form should appear (html.escape converts < > to &lt; &gt;)
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in out
+
+
+def test_to_html_document_strips_style_closer_from_css():
+    """CSS containing </style> must not be able to break out of the style block."""
+    malicious_css = "body { color: red; }</style><script>alert(1)</script><style>"
+    deck = SlideDeck(title="X", css=malicious_css)
+    out = deck.to_html_document()
+    # The injected script tag should not appear as executable markup
+    assert "<script>alert(1)</script>" not in out
+
+
+def test_to_html_document_escapes_chart_js_cdn_attribute():
+    """A CDN URL that tries to break out of the src attribute must be neutralized."""
+    deck = SlideDeck(title="X")
+    out = deck.to_html_document(chart_js_cdn='https://ok.cdn/chart.js" onerror="alert(1)')
+    # Unescaped onerror attribute should NOT appear
+    assert 'onerror="alert(1)"' not in out

--- a/tests/unit/test_slide_deck_to_html_document.py
+++ b/tests/unit/test_slide_deck_to_html_document.py
@@ -1,0 +1,77 @@
+"""Tests for SlideDeck.to_html_document() serializer."""
+
+import pytest
+
+from src.domain.slide import Slide
+from src.domain.slide_deck import SlideDeck
+
+
+@pytest.fixture
+def minimal_deck():
+    return SlideDeck(
+        title="Test Deck",
+        css=".slide { background: white; }",
+        external_scripts=["https://cdn.jsdelivr.net/npm/chart.js"],
+        slides=[
+            Slide(html='<div class="slide"><h1>Slide 1</h1></div>', scripts=""),
+            Slide(
+                html='<div class="slide"><canvas id="c1"></canvas></div>',
+                scripts='new Chart(document.getElementById("c1"), {});',
+            ),
+        ],
+    )
+
+
+def test_to_html_document_is_valid_html5(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert out.startswith("<!doctype html>") or out.startswith("<!DOCTYPE html>")
+    assert "<html" in out
+    assert "<head>" in out
+    assert "<body>" in out
+    assert "</html>" in out
+
+
+def test_to_html_document_includes_title(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert "<title>Test Deck</title>" in out
+
+
+def test_to_html_document_includes_deck_css(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert ".slide { background: white; }" in out
+
+
+def test_to_html_document_includes_chart_js_cdn(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert "chart.js" in out
+
+
+def test_to_html_document_includes_all_slide_html(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert "<h1>Slide 1</h1>" in out
+    assert '<canvas id="c1"></canvas>' in out
+
+
+def test_to_html_document_includes_slide_scripts(minimal_deck):
+    out = minimal_deck.to_html_document()
+    assert 'new Chart(document.getElementById("c1")' in out
+
+
+def test_to_html_document_overrides_chart_js_cdn(minimal_deck):
+    out = minimal_deck.to_html_document(chart_js_cdn="https://internal.cdn/chart.js")
+    assert "https://internal.cdn/chart.js" in out
+    # Default CDN should not appear in the output
+    assert out.count("cdn.jsdelivr.net") == 0
+
+
+def test_to_html_document_empty_deck():
+    deck = SlideDeck(title="Empty")
+    out = deck.to_html_document()
+    assert "<!doctype html>" in out.lower()
+    assert "<title>Empty</title>" in out
+
+
+def test_to_html_document_is_deterministic(minimal_deck):
+    a = minimal_deck.to_html_document()
+    b = minimal_deck.to_html_document()
+    assert a == b

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -16,6 +16,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "databricks-langchain" },
+    { name = "databricks-mcp" },
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
     { name = "esprima" },
@@ -31,6 +32,7 @@ dependencies = [
     { name = "langchain-text-splitters" },
     { name = "litellm" },
     { name = "lxml" },
+    { name = "mcp" },
     { name = "mlflow" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
@@ -45,6 +47,7 @@ dependencies = [
     { name = "python-pptx" },
     { name = "pyyaml" },
     { name = "sqlalchemy" },
+    { name = "svgpathtools" },
     { name = "tinycss2" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -72,6 +75,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "databricks-langchain", specifier = ">=0.1.0" },
+    { name = "databricks-mcp", specifier = ">=0.1.0" },
     { name = "databricks-sdk", specifier = ">=0.85.0" },
     { name = "databricks-sql-connector", specifier = ">=3.0.0" },
     { name = "esprima", specifier = ">=4.0.0" },
@@ -85,8 +89,9 @@ requires-dist = [
     { name = "langchain-community", specifier = ">=0.0.1" },
     { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langchain-text-splitters", specifier = ">=0.0.1" },
-    { name = "litellm", specifier = ">=1.50.0" },
+    { name = "litellm", specifier = "==1.80.11" },
     { name = "lxml", specifier = ">=4.9.0" },
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "mlflow", specifier = ">=3.6.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.6.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
@@ -111,6 +116,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "setuptools-scm", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "svgpathtools", specifier = ">=1.6.0" },
     { name = "tinycss2", specifier = ">=1.3.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=6.2.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
@@ -121,7 +127,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
@@ -130,7 +136,7 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.13.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
@@ -250,7 +256,7 @@ wheels = [
 [[package]]
 name = "aiohttp-retry"
 version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "aiohttp" },
 ]
@@ -262,7 +268,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "frozenlist" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -275,7 +281,7 @@ wheels = [
 [[package]]
 name = "alembic"
 version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
@@ -290,7 +296,7 @@ wheels = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -299,7 +305,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -308,7 +314,7 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
@@ -323,7 +329,7 @@ wheels = [
 [[package]]
 name = "async-timeout"
 version = "4.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f", size = 8345, upload-time = "2023-08-10T16:35:56.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028", size = 5721, upload-time = "2023-08-10T16:35:55.203Z" },
@@ -332,7 +338,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "25.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
@@ -341,7 +347,7 @@ wheels = [
 [[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
@@ -350,7 +356,7 @@ wheels = [
 [[package]]
 name = "backports-tarfile"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
@@ -359,7 +365,7 @@ wheels = [
 [[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
@@ -372,7 +378,7 @@ wheels = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -381,7 +387,7 @@ wheels = [
 [[package]]
 name = "build"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
@@ -397,7 +403,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "6.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
@@ -406,7 +412,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2025.11.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
@@ -415,7 +421,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
@@ -497,7 +503,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
@@ -586,7 +592,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -598,7 +604,7 @@ wheels = [
 [[package]]
 name = "cloudpickle"
 version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
@@ -607,7 +613,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -616,12 +622,12 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -686,7 +692,7 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -694,8 +700,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -775,7 +781,7 @@ wheels = [
 [[package]]
 name = "coverage"
 version = "7.11.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d2/59/9698d57a3b11704c7b89b21d69e9d23ecf80d538cabb536c8b63f4a12322/coverage-7.11.3.tar.gz", hash = "sha256:0f59387f5e6edbbffec2281affb71cdc85e0776c1745150a3ab9b6c1d016106b", size = 815210, upload-time = "2025-11-10T00:13:17.18Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/68/b53157115ef76d50d1d916d6240e5cd5b3c14dba8ba1b984632b8221fc2e/coverage-7.11.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0c986537abca9b064510f3fd104ba33e98d3036608c7f2f5537f869bc10e1ee5", size = 216377, upload-time = "2025-11-10T00:10:27.317Z" },
@@ -879,7 +885,7 @@ toml = [
 [[package]]
 name = "cryptography"
 version = "46.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -944,7 +950,7 @@ wheels = [
 [[package]]
 name = "cycler"
 version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
@@ -953,7 +959,7 @@ wheels = [
 [[package]]
 name = "databricks-ai-bridge"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "databricks-sdk" },
     { name = "mlflow-skinny" },
@@ -970,7 +976,7 @@ wheels = [
 [[package]]
 name = "databricks-connect"
 version = "16.1.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -978,12 +984,12 @@ resolution-markers = [
 dependencies = [
     { name = "databricks-sdk", marker = "python_full_version < '3.12'" },
     { name = "googleapis-common-protos", marker = "python_full_version < '3.12'" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "grpcio-status", version = "1.62.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "grpcio-status", version = "1.62.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
     { name = "packaging", marker = "python_full_version < '3.12'" },
     { name = "pandas", marker = "python_full_version < '3.12'" },
-    { name = "py4j", version = "0.10.9.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "py4j", version = "0.10.9.7", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
     { name = "pyarrow", marker = "python_full_version < '3.12'" },
     { name = "setuptools", marker = "python_full_version < '3.12'" },
     { name = "six", marker = "python_full_version < '3.12'" },
@@ -995,7 +1001,7 @@ wheels = [
 [[package]]
 name = "databricks-connect"
 version = "17.0.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -1004,14 +1010,14 @@ resolution-markers = [
 dependencies = [
     { name = "databricks-sdk", marker = "python_full_version >= '3.12'" },
     { name = "googleapis-common-protos", marker = "python_full_version >= '3.12'" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "grpcio-status", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "grpcio-status", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.14'" },
+    { name = "grpcio-status", version = "1.67.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "grpcio-status", version = "1.76.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
     { name = "packaging", marker = "python_full_version >= '3.12'" },
     { name = "pandas", marker = "python_full_version >= '3.12'" },
-    { name = "py4j", version = "0.10.9.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "py4j", version = "0.10.9.9", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
     { name = "pyarrow", marker = "python_full_version >= '3.12'" },
     { name = "setuptools", marker = "python_full_version >= '3.12'" },
     { name = "six", marker = "python_full_version >= '3.12'" },
@@ -1023,7 +1029,7 @@ wheels = [
 [[package]]
 name = "databricks-langchain"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "databricks-ai-bridge" },
     { name = "databricks-sdk" },
@@ -1039,13 +1045,28 @@ wheels = [
 ]
 
 [[package]]
+name = "databricks-mcp"
+version = "0.9.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+dependencies = [
+    { name = "databricks-ai-bridge" },
+    { name = "databricks-sdk" },
+    { name = "mcp" },
+    { name = "mlflow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/6b/fe9c6291bbbbccd14267bd05ade1f4522b59fc3380d16253476b9984d1a1/databricks_mcp-0.9.0.tar.gz", hash = "sha256:e311c70221306116af7fc9adb2bfedf0fb2f181d7cf12ff1e46682334150a98a", size = 10898, upload-time = "2026-02-20T23:41:39.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/98/710dccd35deedcb5a03a3d191e3e6c2bd99547de865a0d200f6cf52ca434/databricks_mcp-0.9.0-py3-none-any.whl", hash = "sha256:09407d60ecc5ee0ccd5f200b33426b148bf88b0fdc0975bc4f1d55f17f884ec9", size = 12413, upload-time = "2026-02-20T23:41:38.791Z" },
+]
+
+[[package]]
 name = "databricks-sdk"
 version = "0.94.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-auth" },
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/39/18b3a4a69851f583d7970ae71f19975e06ef892ea17393bcafb773088f96/databricks_sdk-0.94.0.tar.gz", hash = "sha256:1b29a9d63e2dc9808ed79253ba3668cd6d130dabb880a576d647fa3b1b1a7b30", size = 861465, upload-time = "2026-02-26T08:17:12.063Z" }
@@ -1056,7 +1077,7 @@ wheels = [
 [[package]]
 name = "databricks-sql-connector"
 version = "4.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "lz4" },
     { name = "oauthlib" },
@@ -1076,12 +1097,12 @@ wheels = [
 [[package]]
 name = "databricks-vectorsearch"
 version = "0.63"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "deprecation" },
     { name = "mlflow-skinny" },
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "requests" },
 ]
 wheels = [
@@ -1091,7 +1112,7 @@ wheels = [
 [[package]]
 name = "dataclasses-json"
 version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "marshmallow" },
     { name = "typing-inspect" },
@@ -1104,7 +1125,7 @@ wheels = [
 [[package]]
 name = "deprecation"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -1116,7 +1137,7 @@ wheels = [
 [[package]]
 name = "distro"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
@@ -1125,7 +1146,7 @@ wheels = [
 [[package]]
 name = "docker"
 version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
@@ -1139,7 +1160,7 @@ wheels = [
 [[package]]
 name = "docutils"
 version = "0.22.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
@@ -1148,13 +1169,13 @@ wheels = [
 [[package]]
 name = "esprima"
 version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/a1/50fccd68a12bcfc27adfc9969c090286670a9109a0259f3f70943390b721/esprima-4.0.1.tar.gz", hash = "sha256:08db1a876d3c2910db9cfaeb83108193af5411fc3a3a66ebefacd390d21323ee", size = 47021, upload-time = "2018-08-24T13:59:11.374Z" }
 
 [[package]]
 name = "et-xmlfile"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
@@ -1163,7 +1184,7 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -1175,7 +1196,7 @@ wheels = [
 [[package]]
 name = "execnet"
 version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
@@ -1184,7 +1205,7 @@ wheels = [
 [[package]]
 name = "fastapi"
 version = "0.121.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
@@ -1199,7 +1220,7 @@ wheels = [
 [[package]]
 name = "fastuuid"
 version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/b2/731a6696e37cd20eed353f69a09f37a984a43c9713764ee3f7ad5f57f7f9/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a", size = 516760, upload-time = "2025-10-19T22:25:21.509Z" },
@@ -1262,7 +1283,7 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.20.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c1/e0/a75dbe4bca1e7d41307323dad5ea2efdd95408f74ab2de8bd7dba9b51a1a/filelock-3.20.2.tar.gz", hash = "sha256:a2241ff4ddde2a7cebddf78e39832509cb045d18ec1a09d7248d6bfc6bfbbe64", size = 19510, upload-time = "2026-01-02T15:33:32.582Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl", hash = "sha256:fbba7237d6ea277175a32c54bb71ef814a8546d8601269e1bfc388de333974e8", size = 16697, upload-time = "2026-01-02T15:33:31.133Z" },
@@ -1271,7 +1292,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
@@ -1288,7 +1309,7 @@ wheels = [
 [[package]]
 name = "flask-cors"
 version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
@@ -1301,7 +1322,7 @@ wheels = [
 [[package]]
 name = "fonttools"
 version = "4.60.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/42/97a13e47a1e51a5a7142475bbcf5107fe3a68fc34aef331c897d5fb98ad0/fonttools-4.60.1.tar.gz", hash = "sha256:ef00af0439ebfee806b25f24c8f92109157ff3fac5731dc7867957812e87b8d9", size = 3559823, upload-time = "2025-09-29T21:13:27.129Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/70/03e9d89a053caff6ae46053890eba8e4a5665a7c5638279ed4492e6d4b8b/fonttools-4.60.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9a52f254ce051e196b8fe2af4634c2d2f02c981756c6464dc192f1b6050b4e28", size = 2810747, upload-time = "2025-09-29T21:10:59.653Z" },
@@ -1358,7 +1379,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/4a/557715d5047da48d54e659203b9335be7bfaafda2c3f627b7c47e0b3aaf3/frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011", size = 86230, upload-time = "2025-10-06T05:35:23.699Z" },
@@ -1479,7 +1500,7 @@ wheels = [
 [[package]]
 name = "fsspec"
 version = "2025.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/27/954057b0d1f53f086f681755207dda6de6c660ce133c829158e8e8fe7895/fsspec-2025.12.0.tar.gz", hash = "sha256:c505de011584597b1060ff778bb664c1bc022e87921b0e4f10cc9c44f9635973", size = 309748, upload-time = "2025-12-03T15:23:42.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl", hash = "sha256:8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b", size = 201422, upload-time = "2025-12-03T15:23:41.434Z" },
@@ -1488,7 +1509,7 @@ wheels = [
 [[package]]
 name = "gitdb"
 version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "smmap" },
 ]
@@ -1500,7 +1521,7 @@ wheels = [
 [[package]]
 name = "gitpython"
 version = "3.1.45"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "gitdb" },
 ]
@@ -1512,13 +1533,13 @@ wheels = [
 [[package]]
 name = "google-api-core"
 version = "2.29.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
     { name = "proto-plus" },
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/10/05572d33273292bac49c2d1785925f7bc3ff2fe50e3044cf1062c1dde32e/google_api_core-2.29.0.tar.gz", hash = "sha256:84181be0f8e6b04006df75ddfe728f24489f0af57c96a529ff7cf45bc28797f7", size = 177828, upload-time = "2026-01-08T22:21:39.269Z" }
@@ -1529,7 +1550,7 @@ wheels = [
 [[package]]
 name = "google-api-python-client"
 version = "2.190.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -1545,7 +1566,7 @@ wheels = [
 [[package]]
 name = "google-auth"
 version = "2.48.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
@@ -1559,7 +1580,7 @@ wheels = [
 [[package]]
 name = "google-auth-httplib2"
 version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "httplib2" },
@@ -1572,7 +1593,7 @@ wheels = [
 [[package]]
 name = "google-auth-oauthlib"
 version = "1.2.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "requests-oauthlib" },
@@ -1585,10 +1606,10 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.72.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
 wheels = [
@@ -1598,7 +1619,7 @@ wheels = [
 [[package]]
 name = "graphene"
 version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "graphql-core" },
     { name = "graphql-relay" },
@@ -1613,7 +1634,7 @@ wheels = [
 [[package]]
 name = "graphql-core"
 version = "3.2.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/9b/037a640a2983b09aed4a823f9cf1729e6d780b0671f854efa4727a7affbe/graphql_core-3.2.7.tar.gz", hash = "sha256:27b6904bdd3b43f2a0556dad5d579bdfdeab1f38e8e8788e555bdcb586a6f62c", size = 513484, upload-time = "2025-11-01T22:30:40.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/14/933037032608787fb92e365883ad6a741c235e0ff992865ec5d904a38f1e/graphql_core-3.2.7-py3-none-any.whl", hash = "sha256:17fc8f3ca4a42913d8e24d9ac9f08deddf0a0b2483076575757f6c412ead2ec0", size = 207262, upload-time = "2025-11-01T22:30:38.912Z" },
@@ -1622,7 +1643,7 @@ wheels = [
 [[package]]
 name = "graphql-relay"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "graphql-core" },
 ]
@@ -1634,7 +1655,7 @@ wheels = [
 [[package]]
 name = "greenlet"
 version = "3.2.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
@@ -1695,7 +1716,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.67.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
@@ -1745,7 +1766,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.76.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
 ]
@@ -1809,15 +1830,15 @@ wheels = [
 [[package]]
 name = "grpcio-status"
 version = "1.62.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 dependencies = [
     { name = "googleapis-common-protos", marker = "python_full_version < '3.12'" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/d7/013ef01c5a1c2fd0932c27c904934162f69f41ca0f28396d3ffe4d386123/grpcio-status-1.62.3.tar.gz", hash = "sha256:289bdd7b2459794a12cf95dc0cb727bd4a1742c37bd823f760236c937e53a485", size = 13063, upload-time = "2024-08-06T00:37:08.003Z" }
 wheels = [
@@ -1827,15 +1848,15 @@ wheels = [
 [[package]]
 name = "grpcio-status"
 version = "1.67.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "googleapis-common-protos", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/c7/fe0e79a80ac6346e0c6c0a24e9e3cbc3ae1c2a009acffb59eab484a6f69b/grpcio_status-1.67.1.tar.gz", hash = "sha256:2bf38395e028ceeecfd8866b081f61628114b384da7d51ae064ddc8d766a5d11", size = 13673, upload-time = "2024-10-29T06:30:21.787Z" }
 wheels = [
@@ -1845,14 +1866,14 @@ wheels = [
 [[package]]
 name = "grpcio-status"
 version = "1.76.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
     { name = "googleapis-common-protos", marker = "python_full_version >= '3.14'" },
-    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/46/e9f19d5be65e8423f886813a2a9d0056ba94757b0c5007aa59aed1a961fa/grpcio_status-1.76.0.tar.gz", hash = "sha256:25fcbfec74c15d1a1cb5da3fab8ee9672852dc16a5a9eeb5baf7d7a9952943cd", size = 13679, upload-time = "2025-10-21T16:28:52.545Z" }
 wheels = [
@@ -1862,7 +1883,7 @@ wheels = [
 [[package]]
 name = "gunicorn"
 version = "23.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -1874,7 +1895,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -1883,7 +1904,7 @@ wheels = [
 [[package]]
 name = "hf-xet"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
@@ -1912,7 +1933,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -1925,7 +1946,7 @@ wheels = [
 [[package]]
 name = "httplib2"
 version = "0.31.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pyparsing" },
 ]
@@ -1937,7 +1958,7 @@ wheels = [
 [[package]]
 name = "httptools"
 version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/e5/c07e0bcf4ec8db8164e9f6738c048b2e66aabf30e7506f440c4cc6953f60/httptools-0.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11d01b0ff1fe02c4c32d60af61a4d613b74fad069e47e06e9067758c01e9ac78", size = 204531, upload-time = "2025-10-10T03:54:20.887Z" },
@@ -1980,7 +2001,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -1995,7 +2016,7 @@ wheels = [
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
@@ -2004,7 +2025,7 @@ wheels = [
 [[package]]
 name = "huey"
 version = "2.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c6/dfe74b0ee9708216ab798449b694d6ba7c1b701bdc2e5d378ec0505ca9a9/huey-2.5.4.tar.gz", hash = "sha256:4b7fb217b640fbb46efc4f4681b446b40726593522f093e8ef27c4a8fcb6cfbb", size = 848666, upload-time = "2025-10-23T13:04:55.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/86/fb8f2ec721106ee9d47adb3a757f937044a52239adb26bae6d9ad753927b/huey-2.5.4-py3-none-any.whl", hash = "sha256:0eac1fb2711f6366a1db003629354a0cea470a3db720d5bab0d140c28e993f9c", size = 76843, upload-time = "2025-10-23T20:58:10.572Z" },
@@ -2013,7 +2034,7 @@ wheels = [
 [[package]]
 name = "huggingface-hub"
 version = "1.2.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
@@ -2034,7 +2055,7 @@ wheels = [
 [[package]]
 name = "id"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "requests" },
 ]
@@ -2046,7 +2067,7 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
@@ -2055,7 +2076,7 @@ wheels = [
 [[package]]
 name = "importlib-metadata"
 version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "zipp" },
 ]
@@ -2067,7 +2088,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -2076,7 +2097,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -2085,7 +2106,7 @@ wheels = [
 [[package]]
 name = "jaraco-classes"
 version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -2097,7 +2118,7 @@ wheels = [
 [[package]]
 name = "jaraco-context"
 version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
@@ -2109,7 +2130,7 @@ wheels = [
 [[package]]
 name = "jaraco-functools"
 version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -2121,7 +2142,7 @@ wheels = [
 [[package]]
 name = "jeepney"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
@@ -2130,7 +2151,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -2142,7 +2163,7 @@ wheels = [
 [[package]]
 name = "jiter"
 version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/45/9d/e0660989c1370e25848bb4c52d061c71837239738ad937e83edca174c273/jiter-0.12.0.tar.gz", hash = "sha256:64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b", size = 168294, upload-time = "2025-11-09T20:49:23.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/91/13cb9505f7be74a933f37da3af22e029f6ba64f5669416cb8b2774bc9682/jiter-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e7acbaba9703d5de82a2c98ae6a0f59ab9770ab5af5fa35e43a303aee962cf65", size = 316652, upload-time = "2025-11-09T20:46:41.021Z" },
@@ -2239,7 +2260,7 @@ wheels = [
 [[package]]
 name = "joblib"
 version = "1.5.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/5d/447af5ea094b9e4c4054f82e223ada074c552335b9b4b2d14bd9b35a67c4/joblib-1.5.2.tar.gz", hash = "sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55", size = 331077, upload-time = "2025-08-27T12:15:46.575Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl", hash = "sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241", size = 308396, upload-time = "2025-08-27T12:15:45.188Z" },
@@ -2248,7 +2269,7 @@ wheels = [
 [[package]]
 name = "jsonpatch"
 version = "1.33"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "jsonpointer" },
 ]
@@ -2260,7 +2281,7 @@ wheels = [
 [[package]]
 name = "jsonpointer"
 version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
@@ -2269,7 +2290,7 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.25.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
@@ -2284,7 +2305,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -2296,7 +2317,7 @@ wheels = [
 [[package]]
 name = "keyring"
 version = "25.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "jaraco-classes" },
@@ -2314,7 +2335,7 @@ wheels = [
 [[package]]
 name = "kiwisolver"
 version = "1.4.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/3c/85844f1b0feb11ee581ac23fe5fce65cd049a200c1446708cc1b7f922875/kiwisolver-1.4.9.tar.gz", hash = "sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d", size = 97564, upload-time = "2025-08-10T21:27:49.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/5d/8ce64e36d4e3aac5ca96996457dcf33e34e6051492399a3f1fec5657f30b/kiwisolver-1.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b4b4d74bda2b8ebf4da5bd42af11d02d04428b2c32846e4c2c93219df8a7987b", size = 124159, upload-time = "2025-08-10T21:25:35.472Z" },
@@ -2422,7 +2443,7 @@ wheels = [
 [[package]]
 name = "langchain"
 version = "1.0.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
@@ -2436,7 +2457,7 @@ wheels = [
 [[package]]
 name = "langchain-classic"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "langchain-core" },
@@ -2455,7 +2476,7 @@ wheels = [
 [[package]]
 name = "langchain-community"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "aiohttp" },
     { name = "dataclasses-json" },
@@ -2463,8 +2484,8 @@ dependencies = [
     { name = "langchain-classic" },
     { name = "langchain-core" },
     { name = "langsmith" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -2479,7 +2500,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -2497,7 +2518,7 @@ wheels = [
 [[package]]
 name = "langchain-text-splitters"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "langchain-core" },
 ]
@@ -2509,7 +2530,7 @@ wheels = [
 [[package]]
 name = "langgraph"
 version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2526,7 +2547,7 @@ wheels = [
 [[package]]
 name = "langgraph-checkpoint"
 version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
@@ -2539,7 +2560,7 @@ wheels = [
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2552,7 +2573,7 @@ wheels = [
 [[package]]
 name = "langgraph-sdk"
 version = "0.2.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson" },
@@ -2565,7 +2586,7 @@ wheels = [
 [[package]]
 name = "langsmith"
 version = "0.4.42"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
@@ -2583,13 +2604,13 @@ wheels = [
 [[package]]
 name = "litellm"
 version = "1.80.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
     { name = "fastuuid" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.14'" },
     { name = "httpx" },
     { name = "importlib-metadata" },
     { name = "jinja2" },
@@ -2608,7 +2629,7 @@ wheels = [
 [[package]]
 name = "lxml"
 version = "6.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/8a/f8192a08237ef2fb1b19733f709db88a4c43bc8ab8357f01cb41a27e7f6a/lxml-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e77dd455b9a16bbd2a5036a63ddbd479c19572af81b624e79ef422f929eef388", size = 8590589, upload-time = "2025-09-22T04:00:10.51Z" },
@@ -2732,7 +2753,7 @@ wheels = [
 [[package]]
 name = "lz4"
 version = "4.4.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/45/2466d73d79e3940cad4b26761f356f19fd33f4409c96f100e01a5c566909/lz4-4.4.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d221fa421b389ab2345640a508db57da36947a437dfe31aeddb8d5c7b646c22d", size = 207396, upload-time = "2025-11-03T13:01:24.965Z" },
@@ -2788,7 +2809,7 @@ wheels = [
 [[package]]
 name = "mako"
 version = "1.3.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -2800,7 +2821,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -2812,7 +2833,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
@@ -2897,7 +2918,7 @@ wheels = [
 [[package]]
 name = "marshmallow"
 version = "3.26.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -2909,15 +2930,15 @@ wheels = [
 [[package]]
 name = "matplotlib"
 version = "3.10.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.11'" },
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -2982,9 +3003,34 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -2993,7 +3039,7 @@ wheels = [
 [[package]]
 name = "mlflow"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "alembic" },
     { name = "cryptography" },
@@ -3006,13 +3052,13 @@ dependencies = [
     { name = "matplotlib" },
     { name = "mlflow-skinny" },
     { name = "mlflow-tracing" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "scikit-learn" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.11'" },
     { name = "sqlalchemy" },
     { name = "waitress", marker = "sys_platform == 'win32'" },
 ]
@@ -3024,7 +3070,7 @@ wheels = [
 [[package]]
 name = "mlflow-skinny"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -3037,8 +3083,8 @@ dependencies = [
     { name = "opentelemetry-proto" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -3055,7 +3101,7 @@ wheels = [
 [[package]]
 name = "mlflow-tracing"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "cachetools" },
     { name = "databricks-sdk" },
@@ -3063,8 +3109,8 @@ dependencies = [
     { name = "opentelemetry-proto" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/4e/a1b2f977a50ed3860e2848548a9173b9018806628d46d5bdafa8b45bc0c7/mlflow_tracing-3.6.0.tar.gz", hash = "sha256:ccff80b3aad6caa18233c98ba69922a91a6f914e0a13d12e1977af7523523d4c", size = 1061879, upload-time = "2025-11-07T18:36:24.818Z" }
@@ -3075,7 +3121,7 @@ wheels = [
 [[package]]
 name = "more-itertools"
 version = "10.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
@@ -3084,7 +3130,7 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -3222,7 +3268,7 @@ wheels = [
 [[package]]
 name = "mypy"
 version = "1.18.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "pathspec" },
@@ -3267,7 +3313,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -3276,7 +3322,7 @@ wheels = [
 [[package]]
 name = "nest-asyncio"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
@@ -3285,7 +3331,7 @@ wheels = [
 [[package]]
 name = "nh3"
 version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/a5/34c26015d3a434409f4d2a1cd8821a06c05238703f49283ffeb937bef093/nh3-0.3.2.tar.gz", hash = "sha256:f394759a06df8b685a4ebfb1874fb67a9cbfd58c64fc5ed587a663c0e63ec376", size = 19288, upload-time = "2025-10-30T11:17:45.948Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/01/a1eda067c0ba823e5e2bb033864ae4854549e49fb6f3407d2da949106bfb/nh3-0.3.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d18957a90806d943d141cc5e4a0fefa1d77cf0d7a156878bf9a66eed52c9cc7d", size = 1419839, upload-time = "2025-10-30T11:17:09.956Z" },
@@ -3318,7 +3364,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "1.26.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -3354,7 +3400,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.3.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -3440,7 +3486,7 @@ wheels = [
 [[package]]
 name = "oauthlib"
 version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
@@ -3449,7 +3495,7 @@ wheels = [
 [[package]]
 name = "openai"
 version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -3468,7 +3514,7 @@ wheels = [
 [[package]]
 name = "openpyxl"
 version = "3.1.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
@@ -3480,7 +3526,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-api"
 version = "1.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
@@ -3493,10 +3539,10 @@ wheels = [
 [[package]]
 name = "opentelemetry-proto"
 version = "1.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/14/f0c4f0f6371b9cb7f9fa9ee8918bfd59ac7040c7791f1e6da32a1839780d/opentelemetry_proto-1.38.0.tar.gz", hash = "sha256:88b161e89d9d372ce723da289b7da74c3a8354a8e5359992be813942969ed468", size = 46152, upload-time = "2025-10-16T08:36:01.612Z" }
 wheels = [
@@ -3506,7 +3552,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "1.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
@@ -3520,7 +3566,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.59b0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
@@ -3533,7 +3579,7 @@ wheels = [
 [[package]]
 name = "orjson"
 version = "3.11.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c6/fe/ed708782d6709cc60eb4c2d8a361a440661f74134675c72990f2c48c785f/orjson-3.11.4.tar.gz", hash = "sha256:39485f4ab4c9b30a3943cfe99e1a213c4776fb69e8abd68f66b83d5a0b0fdc6d", size = 5945188, upload-time = "2025-10-24T15:50:38.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/30/5aed63d5af1c8b02fbd2a8d83e2a6c8455e30504c50dbf08c8b51403d873/orjson-3.11.4-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e3aa2118a3ece0d25489cbe48498de8a5d580e42e8d9979f65bf47900a15aba1", size = 243870, upload-time = "2025-10-24T15:48:28.908Z" },
@@ -3614,7 +3660,7 @@ wheels = [
 [[package]]
 name = "ormsgpack"
 version = "1.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/67/d5ef41c3b4a94400be801984ef7c7fc9623e1a82b643e74eeec367e7462b/ormsgpack-1.12.0.tar.gz", hash = "sha256:94be818fdbb0285945839b88763b269987787cb2f7ef280cad5d6ec815b7e608", size = 49959, upload-time = "2025-11-04T18:30:10.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/0c/8f45fcd22c95190b05d4fba71375d8f783a9e3b0b6aaf476812b693e3868/ormsgpack-1.12.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e08904c232358b94a682ccfbb680bc47d3fd5c424bb7dccb65974dd20c95e8e1", size = 369156, upload-time = "2025-11-04T18:29:17.629Z" },
@@ -3669,7 +3715,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
@@ -3678,10 +3724,10 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -3727,7 +3773,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
@@ -3736,7 +3782,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "12.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/cace85a1b0c9775a9f8f5d5423c8261c858760e2466c79b2dd184638b056/pillow-12.0.0.tar.gz", hash = "sha256:87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353", size = 47008828, upload-time = "2025-10-15T18:24:14.008Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/08/26e68b6b5da219c2a2cb7b563af008b53bb8e6b6fcb3fa40715fcdb2523a/pillow-12.0.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:3adfb466bbc544b926d50fe8f4a4e6abd8c6bffd28a26177594e6e9b2b76572b", size = 5289809, upload-time = "2025-10-15T18:21:27.791Z" },
@@ -3834,7 +3880,7 @@ wheels = [
 [[package]]
 name = "playwright"
 version = "1.56.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
@@ -3853,7 +3899,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -3862,7 +3908,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/0e/934b541323035566a9af292dba85a195f7b78179114f2c6ebb24551118a9/propcache-0.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c2d1fa3201efaf55d730400d945b5b3ab6e672e100ba0f9a409d950ab25d7db", size = 79534, upload-time = "2025-10-08T19:46:02.083Z" },
@@ -3976,10 +4022,10 @@ wheels = [
 [[package]]
 name = "proto-plus"
 version = "1.27.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
-    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "protobuf", version = "5.29.5", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", size = 56929, upload-time = "2026-02-02T17:34:49.035Z" }
 wheels = [
@@ -3989,7 +4035,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "5.29.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
@@ -4007,7 +4053,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "6.33.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.11.*'",
@@ -4027,7 +4073,7 @@ wheels = [
 [[package]]
 name = "psycopg2-binary"
 version = "2.9.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/8767aaa597ba424643dc87348c6f1754dd9f48e80fdc1b9f7ca5c3a7c213/psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c", size = 379620, upload-time = "2025-10-10T11:14:48.041Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/f2/8e377d29c2ecf99f6062d35ea606b036e8800720eccfec5fe3dd672c2b24/psycopg2_binary-2.9.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d6fe6b47d0b42ce1c9f1fa3e35bb365011ca22e39db37074458f27921dca40f2", size = 3756506, upload-time = "2025-10-10T11:10:30.144Z" },
@@ -4090,7 +4136,7 @@ wheels = [
 [[package]]
 name = "py4j"
 version = "0.10.9.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -4103,7 +4149,7 @@ wheels = [
 [[package]]
 name = "py4j"
 version = "0.10.9.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -4117,7 +4163,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "22.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/53/04a7fdc63e6056116c9ddc8b43bc28c12cdd181b85cbeadb79278475f3ae/pyarrow-22.0.0.tar.gz", hash = "sha256:3d600dc583260d845c7d8a6db540339dd883081925da2bd1c5cb808f720b3cd9", size = 1151151, upload-time = "2025-10-24T12:30:00.762Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/9b/cb3f7e0a345353def531ca879053e9ef6b9f38ed91aebcf68b09ba54dec0/pyarrow-22.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:77718810bd3066158db1e95a63c160ad7ce08c6b0710bc656055033e39cdad88", size = 34223968, upload-time = "2025-10-24T10:03:31.21Z" },
@@ -4174,7 +4220,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
@@ -4183,7 +4229,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -4195,7 +4241,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "2.23"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
@@ -4204,7 +4250,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.12.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
@@ -4219,7 +4265,7 @@ wheels = [
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -4337,7 +4383,7 @@ wheels = [
 [[package]]
 name = "pydantic-settings"
 version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -4351,7 +4397,7 @@ wheels = [
 [[package]]
 name = "pyee"
 version = "13.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -4363,7 +4409,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.19.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
@@ -4372,16 +4418,21 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.10.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
 ]
 
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
 [[package]]
 name = "pyparsing"
 version = "3.2.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
@@ -4390,7 +4441,7 @@ wheels = [
 [[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
@@ -4399,7 +4450,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "9.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -4417,7 +4468,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
@@ -4431,7 +4482,7 @@ wheels = [
 [[package]]
 name = "pytest-cov"
 version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
@@ -4445,7 +4496,7 @@ wheels = [
 [[package]]
 name = "pytest-html"
 version = "4.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "jinja2" },
     { name = "pytest" },
@@ -4459,7 +4510,7 @@ wheels = [
 [[package]]
 name = "pytest-metadata"
 version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -4471,7 +4522,7 @@ wheels = [
 [[package]]
 name = "pytest-mock"
 version = "3.15.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -4483,7 +4534,7 @@ wheels = [
 [[package]]
 name = "pytest-xdist"
 version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
@@ -4496,7 +4547,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "six" },
 ]
@@ -4508,7 +4559,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
@@ -4517,7 +4568,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.20"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
@@ -4526,7 +4577,7 @@ wheels = [
 [[package]]
 name = "python-pptx"
 version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "lxml" },
     { name = "pillow" },
@@ -4541,7 +4592,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
@@ -4550,7 +4601,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "311"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
     { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
@@ -4572,7 +4623,7 @@ wheels = [
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
@@ -4581,7 +4632,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
@@ -4645,7 +4696,7 @@ wheels = [
 [[package]]
 name = "readme-renderer"
 version = "44.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "docutils" },
     { name = "nh3" },
@@ -4659,7 +4710,7 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
@@ -4673,7 +4724,7 @@ wheels = [
 [[package]]
 name = "regex"
 version = "2025.11.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/a9/546676f25e573a4cf00fe8e119b78a37b6a8fe2dc95cda877b30889c9c45/regex-2025.11.3.tar.gz", hash = "sha256:1fedc720f9bb2494ce31a58a1631f9c82df6a09b49c19517ea5cc280b4541e01", size = 414669, upload-time = "2025-11-03T21:34:22.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/d6/d788d52da01280a30a3f6268aef2aa71043bff359c618fea4c5b536654d5/regex-2025.11.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2b441a4ae2c8049106e8b39973bfbddfb25a179dda2bdb99b0eeb60c40a6a3af", size = 488087, upload-time = "2025-11-03T21:30:47.317Z" },
@@ -4780,7 +4831,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.32.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -4795,7 +4846,7 @@ wheels = [
 [[package]]
 name = "requests-oauthlib"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
@@ -4808,7 +4859,7 @@ wheels = [
 [[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "requests" },
 ]
@@ -4820,7 +4871,7 @@ wheels = [
 [[package]]
 name = "rfc3986"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
@@ -4829,7 +4880,7 @@ wheels = [
 [[package]]
 name = "rich"
 version = "14.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -4842,7 +4893,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
@@ -4964,7 +5015,7 @@ wheels = [
 [[package]]
 name = "rsa"
 version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -4976,7 +5027,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.14.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/fa/fbb67a5780ae0f704876cb8ac92d6d76da41da4dc72b7ed3565ab18f2f52/ruff-0.14.5.tar.gz", hash = "sha256:8d3b48d7d8aad423d3137af7ab6c8b1e38e4de104800f0d596990f6ada1a9fc1", size = 5615944, upload-time = "2025-11-13T19:58:51.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/31/c07e9c535248d10836a94e4f4e8c5a31a1beed6f169b31405b227872d4f4/ruff-0.14.5-py3-none-linux_armv6l.whl", hash = "sha256:f3b8248123b586de44a8018bcc9fefe31d23dda57a34e6f0e1e53bd51fd63594", size = 13171630, upload-time = "2025-11-13T19:57:54.894Z" },
@@ -5002,13 +5053,13 @@ wheels = [
 [[package]]
 name = "scikit-learn"
 version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "joblib" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.11'" },
     { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
@@ -5048,12 +5099,12 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.15.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -5107,7 +5158,7 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.16.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -5115,8 +5166,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [
@@ -5185,7 +5236,7 @@ wheels = [
 [[package]]
 name = "secretstorage"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "cryptography" },
     { name = "jeepney" },
@@ -5198,7 +5249,7 @@ wheels = [
 [[package]]
 name = "setuptools"
 version = "80.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
@@ -5207,7 +5258,7 @@ wheels = [
 [[package]]
 name = "setuptools-scm"
 version = "9.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "packaging" },
     { name = "setuptools" },
@@ -5221,7 +5272,7 @@ wheels = [
 [[package]]
 name = "shellingham"
 version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
@@ -5230,7 +5281,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -5239,7 +5290,7 @@ wheels = [
 [[package]]
 name = "smmap"
 version = "5.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
@@ -5248,7 +5299,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -5257,7 +5308,7 @@ wheels = [
 [[package]]
 name = "soupsieve"
 version = "2.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
@@ -5266,7 +5317,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy"
 version = "2.0.44"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
@@ -5311,16 +5362,29 @@ wheels = [
 [[package]]
 name = "sqlparse"
 version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.49.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -5331,9 +5395,34 @@ wheels = [
 ]
 
 [[package]]
+name = "svgpathtools"
+version = "1.7.2"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+dependencies = [
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.11'" },
+    { name = "svgwrite" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/a0/06163182bdb00300a23e51b433a6ca5c881761e7dfbef432b4da44e3a84a/svgpathtools-1.7.2.tar.gz", hash = "sha256:5974daba24825e22f284ea10aa980d7d6f77a1ca55d914d80283e3ea8a7ac450", size = 2136092, upload-time = "2025-11-30T19:15:03.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/4b/9128c82796479426fba219a5b0da70bbf8f1f0b571a54cc7a420cea0e9c4/svgpathtools-1.7.2-py2.py3-none-any.whl", hash = "sha256:ecb1885f7c6363be2903f39d8584ed772bd055a2e92044f43d412780b1d4c283", size = 68346, upload-time = "2025-11-30T19:15:02.053Z" },
+]
+
+[[package]]
+name = "svgwrite"
+version = "1.4.3"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/c1/263d4e93b543390d86d8eb4fc23d9ce8a8d6efd146f9427364109004fa9b/svgwrite-1.4.3.zip", hash = "sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3", size = 189516, upload-time = "2022-07-14T14:05:26.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/15/640e399579024a6875918839454025bb1d5f850bb70d96a11eabb644d11c/svgwrite-1.4.3-py3-none-any.whl", hash = "sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d", size = 67122, upload-time = "2022-07-14T14:05:24.459Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
@@ -5342,7 +5431,7 @@ wheels = [
 [[package]]
 name = "tenacity"
 version = "9.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
@@ -5351,7 +5440,7 @@ wheels = [
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
@@ -5360,7 +5449,7 @@ wheels = [
 [[package]]
 name = "thrift"
 version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "six" },
 ]
@@ -5369,7 +5458,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dc
 [[package]]
 name = "tiktoken"
 version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
@@ -5430,7 +5519,7 @@ wheels = [
 [[package]]
 name = "tinycss2"
 version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "webencodings" },
 ]
@@ -5442,7 +5531,7 @@ wheels = [
 [[package]]
 name = "tokenizers"
 version = "0.22.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
@@ -5472,7 +5561,7 @@ wheels = [
 [[package]]
 name = "tomli"
 version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/ed/3f73f72945444548f33eba9a87fc7a6e969915e7b1acc8260b30e1f76a2f/tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549", size = 17392, upload-time = "2025-10-08T22:01:47.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/2e/299f62b401438d5fe1624119c723f5d877acc86a4c2492da405626665f12/tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45", size = 153236, upload-time = "2025-10-08T22:01:00.137Z" },
@@ -5521,7 +5610,7 @@ wheels = [
 [[package]]
 name = "tqdm"
 version = "4.67.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -5533,7 +5622,7 @@ wheels = [
 [[package]]
 name = "twine"
 version = "6.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "id" },
     { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
@@ -5553,7 +5642,7 @@ wheels = [
 [[package]]
 name = "typer-slim"
 version = "0.21.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "click" },
     { name = "typing-extensions" },
@@ -5566,7 +5655,7 @@ wheels = [
 [[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
@@ -5575,7 +5664,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -5584,7 +5673,7 @@ wheels = [
 [[package]]
 name = "typing-inspect"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },
@@ -5597,7 +5686,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -5609,7 +5698,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
@@ -5618,7 +5707,7 @@ wheels = [
 [[package]]
 name = "unitycatalog-ai"
 version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "cloudpickle" },
     { name = "nest-asyncio" },
@@ -5633,8 +5722,8 @@ wheels = [
 
 [package.optional-dependencies]
 databricks = [
-    { name = "databricks-connect", version = "16.1.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "databricks-connect", version = "17.0.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "databricks-connect", version = "16.1.7", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version < '3.12'" },
+    { name = "databricks-connect", version = "17.0.10", source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }, marker = "python_full_version >= '3.12'" },
     { name = "databricks-sdk" },
     { name = "pandas" },
 ]
@@ -5642,7 +5731,7 @@ databricks = [
 [[package]]
 name = "unitycatalog-client"
 version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -5659,7 +5748,7 @@ wheels = [
 [[package]]
 name = "unitycatalog-langchain"
 version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "langchain" },
     { name = "langchain-community" },
@@ -5678,7 +5767,7 @@ databricks = [
 [[package]]
 name = "uritemplate"
 version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
@@ -5687,7 +5776,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
@@ -5696,7 +5785,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
@@ -5721,7 +5810,7 @@ standard = [
 [[package]]
 name = "uvloop"
 version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
@@ -5765,7 +5854,7 @@ wheels = [
 [[package]]
 name = "waitress"
 version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
@@ -5774,7 +5863,7 @@ wheels = [
 [[package]]
 name = "watchfiles"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -5877,7 +5966,7 @@ wheels = [
 [[package]]
 name = "webencodings"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
@@ -5886,7 +5975,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
@@ -5945,7 +6034,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -5957,7 +6046,7 @@ wheels = [
 [[package]]
 name = "xlsxwriter"
 version = "3.2.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
@@ -5966,7 +6055,7 @@ wheels = [
 [[package]]
 name = "xxhash"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/ee/f9f1d656ad168681bb0f6b092372c1e533c4416b8069b1896a175c46e484/xxhash-3.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:87ff03d7e35c61435976554477a7f4cd1704c3596a89a8300d5ce7fc83874a71", size = 32845, upload-time = "2025-10-02T14:33:51.573Z" },
@@ -6084,7 +6173,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.22.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
@@ -6210,7 +6299,7 @@ wheels = [
 [[package]]
 name = "zipp"
 version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
@@ -6219,7 +6308,7 @@ wheels = [
 [[package]]
 name = "zstandard"
 version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/28efd1d371f1acd037ac64ed1c5e2b41514a6cc937dd6ab6a13ab9f0702f/zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd", size = 795256, upload-time = "2025-09-14T22:15:56.415Z" },


### PR DESCRIPTION
## Summary

Exposes tellr's deck-generation capabilities at `/mcp/` over Streamable HTTP so external Databricks Apps and MCP-compatible agents (Claude Code, Cursor, etc.) can programmatically create and refine decks. Four tools: `create_deck`, `get_deck_status`, `edit_deck`, `get_deck`.

## What's in this PR

**Core server** — `src/api/mcp_server.py`, `src/api/mcp_auth.py`, router mount + lifespan wiring in `src/api/main.py`. FastMCP-based, reuses existing `ChatService` / `SessionManager` / `permission_service` / `job_queue` — no parallel pipeline.

**Auth — three priorities.**

1. `x-forwarded-access-token` (user hitting tellr's own `/mcp/` directly).
2. `Authorization: Bearer` (external callers — OAuth U2M tokens from `databricks-cli` profiles).
3. `x-forwarded-email` + `x-forwarded-user` (app-to-app, gated on `TELLR_TRUST_FORWARDED_IDENTITY=true`, set in the production `app.yaml.template`). This priority was added after discovering that the Databricks Apps proxy strips caller-supplied `Authorization` and `x-forwarded-access-token` on app-to-app ingress and substitutes proxy-attested identity headers. Verified end-to-end with a Streamlit test client that creates decks attributed to the signed-in user.

**Reliability** — 10-minute job hard-timeout sweeper in `src/api/services/job_queue.py` so MCP callers get a predictable upper bound on poll duration.

**Domain** — `SlideDeck.to_html_document()` serializer for standalone renderable HTML, with HTML-escaping, CSS sanitisation, and script `src` validation to prevent XSS through MCP consumers.

**Tests** — 16 unit tests for auth (including all three priorities + SP binding), 15 for the tool handlers, 6 end-to-end integration tests hitting the mounted `/mcp/` via FastAPI `TestClient`. Post-deploy smoke script at `scripts/mcp_smoke/mcp_smoke_httpx.py`.

**Docs** — caller-facing reference at `docs/technical/mcp-server.md` and a how-to integration guide at `docs/technical/mcp-integration-guide.md`. The integration guide covers both the in-workspace (app-to-app, forwarded-identity) and external (OAuth U2M) patterns with full Streamlit/Claude Code examples and the gotchas we hit during rollout (PATs rejected by the Apps proxy, FastMCP session timeouts on long polls, relative vs absolute deck URLs).

## Test plan

- [x] `pytest tests/unit/test_mcp_auth.py tests/unit/test_mcp_server.py tests/integration/test_mcp_endpoint.py` — 37 tests pass
- [x] Local Claude Code → tellr (OAuth Bearer path) — creates decks attributed to the user
- [x] Deployed Databricks App → tellr (forwarded-identity path) — 3-slide and 10-slide decks both succeed, attributed correctly
- [x] Polling survives 5+ minute generations (fresh MCP transport session per poll call)
- [ ] CI on this PR
- [ ] Reviewer deploy-test against a fresh workspace

## Notable deviations from the original spec

- **Open verification items #1/#2 resolved** (app-to-app auth). Proxy strips caller-supplied tokens; priority-3 forwarded-identity path added in response. Spec's original `extract-and-forward-as-Bearer` recipe for in-workspace apps was factually wrong and has been replaced in `docs/technical/mcp-server.md` §4.2A with a pointer to the integration guide's verified worked example.
- **`DATABRICKS_APP_URL` not `TELLR_APP_URL`.** The platform auto-injects `DATABRICKS_APP_URL`, so `_public_app_url()` reads that directly instead of requiring manual env-var config on each deployment.

This pull request and its description were written by Isaac.