### PR TITLE
Lakebase branching: staging deploys against ephemeral prod branch

### DIFF
--- a/config/deployment.example.yaml
+++ b/config/deployment.example.yaml
@@ -22,9 +22,14 @@ environments:
 
   staging:
     # Staging deploys against an ephemeral Lakebase branch forked from production
-    # on every `deploy_local.sh create|update --env staging`. The branch is
-    # named after the env (`staging`) and is deleted on `delete --env staging`.
-    # Requires production to be deployed first (uses prod's encryption key).
+    # on every `deploy_local.sh create|update --env staging`. Each deploy creates
+    # a uniquely-named branch `{env}-{unix_timestamp}` (e.g. staging-1777035101)
+    # and relies on Lakebase's 1-day branch TTL for cleanup — `delete --env staging`
+    # removes the app but leaves branches to auto-expire. Requires production to
+    # be deployed first; staging reads prod's encryption key and schema
+    # (app_data_prod) so it's a near-mirror of prod for integration testing.
+    # The staging app will break after ~24h when its branch expires; redeploy
+    # to get a fresh copy.
     app_name: "ai-slide-generator-staging"
     description: "AI Slide Generator - Staging (ephemeral branch of prod)"
     workspace_path: "/Workspace/Shared/apps/staging/ai-slide-generator"

--- a/config/deployment.example.yaml
+++ b/config/deployment.example.yaml
@@ -21,8 +21,12 @@ environments:
       capacity: "CU_1"  # Options: CU_1, CU_2, CU_4, CU_8
 
   staging:
+    # Staging deploys against an ephemeral Lakebase branch forked from production
+    # on every `deploy_local.sh create|update --env staging`. The branch is
+    # named after the env (`staging`) and is deleted on `delete --env staging`.
+    # Requires production to be deployed first (uses prod's encryption key).
     app_name: "ai-slide-generator-staging"
-    description: "AI Slide Generator - Staging Environment"
+    description: "AI Slide Generator - Staging (ephemeral branch of prod)"
     workspace_path: "/Workspace/Shared/apps/staging/ai-slide-generator"
     permissions:
       - group_name: "developers"
@@ -33,12 +37,14 @@ environments:
     env_vars:
       ENVIRONMENT: "staging"
       LOG_LEVEL: "INFO"
-      LAKEBASE_INSTANCE: "ai-slide-generator-staging-db"
-      LAKEBASE_SCHEMA: "app_data"
+      LAKEBASE_INSTANCE: "ai-slide-generator-db"  # must match production
+      # LAKEBASE_SCHEMA is derived from branch_from env — do not set here
     lakebase:
-      database_name: "ai-slide-generator-staging-db"
-      schema: "app_data"
+      # Must match production's database_name (same Lakebase autoscaling project).
+      database_name: "ai-slide-generator-db"
+      branch_from: "production"   # ephemeral branch of production on every deploy
       capacity: "CU_1"  # Options: CU_1, CU_2, CU_4, CU_8
+      # schema omitted — inherited from the branch_from env (production)
 
   production:
     app_name: "ai-slide-generator"

--- a/docs/superpowers/plans/2026-04-24-lakebase-branching-staging.md
+++ b/docs/superpowers/plans/2026-04-24-lakebase-branching-staging.md
@@ -1,0 +1,1904 @@
+# Lakebase branching for staging — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `deploy_local.sh {create|update} --env staging` fork an ephemeral Lakebase branch off production on every deploy, deploy the staging app against that branch with prod's schema + encryption key, and delete the branch on `delete --env staging`. Design doc: `docs/superpowers/specs/2026-04-24-lakebase-branching-staging-design.md`.
+
+**Architecture:** Add a new `lakebase.branch_from` field to `config/deployment.yaml`. Extend `scripts/deploy_local.py` config resolution to inherit the source env's schema + workspace_path when `branch_from` is set. Add branch primitives (`_branch_exists`, `_delete_branch`, `_create_branch_from`, `_recreate_ephemeral_branch`) to `packages/databricks-tellr/databricks_tellr/deploy.py`. Parameterize two existing autoscaling helpers (`_ensure_sp_autoscaling_role`, `_get_or_create_lakebase_autoscaling`) with a `branch_name` kwarg defaulting to `"production"` so prod/dev behaviour is unchanged. Thread branching mode through `create_local` / `update_local` / `delete_local` via a preflight gate.
+
+**Tech Stack:** Python 3.11, `databricks-sdk` (`ws.postgres.create_branch`/`delete_branch`/`get_branch`/`list_endpoints`), `pytest`, `unittest.mock`, `pyyaml`.
+
+---
+
+## File Structure
+
+**New files:**
+- `tests/unit/test_deploy_local_config_branching.py` — tests for config resolution with `branch_from`.
+- `tests/unit/test_deploy_branch_helpers.py` — tests for the 4 new branch helpers in `deploy.py`.
+- `tests/unit/test_deploy_local_preflight.py` — tests for the preflight check function.
+
+**Modified files:**
+- `config/deployment.yaml` — staging entry gets `branch_from: production`, loses `schema`.
+- `scripts/deploy_local.py` — new `_load_branch_source_config`, new `_check_branching_preconditions`, branching mode in `load_deployment_config` / `create_local` / `update_local` / `delete_local`.
+- `packages/databricks-tellr/databricks_tellr/deploy.py` — 4 new branch helpers; add `branch_name` kwarg to `_ensure_sp_autoscaling_role` and `_get_or_create_lakebase_autoscaling`.
+- `tests/unit/test_deploy_autoscaling.py` — update 1-2 existing tests to cover the new `branch_name` kwarg's default (back-compat).
+
+**SDK confirmed** (verified live): `ws.postgres.{create_branch, delete_branch, get_branch, list_branches, list_endpoints}` all exist. `Branch`, `BranchSpec` dataclasses exist. `BranchSpec.source_branch: str` is the field that points at the parent branch path.
+
+---
+
+## Task 1: Config resolution — `_load_branch_source_config` and `branch_from` in `load_deployment_config`
+
+**Files:**
+- Modify: `scripts/deploy_local.py` — function `load_deployment_config`, add helper `_load_branch_source_config`.
+- Create: `tests/unit/test_deploy_local_config_branching.py`
+
+**What this task does:** When `lakebase.branch_from: <name>` is set on an env, staging's resolved config inherits `schema` (read from source env's `lakebase.schema`) and gains two new keys: `branch_from_env` (str) and `branch_from_workspace_path` (str). Non-branching envs keep exact current behaviour.
+
+### Steps
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `tests/unit/test_deploy_local_config_branching.py`:
+
+```python
+"""Tests for branch_from resolution in load_deployment_config."""
+from pathlib import Path
+import pytest
+import yaml
+
+from scripts.deploy_local import load_deployment_config
+
+FIXTURE_YAML = {
+    "environments": {
+        "production": {
+            "app_name": "db-tellr-prod",
+            "description": "prod",
+            "workspace_path": "/Workspace/Users/x/.apps/prod/tellr",
+            "compute_size": "LARGE",
+            "lakebase": {
+                "database_name": "db-tellr",
+                "schema": "app_data_prod",
+                "capacity": "CU_1",
+            },
+        },
+        "staging": {
+            "app_name": "db-tellr-staging",
+            "description": "staging",
+            "workspace_path": "/Workspace/Users/x/.apps/staging/tellr",
+            "compute_size": "MEDIUM",
+            "lakebase": {
+                "database_name": "db-tellr",
+                "branch_from": "production",
+                "capacity": "CU_1",
+            },
+        },
+        "development": {
+            "app_name": "db-tellr-dev",
+            "description": "dev",
+            "workspace_path": "/Workspace/Users/x/.apps/dev/tellr",
+            "compute_size": "MEDIUM",
+            "lakebase": {
+                "database_name": "db-tellr",
+                "schema": "tellr_app_data_dev",
+                "capacity": "CU_1",
+            },
+        },
+    },
+}
+
+
+@pytest.fixture
+def config_path(tmp_path, monkeypatch):
+    """Write FIXTURE_YAML to tmp and point load_deployment_config at it."""
+    cfg = tmp_path / "deployment.yaml"
+    cfg.write_text(yaml.safe_dump(FIXTURE_YAML))
+    # load_deployment_config resolves PROJECT_ROOT / "config" / "deployment.yaml"
+    # Patch PROJECT_ROOT to tmp_path, and put the yaml at tmp_path/config/deployment.yaml
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "deployment.yaml").write_text(yaml.safe_dump(FIXTURE_YAML))
+    monkeypatch.setattr("scripts.deploy_local.PROJECT_ROOT", tmp_path)
+    return tmp_path
+
+
+class TestLoadDeploymentConfig:
+    def test_non_branching_env_unchanged(self, config_path):
+        """production config is unaffected by branch_from logic."""
+        cfg = load_deployment_config("production")
+        assert cfg["schema_name"] == "app_data_prod"
+        assert cfg.get("branch_from_env") is None
+        assert cfg.get("branch_from_workspace_path") is None
+
+    def test_dev_env_unchanged(self, config_path):
+        cfg = load_deployment_config("development")
+        assert cfg["schema_name"] == "tellr_app_data_dev"
+        assert cfg.get("branch_from_env") is None
+
+    def test_staging_inherits_prod_schema(self, config_path):
+        cfg = load_deployment_config("staging")
+        assert cfg["schema_name"] == "app_data_prod"
+        assert cfg["branch_from_env"] == "production"
+        assert cfg["branch_from_workspace_path"] == "/Workspace/Users/x/.apps/prod/tellr"
+        # database_name still staging's own (same value)
+        assert cfg["lakebase_name"] == "db-tellr"
+
+    def test_branch_from_unknown_env_errors(self, config_path, tmp_path, monkeypatch):
+        bad = dict(FIXTURE_YAML)
+        bad["environments"]["staging"]["lakebase"]["branch_from"] = "nonexistent"
+        (tmp_path / "config" / "deployment.yaml").write_text(yaml.safe_dump(bad))
+        with pytest.raises(Exception, match="branch_from.*nonexistent.*not found"):
+            load_deployment_config("staging")
+
+    def test_database_name_mismatch_errors(self, config_path, tmp_path, monkeypatch):
+        bad = yaml.safe_load(yaml.safe_dump(FIXTURE_YAML))
+        bad["environments"]["staging"]["lakebase"]["database_name"] = "other-db"
+        (tmp_path / "config" / "deployment.yaml").write_text(yaml.safe_dump(bad))
+        with pytest.raises(Exception, match="same database_name"):
+            load_deployment_config("staging")
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+```
+pytest tests/unit/test_deploy_local_config_branching.py -v
+```
+
+Expected: ALL tests fail — `KeyError: 'branch_from_env'` or `schema_name` is `None` for staging.
+
+- [ ] **Step 1.3: Implement the resolution logic in `scripts/deploy_local.py`**
+
+Replace the body of `load_deployment_config` (currently lines 50–86) with the logic below. Add the new `_load_branch_source_config` helper immediately above it.
+
+```python
+def _load_branch_source_config(
+    environments: dict, source_env_name: str
+) -> dict:
+    """Return {workspace_path, schema, database_name} from the source env.
+
+    Raises:
+        DeploymentError: if source env is missing.
+    """
+    if source_env_name not in environments:
+        raise DeploymentError(
+            f'branch_from "{source_env_name}" not found in deployment config'
+        )
+    src = environments[source_env_name]
+    src_lb = src.get("lakebase", {})
+    return {
+        "workspace_path": src.get("workspace_path"),
+        "schema": src_lb.get("schema"),
+        "database_name": src_lb.get("database_name"),
+    }
+
+
+def load_deployment_config(env: str) -> dict[str, Any]:
+    """Load deployment configuration for the specified environment.
+
+    Supports `lakebase.branch_from: <env>` — when set, the target env
+    inherits `schema` from the source env and the output dict carries
+    `branch_from_env` + `branch_from_workspace_path` so callers can run the
+    branching flow.
+    """
+    config_path = PROJECT_ROOT / "config" / "deployment.yaml"
+    if not config_path.exists():
+        raise DeploymentError(f"Deployment config not found: {config_path}")
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+
+    environments = config.get("environments", {})
+    if env not in environments:
+        available = ", ".join(environments.keys())
+        raise DeploymentError(
+            f"Environment '{env}' not found in deployment config. "
+            f"Available: {available}"
+        )
+
+    env_config = environments[env]
+    lakebase_config = env_config.get("lakebase", {})
+
+    branch_from = lakebase_config.get("branch_from")
+    schema_name = lakebase_config.get("schema")
+    branch_from_workspace_path = None
+
+    if branch_from:
+        src = _load_branch_source_config(environments, branch_from)
+        if src["database_name"] != lakebase_config.get("database_name"):
+            raise DeploymentError(
+                f"branching requires same database_name; "
+                f'{env}={lakebase_config.get("database_name")}, '
+                f'{branch_from}={src["database_name"]}'
+            )
+        # Inherit schema from source env. If this env also specified a schema
+        # and it differs, raise — avoid silent mismatches.
+        if schema_name and schema_name != src["schema"]:
+            raise DeploymentError(
+                f"branching env '{env}' declared schema '{schema_name}' "
+                f"which differs from source env '{branch_from}' schema "
+                f"'{src['schema']}'. Remove the schema field from '{env}' "
+                f"or change it to match."
+            )
+        schema_name = src["schema"]
+        branch_from_workspace_path = src["workspace_path"]
+
+    return {
+        "app_name": env_config.get("app_name"),
+        "description": env_config.get("description", "AI Slide Generator"),
+        "workspace_path": env_config.get("workspace_path"),
+        "compute_size": env_config.get("compute_size", "MEDIUM"),
+        "lakebase_name": lakebase_config.get("database_name"),
+        "lakebase_capacity": lakebase_config.get("capacity", "CU_1"),
+        "schema_name": schema_name,
+        "branch_from_env": branch_from,
+        "branch_from_workspace_path": branch_from_workspace_path,
+    }
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_local_config_branching.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 1.5: Verify existing tests still pass**
+
+```
+pytest tests/unit/test_deploy_autoscaling.py tests/unit/test_database_autoscaling.py -v
+```
+
+Expected: all pass (no regressions — non-branching envs return same config shape with two extra keys set to `None`).
+
+- [ ] **Step 1.6: Commit**
+
+```
+git add scripts/deploy_local.py tests/unit/test_deploy_local_config_branching.py
+git commit -m "feat(deploy): add branch_from config resolution for Lakebase branching"
+```
+
+---
+
+## Task 2: `_branch_exists` helper
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py` — add new helper.
+- Create: `tests/unit/test_deploy_branch_helpers.py`
+
+**What this task does:** Thin wrapper around `ws.postgres.get_branch` that returns `False` on "not found" and surfaces other errors. Used by preflight + `_recreate_ephemeral_branch`.
+
+### Steps
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Create `tests/unit/test_deploy_branch_helpers.py`:
+
+```python
+"""Tests for Lakebase branch helpers in databricks_tellr.deploy."""
+from unittest.mock import MagicMock, patch
+import pytest
+
+pytest.importorskip("databricks_tellr", reason="databricks-tellr package not installed")
+
+from databricks_tellr.deploy import _branch_exists
+
+
+@pytest.fixture
+def mock_ws():
+    return MagicMock()
+
+
+class TestBranchExists:
+    def test_returns_true_when_branch_exists(self, mock_ws):
+        mock_ws.postgres.get_branch.return_value = MagicMock(name="branch")
+        assert _branch_exists(mock_ws, "db-tellr", "production") is True
+        mock_ws.postgres.get_branch.assert_called_once_with(
+            name="projects/db-tellr/branches/production"
+        )
+
+    def test_returns_false_on_not_found(self, mock_ws):
+        mock_ws.postgres.get_branch.side_effect = Exception("Resource not found")
+        assert _branch_exists(mock_ws, "db-tellr", "staging") is False
+
+    def test_returns_false_on_does_not_exist(self, mock_ws):
+        mock_ws.postgres.get_branch.side_effect = Exception("branch does not exist")
+        assert _branch_exists(mock_ws, "db-tellr", "staging") is False
+
+    def test_surfaces_other_errors(self, mock_ws):
+        mock_ws.postgres.get_branch.side_effect = Exception("permission denied")
+        with pytest.raises(Exception, match="permission denied"):
+            _branch_exists(mock_ws, "db-tellr", "production")
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestBranchExists -v
+```
+
+Expected: `ImportError: cannot import name '_branch_exists'`.
+
+- [ ] **Step 2.3: Implement `_branch_exists`**
+
+In `packages/databricks-tellr/databricks_tellr/deploy.py`, add immediately after `_get_or_create_lakebase` (around line 943):
+
+```python
+def _branch_exists(
+    ws: WorkspaceClient, project_name: str, branch_name: str
+) -> bool:
+    """Return True if the Lakebase branch exists, False on not-found.
+
+    Any error other than not-found is surfaced.
+    """
+    try:
+        ws.postgres.get_branch(
+            name=f"projects/{project_name}/branches/{branch_name}"
+        )
+        return True
+    except Exception as e:
+        error_str = str(e).lower()
+        if "not found" in error_str or "does not exist" in error_str:
+            return False
+        raise
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestBranchExists -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 2.5: Commit**
+
+```
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_branch_helpers.py
+git commit -m "feat(deploy): add _branch_exists helper for Lakebase branches"
+```
+
+---
+
+## Task 3: `_delete_branch` helper
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py`
+- Modify: `tests/unit/test_deploy_branch_helpers.py`
+
+**What this task does:** Idempotent branch delete. Waits on the operation. Swallows "not found" so the command is re-runnable.
+
+### Steps
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Append to `tests/unit/test_deploy_branch_helpers.py`:
+
+```python
+from databricks_tellr.deploy import _delete_branch
+
+
+class TestDeleteBranch:
+    def test_calls_delete_with_correct_path_and_waits(self, mock_ws):
+        operation = MagicMock()
+        mock_ws.postgres.delete_branch.return_value = operation
+
+        _delete_branch(mock_ws, "db-tellr", "staging")
+
+        mock_ws.postgres.delete_branch.assert_called_once_with(
+            name="projects/db-tellr/branches/staging"
+        )
+        operation.wait.assert_called_once()
+
+    def test_noop_on_not_found(self, mock_ws):
+        mock_ws.postgres.delete_branch.side_effect = Exception("Resource not found")
+        # Should not raise
+        _delete_branch(mock_ws, "db-tellr", "staging")
+
+    def test_noop_on_does_not_exist(self, mock_ws):
+        mock_ws.postgres.delete_branch.side_effect = Exception("branch does not exist")
+        _delete_branch(mock_ws, "db-tellr", "staging")
+
+    def test_surfaces_other_errors(self, mock_ws):
+        mock_ws.postgres.delete_branch.side_effect = Exception("permission denied")
+        with pytest.raises(Exception, match="permission denied"):
+            _delete_branch(mock_ws, "db-tellr", "staging")
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestDeleteBranch -v
+```
+
+Expected: `ImportError: cannot import name '_delete_branch'`.
+
+- [ ] **Step 3.3: Implement `_delete_branch`**
+
+Add to `deploy.py` immediately after `_branch_exists`:
+
+```python
+def _delete_branch(
+    ws: WorkspaceClient, project_name: str, branch_name: str
+) -> None:
+    """Delete a Lakebase branch. Idempotent — no-op if the branch is missing.
+
+    Waits on the long-running delete operation. Any error other than
+    not-found is surfaced.
+    """
+    try:
+        operation = ws.postgres.delete_branch(
+            name=f"projects/{project_name}/branches/{branch_name}"
+        )
+        operation.wait()
+        logger.info(f"Deleted Lakebase branch: {branch_name}")
+    except Exception as e:
+        error_str = str(e).lower()
+        if "not found" in error_str or "does not exist" in error_str:
+            logger.info(f"Branch {branch_name} not found (already deleted)")
+            return
+        raise
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestDeleteBranch -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3.5: Commit**
+
+```
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_branch_helpers.py
+git commit -m "feat(deploy): add idempotent _delete_branch helper"
+```
+
+---
+
+## Task 4: `_create_branch_from` helper
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py`
+- Modify: `tests/unit/test_deploy_branch_helpers.py`
+
+**What this task does:** Creates a new branch as a child of `source_branch`. Waits on the operation. Polls `list_endpoints` on the new branch until an endpoint with a populated host appears (up to ~60s). Returns a `lakebase_result`-shaped dict so downstream helpers route connections to this branch.
+
+### Steps
+
+- [ ] **Step 4.1: Write the failing tests**
+
+Append to `tests/unit/test_deploy_branch_helpers.py`:
+
+```python
+from databricks_tellr.deploy import _create_branch_from
+
+
+class TestCreateBranchFrom:
+    def test_creates_branch_with_correct_source(self, mock_ws):
+        # Set up mocks for the create_branch call
+        create_op = MagicMock()
+        mock_ws.postgres.create_branch.return_value = create_op
+
+        # Set up endpoints polling: first call returns empty, then returns one
+        endpoint_ready = MagicMock()
+        endpoint_ready.name = "projects/db-tellr/branches/staging/endpoints/ep1"
+        endpoint_ready.status = MagicMock(
+            hosts=MagicMock(host="staging-ep1.example.com")
+        )
+        # list_endpoints returns an iterator; mock returns ready endpoint
+        mock_ws.postgres.list_endpoints.return_value = iter([endpoint_ready])
+        mock_ws.postgres.get_endpoint.return_value = endpoint_ready
+
+        result = _create_branch_from(
+            mock_ws,
+            project_name="db-tellr",
+            source_branch="production",
+            target_branch="staging",
+        )
+
+        # Verify create_branch call shape
+        call_kwargs = mock_ws.postgres.create_branch.call_args.kwargs
+        assert call_kwargs["parent"] == "projects/db-tellr"
+        assert call_kwargs["branch_id"] == "staging"
+        branch_arg = call_kwargs["branch"]
+        assert branch_arg.spec.source_branch == "projects/db-tellr/branches/production"
+
+        # Verify operation waited
+        create_op.wait.assert_called_once()
+
+        # Verify returned lakebase_result shape
+        assert result["type"] == "autoscaling"
+        assert result["name"] == "db-tellr"
+        assert result["host"] == "staging-ep1.example.com"
+        assert result["endpoint_name"] == "projects/db-tellr/branches/staging/endpoints/ep1"
+        assert result["project_id"] == "db-tellr"
+        assert result["instance_name"] is None
+
+    def test_raises_when_no_endpoint_after_timeout(self, mock_ws, monkeypatch):
+        """If list_endpoints never returns a ready endpoint, raise DeploymentError."""
+        from databricks_tellr.deploy import DeploymentError
+
+        create_op = MagicMock()
+        mock_ws.postgres.create_branch.return_value = create_op
+        # Always empty
+        mock_ws.postgres.list_endpoints.return_value = iter([])
+
+        # Patch sleep so the test doesn't actually wait
+        monkeypatch.setattr("databricks_tellr.deploy.time.sleep", lambda *_: None)
+        # Shrink the timeout for fast test
+        monkeypatch.setattr("databricks_tellr.deploy._BRANCH_ENDPOINT_TIMEOUT_S", 0.1)
+
+        with pytest.raises(DeploymentError, match="no endpoint ready"):
+            _create_branch_from(mock_ws, "db-tellr", "production", "staging")
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestCreateBranchFrom -v
+```
+
+Expected: `ImportError: cannot import name '_create_branch_from'`.
+
+- [ ] **Step 4.3: Implement `_create_branch_from`**
+
+First add `import time` if not already at the top of `deploy.py` (check with `grep -n "^import time" packages/databricks-tellr/databricks_tellr/deploy.py` — add at alphabetical position in the stdlib imports if missing).
+
+Add the module-level constant near the top of the autoscaling section (around line 707, just before `_probe_autoscaling_available`):
+
+```python
+# How long to poll for a new branch's endpoint to come up before giving up.
+_BRANCH_ENDPOINT_TIMEOUT_S = 120
+_BRANCH_ENDPOINT_POLL_INTERVAL_S = 3
+```
+
+Add the helper immediately after `_delete_branch`:
+
+```python
+def _create_branch_from(
+    ws: WorkspaceClient,
+    project_name: str,
+    source_branch: str,
+    target_branch: str,
+) -> dict[str, Any]:
+    """Create a new Lakebase branch as a child of `source_branch`.
+
+    Waits on the create operation, then polls list_endpoints on the new
+    branch until an endpoint with a populated host appears
+    (up to _BRANCH_ENDPOINT_TIMEOUT_S). Raises DeploymentError on timeout.
+
+    Returns a lakebase_result-shaped dict pointing at the new branch.
+    """
+    if not HAS_AUTOSCALING_SDK:
+        raise DeploymentError(
+            "Autoscaling SDK not available — cannot create Lakebase branch. "
+            "Upgrade databricks-sdk."
+        )
+
+    source_path = f"projects/{project_name}/branches/{source_branch}"
+    target_parent = f"projects/{project_name}"
+    target_path = f"projects/{project_name}/branches/{target_branch}"
+
+    logger.info(f"Creating branch {target_branch} from {source_branch}")
+    operation = ws.postgres.create_branch(
+        parent=target_parent,
+        branch=Branch(spec=BranchSpec(source_branch=source_path)),
+        branch_id=target_branch,
+    )
+    operation.wait()
+    logger.info(f"Branch {target_branch} created")
+
+    # Poll for endpoint readiness
+    deadline = time.time() + _BRANCH_ENDPOINT_TIMEOUT_S
+    endpoint = None
+    while time.time() < deadline:
+        endpoints = list(ws.postgres.list_endpoints(parent=target_path))
+        ready = [
+            e for e in endpoints
+            if getattr(e, "status", None)
+            and getattr(e.status, "hosts", None)
+            and getattr(e.status.hosts, "host", None)
+        ]
+        if ready:
+            endpoint = ready[0]
+            break
+        time.sleep(_BRANCH_ENDPOINT_POLL_INTERVAL_S)
+
+    if endpoint is None:
+        raise DeploymentError(
+            f"Branch {target_branch} created but no endpoint ready within "
+            f"{_BRANCH_ENDPOINT_TIMEOUT_S}s"
+        )
+
+    return {
+        "name": project_name,
+        "type": "autoscaling",
+        "status": "created",
+        "host": endpoint.status.hosts.host,
+        "endpoint_name": endpoint.name,
+        "project_id": project_name,
+        "instance_name": None,
+    }
+```
+
+Also add `Branch, BranchSpec` to the autoscaling import block at the top of `deploy.py` (currently line 32–37):
+
+```python
+# Autoscaling imports (Lakebase next-gen)
+try:
+    from databricks.sdk.service.postgres import (
+        Branch,
+        BranchSpec,
+        Project,
+        ProjectDefaultEndpointSettings,
+        ProjectSpec,
+    )
+    HAS_AUTOSCALING_SDK = True
+except ImportError:
+    HAS_AUTOSCALING_SDK = False
+```
+
+- [ ] **Step 4.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestCreateBranchFrom -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 4.5: Commit**
+
+```
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_branch_helpers.py
+git commit -m "feat(deploy): add _create_branch_from helper with endpoint polling"
+```
+
+---
+
+## Task 5: `_recreate_ephemeral_branch` helper
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py`
+- Modify: `tests/unit/test_deploy_branch_helpers.py`
+
+**What this task does:** Composition of `_delete_branch` + `_create_branch_from`. Exists as its own function for call-site readability in `create_local`/`update_local`.
+
+### Steps
+
+- [ ] **Step 5.1: Write the failing tests**
+
+Append to `tests/unit/test_deploy_branch_helpers.py`:
+
+```python
+from databricks_tellr.deploy import _recreate_ephemeral_branch
+
+
+class TestRecreateEphemeralBranch:
+    def test_deletes_then_creates(self, mock_ws, monkeypatch):
+        calls = []
+
+        def fake_delete(ws, project, branch):
+            calls.append(("delete", branch))
+
+        def fake_create(ws, project, source, target):
+            calls.append(("create", source, target))
+            return {"host": "x", "endpoint_name": "e", "type": "autoscaling"}
+
+        monkeypatch.setattr(
+            "databricks_tellr.deploy._delete_branch", fake_delete
+        )
+        monkeypatch.setattr(
+            "databricks_tellr.deploy._create_branch_from", fake_create
+        )
+
+        result = _recreate_ephemeral_branch(
+            mock_ws,
+            project_name="db-tellr",
+            source_branch="production",
+            target_branch="staging",
+        )
+
+        assert calls == [
+            ("delete", "staging"),
+            ("create", "production", "staging"),
+        ]
+        assert result["host"] == "x"
+```
+
+- [ ] **Step 5.2: Run tests to verify they fail**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestRecreateEphemeralBranch -v
+```
+
+Expected: `ImportError: cannot import name '_recreate_ephemeral_branch'`.
+
+- [ ] **Step 5.3: Implement `_recreate_ephemeral_branch`**
+
+In `deploy.py`, add immediately after `_create_branch_from`:
+
+```python
+def _recreate_ephemeral_branch(
+    ws: WorkspaceClient,
+    project_name: str,
+    source_branch: str,
+    target_branch: str,
+) -> dict[str, Any]:
+    """Delete `target_branch` if it exists, then create it from `source_branch`.
+
+    Returns the lakebase_result dict for the newly-created branch.
+    """
+    _delete_branch(ws, project_name, target_branch)
+    return _create_branch_from(ws, project_name, source_branch, target_branch)
+```
+
+- [ ] **Step 5.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py::TestRecreateEphemeralBranch -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 5.5: Run the full branch-helpers test file**
+
+```
+pytest tests/unit/test_deploy_branch_helpers.py -v
+```
+
+Expected: 11 passed (4 + 4 + 2 + 1).
+
+- [ ] **Step 5.6: Commit**
+
+```
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_branch_helpers.py
+git commit -m "feat(deploy): add _recreate_ephemeral_branch composition helper"
+```
+
+---
+
+## Task 6: Parameterize `_ensure_sp_autoscaling_role` with `branch_name`
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py` — function `_ensure_sp_autoscaling_role` (currently at line 777).
+- Modify: `tests/unit/test_deploy_autoscaling.py` — add test covering non-default `branch_name`.
+
+**What this task does:** Replace the hardcoded `branches/production` with a `branch_name` kwarg defaulting to `"production"`. All existing callers keep working; staging flow can pass `branch_name="staging"`.
+
+### Steps
+
+- [ ] **Step 6.1: Write the failing test**
+
+Find the existing `TestEnsureSpAutoscalingRole` (or similar) class in `tests/unit/test_deploy_autoscaling.py` and append this test to it. If no such class exists, add it at the bottom of the file:
+
+```python
+class TestEnsureSpAutoscalingRoleBranchName:
+    """Tests that _ensure_sp_autoscaling_role uses the branch_name kwarg."""
+
+    def test_default_branch_is_production(self, mock_ws):
+        # get_role raises not-found so we go down the create path
+        mock_ws.postgres.get_role.side_effect = Exception("not found")
+        create_op = MagicMock()
+        mock_ws.postgres.create_role.return_value = create_op
+
+        _ensure_sp_autoscaling_role(mock_ws, "db-tellr", "client-123")
+
+        # Inspect parent path used for role creation
+        assert (
+            mock_ws.postgres.create_role.call_args.kwargs["parent"]
+            == "projects/db-tellr/branches/production"
+        )
+
+    def test_custom_branch_name_threads_through(self, mock_ws):
+        mock_ws.postgres.get_role.side_effect = Exception("not found")
+        create_op = MagicMock()
+        mock_ws.postgres.create_role.return_value = create_op
+
+        _ensure_sp_autoscaling_role(
+            mock_ws, "db-tellr", "client-123", branch_name="staging"
+        )
+
+        assert (
+            mock_ws.postgres.create_role.call_args.kwargs["parent"]
+            == "projects/db-tellr/branches/staging"
+        )
+```
+
+- [ ] **Step 6.2: Run the tests to verify failure**
+
+```
+pytest tests/unit/test_deploy_autoscaling.py::TestEnsureSpAutoscalingRoleBranchName -v
+```
+
+Expected: `test_custom_branch_name_threads_through` fails because the `branch_name` kwarg doesn't exist yet (TypeError: unexpected keyword argument). `test_default_branch_is_production` may pass today because the hardcoded `"production"` happens to match.
+
+- [ ] **Step 6.3: Modify `_ensure_sp_autoscaling_role` in `deploy.py`**
+
+Change the signature (line 777) from:
+
+```python
+def _ensure_sp_autoscaling_role(
+    ws: WorkspaceClient, project_name: str, client_id: str
+) -> None:
+```
+
+to:
+
+```python
+def _ensure_sp_autoscaling_role(
+    ws: WorkspaceClient,
+    project_name: str,
+    client_id: str,
+    branch_name: str = "production",
+) -> None:
+```
+
+Replace the hardcoded branch_path (line 803):
+
+```python
+branch_path = f"projects/{project_name}/branches/production"
+```
+
+with:
+
+```python
+branch_path = f"projects/{project_name}/branches/{branch_name}"
+```
+
+Update the docstring at the top of the function to mention the new parameter (one line is fine).
+
+- [ ] **Step 6.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_autoscaling.py -v
+```
+
+Expected: all existing tests still pass + 2 new tests pass.
+
+- [ ] **Step 6.5: Commit**
+
+```
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_autoscaling.py
+git commit -m "refactor(deploy): parameterize _ensure_sp_autoscaling_role with branch_name"
+```
+
+---
+
+## Task 7: Parameterize `_get_or_create_lakebase_autoscaling` with `branch_name`
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py` — function `_get_or_create_lakebase_autoscaling` (currently at line 720).
+- Modify: `tests/unit/test_deploy_autoscaling.py` — add test covering non-default `branch_name`.
+
+**What this task does:** Allow the caller to fetch the endpoint info from a non-production branch. Used by the staging flow to grab connection info for the staging branch.
+
+### Steps
+
+- [ ] **Step 7.1: Write the failing test**
+
+Append to `tests/unit/test_deploy_autoscaling.py`:
+
+```python
+class TestGetOrCreateLakebaseAutoscalingBranchName:
+    def test_default_branch_is_production(self, mock_ws):
+        # Mock get_project so we skip the create path
+        mock_ws.postgres.get_project.return_value = MagicMock()
+        endpoint = MagicMock()
+        endpoint.name = "projects/db-tellr/branches/production/endpoints/ep1"
+        endpoint.status = MagicMock(hosts=MagicMock(host="prod-host"))
+        mock_ws.postgres.list_endpoints.return_value = iter([endpoint])
+        mock_ws.postgres.get_endpoint.return_value = endpoint
+
+        _get_or_create_lakebase_autoscaling(mock_ws, "db-tellr", "CU_1")
+
+        mock_ws.postgres.list_endpoints.assert_called_once_with(
+            parent="projects/db-tellr/branches/production"
+        )
+
+    def test_custom_branch_name(self, mock_ws):
+        mock_ws.postgres.get_project.return_value = MagicMock()
+        endpoint = MagicMock()
+        endpoint.name = "projects/db-tellr/branches/staging/endpoints/ep1"
+        endpoint.status = MagicMock(hosts=MagicMock(host="staging-host"))
+        mock_ws.postgres.list_endpoints.return_value = iter([endpoint])
+        mock_ws.postgres.get_endpoint.return_value = endpoint
+
+        result = _get_or_create_lakebase_autoscaling(
+            mock_ws, "db-tellr", "CU_1", branch_name="staging"
+        )
+
+        mock_ws.postgres.list_endpoints.assert_called_once_with(
+            parent="projects/db-tellr/branches/staging"
+        )
+        assert result["host"] == "staging-host"
+```
+
+- [ ] **Step 7.2: Run tests to verify failure**
+
+```
+pytest tests/unit/test_deploy_autoscaling.py::TestGetOrCreateLakebaseAutoscalingBranchName -v
+```
+
+Expected: `test_custom_branch_name` fails with TypeError (unexpected kwarg).
+
+- [ ] **Step 7.3: Modify `_get_or_create_lakebase_autoscaling` in `deploy.py`**
+
+Change the signature (line 720) from:
+
+```python
+def _get_or_create_lakebase_autoscaling(
+    ws: WorkspaceClient, database_name: str, capacity: str
+) -> dict[str, Any]:
+```
+
+to:
+
+```python
+def _get_or_create_lakebase_autoscaling(
+    ws: WorkspaceClient,
+    database_name: str,
+    capacity: str,
+    branch_name: str = "production",
+) -> dict[str, Any]:
+```
+
+Replace the hardcoded endpoint parent (line 755):
+
+```python
+endpoints = list(ws.postgres.list_endpoints(
+    parent=f"projects/{database_name}/branches/production"
+))
+```
+
+with:
+
+```python
+endpoints = list(ws.postgres.list_endpoints(
+    parent=f"projects/{database_name}/branches/{branch_name}"
+))
+```
+
+Also update the error message at line 758 to include the branch:
+
+```python
+raise DeploymentError(
+    f"No endpoints found for autoscaling project {database_name} "
+    f"on branch {branch_name}"
+)
+```
+
+- [ ] **Step 7.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_autoscaling.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 7.5: Commit**
+
+```
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_autoscaling.py
+git commit -m "refactor(deploy): parameterize _get_or_create_lakebase_autoscaling with branch_name"
+```
+
+---
+
+## Task 8: Preflight `_check_branching_preconditions` in `deploy_local.py`
+
+**Files:**
+- Modify: `scripts/deploy_local.py` — new helper `_check_branching_preconditions`.
+- Create: `tests/unit/test_deploy_local_preflight.py`
+
+**What this task does:** Runs all 6 preconditions from the spec §Error handling table. Returns the source app's encryption key (so callers don't re-download). Raises `DeploymentError` with actionable messages. Must be invoked before any mutating Lakebase call.
+
+### Steps
+
+- [ ] **Step 8.1: Write the failing tests**
+
+Create `tests/unit/test_deploy_local_preflight.py`:
+
+```python
+"""Tests for branching-mode preflight checks."""
+from unittest.mock import MagicMock, patch
+import pytest
+
+pytest.importorskip("databricks_tellr", reason="databricks-tellr package not installed")
+
+from databricks_tellr.deploy import DeploymentError
+
+
+@pytest.fixture
+def mock_ws():
+    return MagicMock()
+
+
+@pytest.fixture
+def good_config():
+    return {
+        "lakebase_name": "db-tellr",
+        "branch_from_env": "production",
+        "branch_from_workspace_path": "/Workspace/Users/x/.apps/prod/tellr",
+    }
+
+
+class TestCheckBranchingPreconditions:
+    def test_happy_path_returns_encryption_key(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        # Patch all the Workspace/SDK calls
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="prod-key-123",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available", return_value=True
+        ):
+            mock_ws.postgres.get_project.return_value = MagicMock()
+            with patch(
+                "scripts.deploy_local._branch_exists", return_value=True
+            ):
+                key = _check_branching_preconditions(mock_ws, good_config)
+        assert key == "prod-key-123"
+
+    def test_missing_prod_app_yaml(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value=None,
+        ):
+            with pytest.raises(
+                DeploymentError, match="production not deployed"
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_provisioned_lakebase_errors(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="k",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available",
+            return_value=False,
+        ):
+            with pytest.raises(
+                DeploymentError, match="requires autoscaling"
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_project_missing(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="k",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available",
+            return_value=True,
+        ):
+            mock_ws.postgres.get_project.side_effect = Exception("not found")
+            with pytest.raises(
+                DeploymentError, match="not an autoscaling project"
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_source_branch_missing(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="k",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available",
+            return_value=True,
+        ), patch(
+            "scripts.deploy_local._branch_exists", return_value=False
+        ):
+            mock_ws.postgres.get_project.return_value = MagicMock()
+            with pytest.raises(
+                DeploymentError, match='source branch "production" not found'
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_preflight_does_not_mutate_on_any_failure(self, mock_ws, good_config):
+        """Confirm no mutating ws.postgres call is made when preflight fails."""
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value=None,
+        ):
+            with pytest.raises(DeploymentError):
+                _check_branching_preconditions(mock_ws, good_config)
+
+        mock_ws.postgres.create_branch.assert_not_called()
+        mock_ws.postgres.delete_branch.assert_not_called()
+        mock_ws.postgres.create_role.assert_not_called()
+```
+
+- [ ] **Step 8.2: Run tests to verify failure**
+
+```
+pytest tests/unit/test_deploy_local_preflight.py -v
+```
+
+Expected: `ImportError: cannot import name '_check_branching_preconditions'`.
+
+- [ ] **Step 8.3: Implement `_check_branching_preconditions` in `scripts/deploy_local.py`**
+
+First, add these imports at the top of `deploy_local.py` alongside the existing `from databricks_tellr.deploy import ...`:
+
+```python
+from databricks_tellr.deploy import (
+    DeploymentError,
+    _branch_exists,
+    _get_workspace_client,
+    _get_or_create_lakebase,
+    _probe_autoscaling_available,
+    _read_existing_encryption_key,
+    _recreate_ephemeral_branch,
+    _write_requirements,
+    _write_app_yaml,
+    _upload_files,
+    _create_app,
+    _deploy_app,
+    _setup_database_schema,
+    _reset_schema,
+    _get_app_client_id,
+    _ensure_sp_autoscaling_role,
+    delete,
+)
+```
+
+(Adds: `_branch_exists`, `_probe_autoscaling_available`, `_recreate_ephemeral_branch`.)
+
+Add the new function immediately above `create_local`:
+
+```python
+def _check_branching_preconditions(
+    ws: WorkspaceClient, config: dict[str, Any]
+) -> str:
+    """Run preconditions for branching-mode deploy. Return prod's encryption key.
+
+    Raises DeploymentError if any precondition fails, BEFORE any mutating
+    ws.postgres call.
+    """
+    branch_from_env = config["branch_from_env"]
+    branch_from_workspace_path = config["branch_from_workspace_path"]
+    project_name = config["lakebase_name"]
+
+    # 1+2 handled by load_deployment_config. By the time we get here,
+    # branch_from_env is already resolved and database_name matches.
+
+    # 3 + 4: source app.yaml exists and has a key
+    encryption_key = _read_existing_encryption_key(ws, branch_from_workspace_path)
+    if not encryption_key:
+        raise DeploymentError(
+            f"{branch_from_env} not deployed — deploy {branch_from_env} first "
+            f"(could not read GOOGLE_OAUTH_ENCRYPTION_KEY from "
+            f"{branch_from_workspace_path}/app.yaml)"
+        )
+
+    # 5: Lakebase is autoscaling
+    if not _probe_autoscaling_available(ws):
+        raise DeploymentError(
+            f"Lakebase branching requires autoscaling; "
+            f"{project_name} is not an autoscaling project"
+        )
+    try:
+        ws.postgres.get_project(name=f"projects/{project_name}")
+    except Exception as e:
+        raise DeploymentError(
+            f"Lakebase branching requires autoscaling; "
+            f"{project_name} is not an autoscaling project (get_project failed: {e})"
+        ) from e
+
+    # 6: source branch exists
+    if not _branch_exists(ws, project_name, branch_from_env):
+        raise DeploymentError(
+            f'source branch "{branch_from_env}" not found in project {project_name}'
+        )
+
+    return encryption_key
+```
+
+- [ ] **Step 8.4: Run tests to verify they pass**
+
+```
+pytest tests/unit/test_deploy_local_preflight.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 8.5: Commit**
+
+```
+git add scripts/deploy_local.py tests/unit/test_deploy_local_preflight.py
+git commit -m "feat(deploy): add branching-mode preflight check with all six preconditions"
+```
+
+---
+
+## Task 9: Wire branching mode into `create_local`
+
+**Files:**
+- Modify: `scripts/deploy_local.py` — function `create_local`.
+
+**What this task does:** When `config["branch_from_env"]` is set, run preflight, recreate the ephemeral branch, and pass the branch-pointing `lakebase_result` through the rest of the flow. Use prod's encryption key (already returned by preflight). When `branch_from_env` is not set, behaviour is unchanged.
+
+Tests: we don't unit-test `create_local` end-to-end (too many moving parts); we verify the piece we changed — the branching switch — via the preflight tests and integration tests documented in Task 14.
+
+### Steps
+
+- [ ] **Step 9.1: Modify `create_local` in `scripts/deploy_local.py`**
+
+Replace the current body of `create_local` (currently lines 163–288) with the branching-aware version below. The diff is additive at the top (preflight + branch creation) and a small change in the lakebase-acquisition path.
+
+```python
+def create_local(
+    env: str,
+    profile: str,
+    seed_databricks_defaults: bool = True,
+) -> dict[str, Any]:
+    """Create a new Databricks App using locally-built wheels."""
+    config = load_deployment_config(env)
+    ws = _get_workspace_client(profile=profile)
+
+    app_name = config["app_name"]
+    workspace_path = config["workspace_path"]
+    lakebase_name = config["lakebase_name"]
+    schema_name = config["schema_name"]
+    branch_from_env = config.get("branch_from_env")
+
+    print("Deploying AI Slide Generator (local wheels)...")
+    print(f"   App name: {app_name}")
+    print(f"   Workspace path: {workspace_path}")
+    print(f"   Lakebase: {lakebase_name}")
+    print(f"   Schema: {schema_name}")
+    if branch_from_env:
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{env}')")
+    print()
+
+    try:
+        # Find and upload wheel
+        print("Finding built wheel...")
+        wheel_path = find_app_wheel()
+        print(f"   Found: {wheel_path.name}")
+
+        print("Uploading wheel to workspace...")
+        local_wheel_ref = upload_wheel(ws, wheel_path, workspace_path)
+        print(f"   Uploaded: {local_wheel_ref}")
+        print()
+
+        # Branching mode: preflight + recreate branch
+        encryption_key = None
+        if branch_from_env:
+            print("Running branching preflight checks...")
+            encryption_key = _check_branching_preconditions(ws, config)
+            print(f"   Preflight OK (source: {branch_from_env})")
+
+            print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, env
+            )
+            print(
+                f"   Branch '{env}' ready "
+                f"(endpoint: {lakebase_result['host']})"
+            )
+        else:
+            # Standard path: get/create project + read production endpoint
+            print("Setting up Lakebase database...")
+            lakebase_result = _get_or_create_lakebase(
+                ws, lakebase_name, config["lakebase_capacity"]
+            )
+
+        lakebase_type = lakebase_result.get("type", "provisioned")
+        print(f"   Lakebase: {lakebase_result['name']} ({lakebase_result['status']})")
+        print(f"   Type: {lakebase_type}")
+        print()
+
+        # Generate and upload deployment files
+        print("Preparing deployment files...")
+        staging_dir = Path(tempfile.mkdtemp(prefix="tellr_local_staging_"))
+        try:
+            _write_requirements(staging_dir, None, local_wheel_path=local_wheel_ref)
+            print("   Generated requirements.txt (local wheel)")
+
+            _write_app_yaml(
+                staging_dir,
+                lakebase_name,
+                schema_name,
+                seed_databricks_defaults=seed_databricks_defaults,
+                encryption_key=encryption_key,  # None → _write_app_yaml generates one
+                lakebase_result=lakebase_result,
+            )
+            print("   Generated app.yaml")
+
+            print(f"Uploading to: {workspace_path}")
+            _upload_files(ws, staging_dir, workspace_path)
+            print("   Files uploaded")
+        finally:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        print()
+
+        # Create app
+        print(f"Creating Databricks App: {app_name}")
+        app = _create_app(
+            ws,
+            app_name=app_name,
+            description=config["description"],
+            workspace_path=workspace_path,
+            compute_size=config["compute_size"],
+            lakebase_name=lakebase_name,
+            lakebase_type=lakebase_type,
+        )
+        print("   App registered")
+        print()
+
+        # Register SP role on the target branch (staging branch or production branch)
+        if lakebase_type == "autoscaling":
+            client_id = _get_app_client_id(app)
+            if client_id:
+                print("Configuring SP role on autoscaling project...")
+                sp_branch = env if branch_from_env else "production"
+                _ensure_sp_autoscaling_role(
+                    ws, lakebase_name, client_id, branch_name=sp_branch
+                )
+            else:
+                print("   Warning: Could not get SP client ID — role setup skipped")
+
+        # Set up database schema
+        print("Setting up database schema...")
+        _setup_database_schema(
+            ws, app, lakebase_name, schema_name,
+            lakebase_result=lakebase_result,
+        )
+        print(f"   Schema '{schema_name}' configured")
+        print()
+
+        # Deploy the app
+        print("Deploying app...")
+        app = _deploy_app(ws, app_name, workspace_path)
+        print("   App deployed")
+        if app.url:
+            print(f"   URL: {app.url}")
+        print()
+
+        print("Deployment complete!")
+        return {
+            "url": app.url,
+            "app_name": app_name,
+            "lakebase_name": lakebase_name,
+            "schema_name": schema_name,
+            "wheel": wheel_path.name,
+            "branch": env if branch_from_env else None,
+            "status": "created",
+        }
+
+    except Exception as e:
+        raise DeploymentError(f"Deployment failed: {e}") from e
+```
+
+- [ ] **Step 9.2: Run all unit tests for regressions**
+
+```
+pytest tests/unit/ -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 9.3: Commit**
+
+```
+git add scripts/deploy_local.py
+git commit -m "feat(deploy): wire branching mode into create_local"
+```
+
+---
+
+## Task 10: Wire branching mode into `update_local`
+
+**Files:**
+- Modify: `scripts/deploy_local.py` — function `update_local`.
+
+**What this task does:** On every `update --env staging`, preflight + recreate the branch + re-register the SP role on the new branch. For non-branching envs, behaviour is unchanged (continue reading the existing encryption key from the app's own workspace path).
+
+### Steps
+
+- [ ] **Step 10.1: Modify `update_local` in `scripts/deploy_local.py`**
+
+Replace the current `update_local` (currently lines 291–395) with:
+
+```python
+def update_local(
+    env: str,
+    profile: str,
+    reset_database: bool = False,
+    seed_databricks_defaults: bool = True,
+) -> dict[str, Any]:
+    """Update an existing Databricks App using locally-built wheels."""
+    config = load_deployment_config(env)
+    ws = _get_workspace_client(profile=profile)
+
+    app_name = config["app_name"]
+    workspace_path = config["workspace_path"]
+    lakebase_name = config["lakebase_name"]
+    schema_name = config["schema_name"]
+    branch_from_env = config.get("branch_from_env")
+
+    if branch_from_env and reset_database:
+        print(
+            "WARNING: --reset-db is a no-op for branching envs "
+            "(each deploy is already a fresh branch). Ignoring."
+        )
+        reset_database = False
+
+    print(f"Updating AI Slide Generator (local wheels): {app_name}")
+    if branch_from_env:
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{env}')")
+    print()
+
+    try:
+        # Branching mode: preflight + recreate branch
+        if branch_from_env:
+            print("Running branching preflight checks...")
+            encryption_key = _check_branching_preconditions(ws, config)
+            print(f"   Preflight OK (source: {branch_from_env})")
+
+            print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, env
+            )
+            print(
+                f"   Branch '{env}' ready "
+                f"(endpoint: {lakebase_result['host']})"
+            )
+
+            # Register SP role on the new staging branch
+            app = ws.apps.get(name=app_name)
+            client_id = _get_app_client_id(app)
+            if client_id:
+                print("Configuring SP role on new branch...")
+                _ensure_sp_autoscaling_role(
+                    ws, lakebase_name, client_id, branch_name=env
+                )
+
+            # Grant schema perms on the new branch
+            print("Granting schema permissions on new branch...")
+            _setup_database_schema(
+                ws, app, lakebase_name, schema_name,
+                lakebase_result=lakebase_result,
+            )
+            print(f"   Schema '{schema_name}' permissions configured")
+        else:
+            # Standard path (prod/dev): get current Lakebase state
+            print("Checking Lakebase database...")
+            lakebase_result = _get_or_create_lakebase(
+                ws, lakebase_name, config["lakebase_capacity"]
+            )
+            encryption_key = _read_existing_encryption_key(ws, workspace_path)
+
+        lakebase_type = lakebase_result.get("type", "provisioned")
+        print(f"   Lakebase: {lakebase_result['name']} (type={lakebase_type})")
+        print()
+
+        # Reset database if requested (non-branching only; warning already printed)
+        if reset_database:
+            print("Resetting database schema...")
+            app = ws.apps.get(name=app_name)
+            _reset_schema(
+                ws, app, lakebase_name, schema_name,
+                lakebase_result=lakebase_result,
+            )
+            print(f"   Schema '{schema_name}' reset")
+            print()
+
+        # Find and upload wheel
+        print("Finding built wheel...")
+        wheel_path = find_app_wheel()
+        print(f"   Found: {wheel_path.name}")
+
+        print("Uploading wheel to workspace...")
+        local_wheel_ref = upload_wheel(ws, wheel_path, workspace_path)
+        print(f"   Uploaded: {local_wheel_ref}")
+        print()
+
+        # Generate and upload deployment files
+        print("Preparing deployment files...")
+        staging_dir = Path(tempfile.mkdtemp(prefix="tellr_local_staging_"))
+        try:
+            _write_requirements(staging_dir, None, local_wheel_path=local_wheel_ref)
+            print("   Generated requirements.txt (local wheel)")
+
+            _write_app_yaml(
+                staging_dir,
+                lakebase_name,
+                schema_name,
+                seed_databricks_defaults=seed_databricks_defaults,
+                encryption_key=encryption_key,
+                lakebase_result=lakebase_result,
+            )
+            print("   Generated app.yaml")
+
+            _upload_files(ws, staging_dir, workspace_path)
+            print("   Files updated")
+        finally:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+
+        # Deploy new version
+        print("   Deploying...")
+        deployment = AppDeployment(source_code_path=workspace_path)
+        result = ws.apps.deploy_and_wait(app_name=app_name, app_deployment=deployment)
+        print(f"   Deployment completed: {result.deployment_id}")
+
+        app = ws.apps.get(name=app_name)
+        if app.url:
+            print(f"   URL: {app.url}")
+
+        return {
+            "url": app.url,
+            "app_name": app_name,
+            "deployment_id": result.deployment_id,
+            "wheel": wheel_path.name,
+            "status": "updated",
+            "branch": env if branch_from_env else None,
+            "database_reset": reset_database,
+        }
+
+    except Exception as e:
+        raise DeploymentError(f"Update failed: {e}") from e
+```
+
+- [ ] **Step 10.2: Run all unit tests**
+
+```
+pytest tests/unit/ -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 10.3: Commit**
+
+```
+git add scripts/deploy_local.py
+git commit -m "feat(deploy): wire branching mode into update_local with per-deploy branch reset"
+```
+
+---
+
+## Task 11: Wire branching mode into `delete_local`
+
+**Files:**
+- Modify: `scripts/deploy_local.py` — function `delete_local`.
+
+**What this task does:** After the existing `delete()` call removes the app, also delete the staging branch. Idempotent. Non-branching envs unchanged.
+
+### Steps
+
+- [ ] **Step 11.1: Modify `delete_local`**
+
+Replace current `delete_local` (lines 398–417) with:
+
+```python
+def delete_local(env: str, profile: str, reset_database: bool = False) -> dict[str, Any]:
+    """Delete a Databricks App (and its ephemeral branch, if branching)."""
+    config = load_deployment_config(env)
+    branch_from_env = config.get("branch_from_env")
+
+    result = delete(
+        app_name=config["app_name"],
+        lakebase_name=config["lakebase_name"],
+        schema_name=config["schema_name"],
+        reset_database=reset_database,
+        profile=profile,
+    )
+
+    if branch_from_env:
+        ws = _get_workspace_client(profile=profile)
+        print(f"Deleting ephemeral branch '{env}'...")
+        _delete_branch(ws, config["lakebase_name"], env)
+        print(f"   Branch '{env}' deleted")
+        result["branch_deleted"] = env
+
+    return result
+```
+
+Also add `_delete_branch` to the import list at the top of `scripts/deploy_local.py`:
+
+```python
+from databricks_tellr.deploy import (
+    ...
+    _delete_branch,
+    ...
+)
+```
+
+- [ ] **Step 11.2: Run all unit tests**
+
+```
+pytest tests/unit/ -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 11.3: Commit**
+
+```
+git add scripts/deploy_local.py
+git commit -m "feat(deploy): delete ephemeral branch on delete_local when branching"
+```
+
+---
+
+## Task 12: `--reset-db` no-op warning sanity test
+
+**Files:**
+- Modify: `tests/unit/test_deploy_local_config_branching.py` — add a small unit test for the warning behaviour (by checking `update_local` path is reachable, or test the warning message via stdout capture).
+
+**What this task does:** The warning logic already landed in Task 10. This task verifies the observable behaviour with a small test. Skippable if you've manually verified — flagged because silent "ignore a flag" behaviour is the kind of thing that surprises users later.
+
+### Steps
+
+- [ ] **Step 12.1: Write the test**
+
+Append to `tests/unit/test_deploy_local_config_branching.py`:
+
+```python
+class TestResetDbNoopWarning:
+    def test_reset_db_warning_printed_for_branching_env(
+        self, config_path, capsys, monkeypatch
+    ):
+        """update_local with a branching env + reset_database prints a warning and ignores the flag."""
+        from scripts import deploy_local
+
+        # Patch every side-effecting call in update_local down to the warning print
+        monkeypatch.setattr(
+            deploy_local, "_get_workspace_client", lambda profile=None: MagicMock()
+        )
+        # Make preflight fail loudly with a recognisable error — we just want to
+        # get past the warning print, not execute the rest of the flow.
+        def boom(*a, **kw):
+            raise deploy_local.DeploymentError("STOP")
+        monkeypatch.setattr(deploy_local, "_check_branching_preconditions", boom)
+
+        with pytest.raises(deploy_local.DeploymentError, match="STOP"):
+            deploy_local.update_local(
+                env="staging", profile="p", reset_database=True
+            )
+
+        captured = capsys.readouterr()
+        assert "--reset-db is a no-op for branching envs" in captured.out
+```
+
+(Add `from unittest.mock import MagicMock` at the top of the file if not already imported.)
+
+- [ ] **Step 12.2: Run the test**
+
+```
+pytest tests/unit/test_deploy_local_config_branching.py::TestResetDbNoopWarning -v
+```
+
+Expected: passes (warning behaviour is already implemented in Task 10).
+
+- [ ] **Step 12.3: Commit**
+
+```
+git add tests/unit/test_deploy_local_config_branching.py
+git commit -m "test(deploy): verify --reset-db prints warning for branching envs"
+```
+
+---
+
+## Task 13: Update `config/deployment.yaml`
+
+**Files:**
+- Modify: `config/deployment.yaml` — staging entry.
+
+**What this task does:** Switches staging to branching mode. No tests (config file).
+
+### Steps
+
+- [ ] **Step 13.1: Edit `config/deployment.yaml`**
+
+Replace the current `staging:` block (lines 5–21) with:
+
+```yaml
+  staging:
+    app_name: "db-tellr-staging"
+    description: "AI Slide Generator - Staging (ephemeral branch of prod)"
+    workspace_path: "/Workspace/Users/robert.whiffin@databricks.com/.apps/staging/tellr"
+    permissions:
+      - user_name: "robert.whiffin@databricks.com"
+        permission_level: "CAN_MANAGE"
+    compute_size: "MEDIUM"  # Options: MEDIUM, LARGE, LIQUID
+    env_vars:
+      ENVIRONMENT: "staging"
+      LOG_LEVEL: "DEBUG"
+      LAKEBASE_INSTANCE: "db-tellr"
+      # LAKEBASE_SCHEMA derived from branch_from env — not set here
+    lakebase:
+      database_name: "db-tellr"
+      branch_from: "production"   # ephemeral branch of production on every deploy
+      capacity: "CU_1"
+      # schema omitted — inherited from production env
+```
+
+- [ ] **Step 13.2: Sanity-check load_deployment_config against the real file**
+
+```
+python -c "from scripts.deploy_local import load_deployment_config; import json; print(json.dumps(load_deployment_config('staging'), indent=2))"
+```
+
+Expected output contains:
+```
+"schema_name": "app_data_prod",
+"branch_from_env": "production",
+"branch_from_workspace_path": "/Workspace/Users/robert.whiffin@databricks.com/.apps/prod/tellr"
+```
+
+And:
+```
+python -c "from scripts.deploy_local import load_deployment_config; import json; print(json.dumps(load_deployment_config('development'), indent=2))"
+```
+
+Expected: `"schema_name": "tellr_app_data_dev"`, `"branch_from_env": null`.
+
+- [ ] **Step 13.3: Commit**
+
+```
+git add config/deployment.yaml
+git commit -m "feat(config): switch staging env to Lakebase branch_from production"
+```
+
+---
+
+## Task 14: Manual integration test — verify against real workspace
+
+**Files:** none modified. Records evidence in the PR body / commit message.
+
+**What this task does:** Execute the integration checklist from the spec (§Testing → Integration) against the real Databricks workspace. Unit tests don't cover the SDK contract for Lakebase branch creation — only a live deploy does.
+
+### Steps
+
+- [ ] **Step 14.1: Run baseline — dev untouched**
+
+```
+./scripts/deploy_local.sh update --env development --profile <profile>
+```
+
+Expected: deploys successfully. Confirms non-branching path is unaffected.
+
+- [ ] **Step 14.2: Staging first deploy**
+
+If a staging app already exists with the old schema config, delete it first:
+
+```
+./scripts/deploy_local.sh delete --env staging --profile <profile>
+```
+
+Then create fresh:
+
+```
+./scripts/deploy_local.sh create --env staging --profile <profile>
+```
+
+Verify:
+- In the Databricks UI → Lakebase → `db-tellr` → branches, you see `staging` as a child of `production`.
+- In the Databricks UI → Workspace → `/Workspace/Users/.../.apps/staging/tellr/app.yaml`, `LAKEBASE_SCHEMA=app_data_prod`, `GOOGLE_OAUTH_ENCRYPTION_KEY=` matches prod's value, and `LAKEBASE_PG_HOST` is the staging branch's host (differs from prod's host).
+- Log in to the staging app URL. You see your own prod sessions / slide decks.
+- If you had a Google OAuth credential configured in prod, it still works in staging (encryption key matches).
+
+- [ ] **Step 14.3: Staging update — confirms branch is recreated**
+
+Record the current `branches/staging` `create_time` via the Lakebase UI, then:
+
+```
+./scripts/deploy_local.sh update --env staging --profile <profile>
+```
+
+Verify:
+- `branches/staging` now has a newer `create_time`.
+- Any test data you wrote in Step 14.2 is gone (you see a fresh copy of current prod).
+
+- [ ] **Step 14.4: `--reset-db` warning**
+
+```
+./scripts/deploy_local.sh update --env staging --profile <profile> --reset-db
+```
+
+Verify: stdout contains `WARNING: --reset-db is a no-op for branching envs`. Deploy still succeeds.
+
+- [ ] **Step 14.5: Staging delete — confirms branch cleanup**
+
+```
+./scripts/deploy_local.sh delete --env staging --profile <profile>
+```
+
+Verify:
+- Staging app is gone.
+- `branches/staging` is gone from the Lakebase UI.
+- `branches/production` is untouched.
+
+- [ ] **Step 14.6: Precondition failure — prod not deployed**
+
+Temporarily rename the prod app.yaml (via the Databricks UI or API) to simulate "prod not deployed":
+
+```
+# (UI: rename /Workspace/.../.apps/prod/tellr/app.yaml to app.yaml.bak)
+./scripts/deploy_local.sh update --env staging --profile <profile>
+```
+
+Expected: fails at preflight with `production not deployed — deploy production first`. Run `ws.postgres` audit log or observe that no `branches/staging` was created during the failed run.
+
+Restore the renamed file.
+
+- [ ] **Step 14.7: Production untouched sanity check**
+
+Throughout 14.2–14.6, confirm the production app URL keeps returning 200 and continues to serve real users. No unexpected deploys were triggered against `db-tellr-prod`.
+
+- [ ] **Step 14.8: Commit evidence to PR body**
+
+Paste a compact summary of the results from steps 14.1–14.7 into the PR body when opening the branch for review. No code changes.
+
+---
+
+## Post-implementation: open PR
+
+- [ ] **Final step: open PR with evidence**
+
+```
+git push -u origin <branch-name>
+gh pr create --title "Lakebase branching: staging deploys against ephemeral prod branch" --body "$(cat <<'EOF'
+## Summary
+- Adds `lakebase.branch_from` field to `config/deployment.yaml`; staging now uses `branch_from: production`.
+- On every `deploy_local.sh create|update --env staging`, recreates an ephemeral Lakebase branch `staging` forked from `branches/production`. Staging app reads schema `app_data_prod` with prod's encryption key.
+- On `delete --env staging`, also deletes the branch. `--reset-db` on branching envs is a no-op with a warning.
+- Prod/dev deploys unchanged.
+
+Design: `docs/superpowers/specs/2026-04-24-lakebase-branching-staging-design.md`
+Plan:   `docs/superpowers/plans/2026-04-24-lakebase-branching-staging.md`
+
+## Test plan
+- [x] Unit tests: config resolution (5), branch helpers (11), preflight (6), warning (1).
+- [x] Regression: `test_deploy_autoscaling.py` passes with the new `branch_name` kwargs.
+- [x] Integration checklist §Task 14: steps 14.1–14.7 executed against workspace <profile>. Evidence: <paste per-step notes>.
+
+This pull request and its description were written by Isaac.
+EOF
+)"
+```
+
+---
+
+## Self-review (performed after plan was written)
+
+**Spec coverage:**
+- §Configuration → Task 1 (resolution) + Task 13 (yaml change). ✓
+- §Deployment flow (create) → Task 9. ✓
+- §Deployment flow (update) → Task 10. ✓
+- §Deployment flow (delete) → Task 11. ✓
+- §Deployment flow (--reset-db warning) → Task 10 (impl) + Task 12 (test). ✓
+- §Code changes (modified helpers) → Tasks 6, 7. ✓
+- §Code changes (new helpers in deploy.py) → Tasks 2, 3, 4, 5. ✓
+- §Code changes (new helper in deploy_local.py: `_load_branch_source_config`) → Task 1. ✓
+- §Code changes (modified flow fns) → Tasks 1, 9, 10, 11. ✓
+- §Error handling preconditions (6) → Task 8 tests cover all 6. ✓
+- §Error handling runtime failures → covered by existing SDK operation.wait() semantics; idempotent delete in Task 3; timeout in Task 4.
+- §Testing unit tests → Tasks 1, 2-5, 8, 12. ✓
+- §Testing regression → Task 7.5 + runs in Tasks 9.2, 10.2, 11.2. ✓
+- §Testing integration → Task 14. ✓
+
+**Type consistency check:**
+- `_branch_exists` returns `bool` — consumers (Task 8 preflight) use it as bool. ✓
+- `_create_branch_from` returns lakebase_result-shaped dict — consumers (`_recreate_ephemeral_branch`, `create_local`/`update_local`) pass it to `_write_app_yaml`/`_setup_database_schema` which already accept that shape. ✓
+- `_recreate_ephemeral_branch` kwargs: `ws, project_name, source_branch, target_branch`. Callers in Tasks 9 & 10 use those exact names. ✓
+- `_ensure_sp_autoscaling_role` new kwarg `branch_name` — used in Tasks 9 & 10. ✓
+- `_get_or_create_lakebase_autoscaling` new kwarg `branch_name` — unused by this feature (branching flow goes through `_create_branch_from` instead), but added for parity so future work can fetch endpoint info for arbitrary branches without another modification.
+- `_check_branching_preconditions` returns `str` (the encryption key). Callers in Tasks 9 & 10 bind its return value as `encryption_key`. ✓
+
+**No placeholders:** scanned — every step has concrete code and commands.
+
+**Scope:** single feature, one PR, ~14 tasks, ~65 steps. Right size.

--- a/docs/superpowers/specs/2026-04-24-lakebase-branching-staging-design.md
+++ b/docs/superpowers/specs/2026-04-24-lakebase-branching-staging-design.md
@@ -1,0 +1,287 @@
+# Staging deploys against an ephemeral branch of production Lakebase
+
+**Status:** Approved design (2026-04-24)
+**Author:** robert.whiffin@databricks.com
+
+## Problem
+
+Today, `deploy_local.sh update --env staging` deploys the staging app against a
+sibling schema (`app_data_staging`) on the same Lakebase instance as production.
+That schema has its own, diverging data set. It does not exercise the code path
+against prod-shaped data, so staging deploys can pass while a prod deploy of
+the same build fails against prod's actual schema and data.
+
+We want staging to be a one-shot integration test *against prod's current
+database state* before every prod push.
+
+## Solution
+
+Staging deploys target an **ephemeral copy-on-write branch** of the production
+Lakebase project. On every `deploy_local.sh create|update --env staging`:
+
+1. If `branches/staging` exists on the prod Lakebase project, delete it.
+2. Create a fresh `branches/staging` forked from `branches/production`.
+3. Point the staging app at the new branch via `LAKEBASE_PG_HOST` /
+   `LAKEBASE_ENDPOINT_NAME` / `LAKEBASE_SCHEMA`.
+4. Deploy. First startup runs migrations against a byte-identical copy of prod.
+
+On `deploy_local.sh delete --env staging`, the app and the branch are both
+removed.
+
+This gives a full mirror: staging reads schema `app_data_prod` on the branch
+and uses prod's `GOOGLE_OAUTH_ENCRYPTION_KEY`, so encrypted fields (notably
+Google OAuth credentials) decrypt. Staging ≈ prod for testing purposes.
+
+## Decisions
+
+| # | Decision | Chosen | Why |
+|---|----------|--------|-----|
+| 1 | Branch lifecycle | Ephemeral per-deploy | Long-lived branches diverge from prod and eventually mask real breakage. |
+| 2 | Data + encryption | Full mirror (same key, same schema) | Staging's job is "does this work against prod" — rotating secrets defeats the point and makes OAuth credentials un-decryptable. |
+| 3 | Branch naming | Fixed name `staging`, recreate on every deploy | Keeps Lakebase console tidy; matches ephemeral lifecycle. |
+| 4 | Scope | Staging only (for now) | Dev stays cheap / empty. Dev engineers wanting prod-data tests deploy to staging. |
+| 5 | Implementation shape | Config-driven via `branch_from` field in `deployment.yaml` | Avoids magic strings; generalizes cleanly if we later opt another env into branching. |
+
+## Configuration
+
+`config/deployment.yaml` — staging entry loses `schema` and gains
+`branch_from`:
+
+```yaml
+staging:
+  app_name: "db-tellr-staging"
+  description: "AI Slide Generator - Staging (prod branch)"
+  workspace_path: "/Workspace/Users/robert.whiffin@databricks.com/.apps/staging/tellr"
+  permissions:
+    - user_name: "robert.whiffin@databricks.com"
+      permission_level: "CAN_MANAGE"
+  compute_size: "MEDIUM"
+  env_vars:
+    ENVIRONMENT: "staging"
+    LOG_LEVEL: "DEBUG"
+    LAKEBASE_INSTANCE: "db-tellr"
+    # LAKEBASE_SCHEMA derived from branch_from env — not set here
+  lakebase:
+    database_name: "db-tellr"
+    branch_from: "production"       # NEW: name of env to branch from
+    capacity: "CU_1"
+    # schema removed — inherited from branch_from env
+```
+
+Dev and prod entries are unchanged. `app.yaml.template` is unchanged — the
+template already takes `LAKEBASE_PG_HOST` / `LAKEBASE_ENDPOINT_NAME` /
+`LAKEBASE_SCHEMA` / `GOOGLE_OAUTH_ENCRYPTION_KEY` as substitutions.
+
+**Target branch naming convention:** for any env in branching mode, the target
+branch is named after the env itself. Staging → `branches/staging`. If a future
+env `preview` also sets `branch_from: production`, it would target
+`branches/preview`. There is no per-env override of the target branch name;
+keeping the env name and the branch name aligned removes a dimension of config
+drift.
+
+**Legacy `app_data_staging` schema:** the existing `app_data_staging` schema on
+the production Lakebase instance becomes orphaned after this change — nothing
+will write to it. Leave it alone. Dropping it is out of scope (it's harmless,
+and a manual `DROP SCHEMA` remains an option later if storage cost ever
+matters).
+
+## Deployment flow
+
+### `deploy_local.sh create|update --env staging`
+
+1. Load config. If `lakebase.branch_from` is set, enter branching mode.
+   Otherwise, behave as today.
+2. **Preflight** (branching mode only; fail loud, stop):
+   1. `branch_from` resolves to an env that exists in `deployment.yaml`.
+   2. Source and target share the same `lakebase.database_name`.
+   3. Source app is deployed — `ws.workspace.download(<source>/app.yaml)`
+      succeeds.
+   4. Source app.yaml contains `GOOGLE_OAUTH_ENCRYPTION_KEY`.
+   5. Lakebase is autoscaling — `_probe_autoscaling_available(ws)` AND
+      `ws.postgres.get_project(name="projects/<db>")` succeed.
+   6. Source branch exists — `ws.postgres.get_branch(...)` succeeds for
+      `projects/<db>/branches/<branch_from>`.
+3. **Recreate ephemeral branch.** Delete `projects/<db>/branches/staging` if
+   present, then `ws.postgres.create_branch(parent=...)` with
+   `spec.parent_branch="projects/<db>/branches/production"`. Wait for the
+   operation. Poll `list_endpoints(parent=branches/staging)` for a ready
+   endpoint; capture `endpoint_name` and `host`.
+4. Build a `lakebase_result` dict with the **staging branch's** host/endpoint,
+   the same shape `_get_or_create_lakebase_autoscaling()` returns today. Every
+   existing helper that accepts `lakebase_result` then routes to the staging
+   branch automatically.
+5. **Create the app** (only on `create`; `update` skips this). Same call as
+   today — no `AppResourceDatabase` because autoscaling.
+6. **Register the staging app's SP on the staging branch** via
+   `_ensure_sp_autoscaling_role(ws, project_name, client_id, branch_name="staging")`.
+   (The currently-hardcoded `branches/production` path is parameterised.)
+7. **Setup schema = grant-only.** The branch already carries `app_data_prod`
+   and its tables. `_setup_database_schema()` runs unchanged —
+   `CREATE SCHEMA IF NOT EXISTS` is a no-op, then `_grant_schema_permissions()`
+   gives the staging SP access.
+8. **Generate app.yaml** with the staging branch's `host`/`endpoint_name`,
+   prod's schema (`app_data_prod`), and prod's encryption key (read from
+   `<branch_from>/app.yaml` via `_read_existing_encryption_key`).
+9. **Deploy.** First startup runs `init_database()` — migrations are
+   idempotent on existing columns; new columns get added. That is the test.
+
+### `deploy_local.sh delete --env staging`
+
+1. Delete the app (as today via `databricks_tellr.deploy.delete`).
+2. Delete `projects/<db>/branches/staging`. Silently swallow "not found" so the
+   command is re-runnable.
+
+### `--reset-db` on a branching env
+
+Prints `WARNING: --reset-db is a no-op for branching envs (each deploy is
+already a fresh branch)` and skips `_reset_schema`. No behavioural difference —
+the branch about to be destroyed on the next deploy would have been reset
+anyway.
+
+## Code changes
+
+### Modified helpers (backward-compatible)
+
+- `_ensure_sp_autoscaling_role(ws, project_name, client_id, branch_name: str = "production")`
+  — thread `branch_name` through instead of hardcoding it in the function body.
+- `_get_or_create_lakebase_autoscaling(ws, database_name, capacity, branch_name: str = "production")`
+  — optional `branch_name` so staging can fetch endpoint info from
+  `branches/staging`. Creation path unchanged (create_project still only
+  creates the project; the `production` branch is auto-created).
+
+Both defaults remain `"production"` so existing callers keep working.
+
+### New helpers in `packages/databricks-tellr/databricks_tellr/deploy.py`
+
+- `_branch_exists(ws, project_name, branch_name) -> bool` — wraps
+  `ws.postgres.get_branch`, returns False on "not found".
+- `_create_branch_from(ws, project_name, source_branch, target_branch) -> dict`
+  — calls `ws.postgres.create_branch` with parent set to the source branch,
+  waits for the operation, then polls `list_endpoints` for a ready endpoint.
+  Returns a `lakebase_result`-shaped dict pointing at the new branch.
+- `_delete_branch(ws, project_name, branch_name) -> None` — idempotent; no-op
+  on "not found".
+- `_recreate_ephemeral_branch(ws, project_name, source_branch, target_branch) -> dict`
+  — composition of delete + create. Single call site; exists for
+  `create_local`/`update_local` readability.
+
+### New helper in `scripts/deploy_local.py`
+
+- `_load_branch_source_config(all_environments, branch_from_env_name) -> dict`
+  — returns `{workspace_path, schema, database_name}` from the source env.
+  Caller validates `database_name` matches staging's.
+
+### Modified flow functions
+
+- `load_deployment_config(env)` (scripts/deploy_local.py) — if
+  `lakebase.branch_from` is set, derive schema from source env and add two new
+  output keys: `branch_from_env` and `branch_from_workspace_path`.
+- `create_local`, `update_local` — if `branch_from` set, run preflight then the
+  branch recreation before app creation; read encryption key from
+  `branch_from_workspace_path`; pass `lakebase_result` pointing at the staging
+  branch.
+- `delete_local` — if `branch_from` set, delete the branch after deleting the
+  app.
+
+### Unchanged helpers that Just Work
+
+- `_get_lakebase_connection` — reads host/endpoint from `lakebase_result`.
+- `_setup_database_schema`, `_reset_schema`, `_grant_schema_permissions` —
+  operate on whatever connection `_get_lakebase_connection` returns.
+- `_write_app_yaml` — already templates
+  `LAKEBASE_PG_HOST` / `LAKEBASE_ENDPOINT_NAME` / `LAKEBASE_SCHEMA` from the
+  `lakebase_result` dict.
+- `_read_existing_encryption_key` — already takes an arbitrary
+  `workspace_path`. Called against `branch_from_workspace_path` for staging.
+
+## Error handling
+
+All preflight failures raise `DeploymentError` with an actionable message and
+happen **before** any mutating call. A bad staging deploy never half-creates a
+branch, half-deploys an app, or leaves orphaned resources.
+
+| Failure | Message |
+|---------|---------|
+| `branch_from` unset in referenced env | `branch_from "production" not found in deployment config` |
+| Different `database_name` between source and target | `branching requires same database_name; staging=<x>, production=<y>` |
+| Source not deployed | `production not deployed — deploy production first` |
+| Key missing from source app.yaml | `GOOGLE_OAUTH_ENCRYPTION_KEY missing from production app.yaml` |
+| Lakebase is provisioned, not autoscaling | `Lakebase branching requires autoscaling; <db> is not an autoscaling project` |
+| Source branch missing | `source branch "production" not found in project <db>` |
+
+### Runtime failures during branch ops
+
+- **Delete-old-branch, "not found"** → treat as success.
+- **Delete-old-branch, "active connections"** → retry once after 5 s, then
+  surface. The previous staging app's connections should drain when
+  `ws.apps.get_or_deploy` cycles compute; if this keeps biting in practice,
+  add an explicit "stop app" step before branch delete.
+- **Create-branch operation times out** → surface with the operation ID.
+- **SP role creation fails** → surface (same failure mode as today's prod
+  path).
+
+### Orphan risk
+
+If branch creation succeeds but `_create_app` fails, we have a fresh branch
+with no app attached. Acceptable — next staging deploy deletes it and
+recreates. Self-healing. No rollback machinery.
+
+## Testing
+
+### Unit tests (new)
+
+- `tests/unit/test_load_deployment_config_branching.py`
+  - `branch_from` unset → behaviour unchanged from today.
+  - `branch_from: production` → resolved config has prod's schema and both
+    new keys populated.
+  - `branch_from` points at missing env → `DeploymentError`.
+  - `database_name` mismatch → `DeploymentError`.
+- `tests/unit/test_branch_helpers.py` (with `ws` mocked)
+  - `_branch_exists`: False on "not found", True on success, surfaces other
+    errors.
+  - `_delete_branch`: idempotent on "not found".
+  - `_create_branch_from`: correct `parent_branch` in spec, polls endpoints.
+  - `_recreate_ephemeral_branch`: delete-then-create order.
+- `tests/unit/test_deploy_local_preflight.py`
+  - Each of the 6 preconditions fails with the expected message.
+  - On preflight failure, no mutating `ws.postgres` call is made.
+
+### Regression
+
+- `tests/unit/test_database_autoscaling.py` — re-run to confirm the modified
+  signatures with default args still match every existing call site.
+
+### Integration (manual)
+
+Documented here; not automated. Hits a real Databricks workspace.
+
+1. **Baseline:** `deploy_local.sh update --env development --profile <p>`
+   succeeds. (Non-branching path untouched.)
+2. **Staging create:** `deploy_local.sh create --env staging --profile <p>`.
+   Verify in the Lakebase UI that `projects/db-tellr/branches/staging` exists
+   as a child of `branches/production`. Verify the deployed staging `app.yaml`
+   has prod's encryption key and `LAKEBASE_SCHEMA=app_data_prod`. Log in to
+   the staging app and confirm a copy of your own prod sessions/decks is
+   visible and a decrypted Google OAuth credential works.
+3. **Staging update:** `deploy_local.sh update --env staging --profile <p>`.
+   Confirm `branches/staging` has a newer creation timestamp. Any data you
+   wrote in step 2 is gone.
+4. **Staging delete:** `deploy_local.sh delete --env staging --profile <p>`.
+   Confirm both the app and `branches/staging` are gone. `branches/production`
+   untouched.
+5. **Production untouched:** during 2–4, prod app continues serving with no
+   extra deploys triggered.
+6. **Precondition failures:** temporarily rename the prod workspace_path and
+   run `update --env staging` → should fail at preflight with
+   `production not deployed — deploy production first`, and no `ws.postgres`
+   mutation has been attempted.
+
+## Out of scope
+
+- Branch-per-PR / branch-per-git-branch. Could be added later by giving
+  `branch_from` a templating syntax (e.g., `staging-${GIT_SHA}`) without
+  changing the rest of the flow.
+- Dev env branching. Staging-only for now.
+- Automating the integration test above in CI.
+- Stopping an in-flight staging app before branch delete (only needed if the
+  "active connections" failure mode becomes routine).

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -942,6 +942,25 @@ def _get_or_create_lakebase(
     return result
 
 
+def _branch_exists(
+    ws: WorkspaceClient, project_name: str, branch_name: str
+) -> bool:
+    """Return True if the Lakebase branch exists, False on not-found.
+
+    Any error other than not-found is surfaced.
+    """
+    try:
+        ws.postgres.get_branch(
+            name=f"projects/{project_name}/branches/{branch_name}"
+        )
+        return True
+    except Exception as e:
+        error_str = str(e).lower()
+        if "not found" in error_str or "does not exist" in error_str:
+            return False
+        raise
+
+
 def _write_requirements(
     staging_dir: Path,
     app_version: Optional[str],

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -35,6 +35,7 @@ try:
     from databricks.sdk.service.postgres import (
         Branch,
         BranchSpec,
+        Duration,
         Project,
         ProjectDefaultEndpointSettings,
         ProjectSpec,
@@ -1003,19 +1004,39 @@ def _delete_branch(
         raise
 
 
+# Lakebase branch TTL: 1 day. Branches auto-expire and are garbage-collected
+# after this window. The deploy flow relies on this for cleanup — we never
+# explicitly delete old branches, because Lakebase's delete is async and its
+# purge window is unpredictable (fixed-name reuse hits "branch id already
+# exists" for many minutes after delete). Unique-per-deploy IDs + TTL sidesteps
+# the whole issue.
+_BRANCH_TTL_SECONDS = 86400
+
+
 def _create_branch_from(
     ws: WorkspaceClient,
     project_name: str,
     source_branch: str,
-    target_branch: str,
+    target_branch_prefix: str,
 ) -> dict[str, Any]:
     """Create a new Lakebase branch as a child of `source_branch`.
 
-    Waits on the create operation, then polls list_endpoints on the new
-    branch until an endpoint with a populated host appears
-    (up to _BRANCH_ENDPOINT_TIMEOUT_S). Raises DeploymentError on timeout.
+    The branch ID is `{target_branch_prefix}-{unix_timestamp}` so that every
+    deploy gets a fresh unique ID. This avoids the "branch id already exists"
+    collision we hit when trying to reuse a fixed ID right after a delete —
+    Lakebase's delete is async and its purge window is unpredictable.
 
-    Returns a lakebase_result-shaped dict pointing at the new branch.
+    Branch is created with a 1-day TTL so Lakebase garbage-collects it for us.
+    The staging app the branch backs will break after ~1 day; re-deploy to get
+    a fresh branch. This trade is intentional: no cleanup code, no stale state.
+
+    Waits on the create operation, then polls list_endpoints on the new branch
+    until an endpoint with a populated host appears (up to
+    _BRANCH_ENDPOINT_TIMEOUT_S). Raises DeploymentError on timeout.
+
+    Returns a lakebase_result-shaped dict pointing at the new branch, with an
+    added `branch_id` field so callers can reference the unique name (e.g.,
+    for SP role registration).
     """
     if not HAS_AUTOSCALING_SDK:
         raise DeploymentError(
@@ -1023,18 +1044,24 @@ def _create_branch_from(
             "Upgrade databricks-sdk."
         )
 
+    branch_id = f"{target_branch_prefix}-{int(time.time())}"
     source_path = f"projects/{project_name}/branches/{source_branch}"
     target_parent = f"projects/{project_name}"
-    target_path = f"projects/{project_name}/branches/{target_branch}"
+    target_path = f"projects/{project_name}/branches/{branch_id}"
 
-    logger.info(f"Creating branch {target_branch} from {source_branch}")
+    logger.info(f"Creating branch {branch_id} from {source_branch}")
     operation = ws.postgres.create_branch(
         parent=target_parent,
-        branch=Branch(spec=BranchSpec(source_branch=source_path, no_expiry=True)),
-        branch_id=target_branch,
+        branch=Branch(
+            spec=BranchSpec(
+                source_branch=source_path,
+                ttl=Duration(seconds=_BRANCH_TTL_SECONDS),
+            )
+        ),
+        branch_id=branch_id,
     )
     operation.wait()
-    logger.info(f"Branch {target_branch} created")
+    logger.info(f"Branch {branch_id} created")
 
     # Poll for endpoint readiness
     deadline = time.time() + _BRANCH_ENDPOINT_TIMEOUT_S
@@ -1054,7 +1081,7 @@ def _create_branch_from(
 
     if endpoint is None:
         raise DeploymentError(
-            f"Branch {target_branch} created but no endpoint ready within "
+            f"Branch {branch_id} created but no endpoint ready within "
             f"{_BRANCH_ENDPOINT_TIMEOUT_S}s"
         )
 
@@ -1066,6 +1093,7 @@ def _create_branch_from(
         "endpoint_name": endpoint.name,
         "project_id": project_name,
         "instance_name": None,
+        "branch_id": branch_id,
     }
 
 
@@ -1073,14 +1101,17 @@ def _recreate_ephemeral_branch(
     ws: WorkspaceClient,
     project_name: str,
     source_branch: str,
-    target_branch: str,
+    target_branch_prefix: str,
 ) -> dict[str, Any]:
-    """Delete `target_branch` if it exists, then create it from `source_branch`.
+    """Create a fresh ephemeral Lakebase branch for this deploy.
 
-    Returns the lakebase_result dict for the newly-created branch.
+    Thin wrapper around _create_branch_from for call-site readability. Does
+    NOT delete any prior branch — we rely on Lakebase's TTL-driven garbage
+    collection (see _BRANCH_TTL_SECONDS) to clean up old branches, because
+    explicit delete has an async purge window that causes fixed-ID reuse to
+    collide for many minutes.
     """
-    _delete_branch(ws, project_name, target_branch)
-    return _create_branch_from(ws, project_name, source_branch, target_branch)
+    return _create_branch_from(ws, project_name, source_branch, target_branch_prefix)
 
 
 def _write_requirements(

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import time
 import uuid
 from contextlib import contextmanager
 from importlib import metadata, resources
@@ -31,7 +32,13 @@ from databricks.sdk.service.workspace import ImportFormat
 
 # Autoscaling imports (Lakebase next-gen)
 try:
-    from databricks.sdk.service.postgres import Project, ProjectDefaultEndpointSettings, ProjectSpec
+    from databricks.sdk.service.postgres import (
+        Branch,
+        BranchSpec,
+        Project,
+        ProjectDefaultEndpointSettings,
+        ProjectSpec,
+    )
     HAS_AUTOSCALING_SDK = True
 except ImportError:
     HAS_AUTOSCALING_SDK = False
@@ -704,6 +711,11 @@ def _capacity_to_autoscaling_cu(capacity: str) -> tuple[float, float]:
     return min_cu, max_cu
 
 
+# How long to poll for a new branch's endpoint to come up before giving up.
+_BRANCH_ENDPOINT_TIMEOUT_S = 120
+_BRANCH_ENDPOINT_POLL_INTERVAL_S = 3
+
+
 def _probe_autoscaling_available(ws: WorkspaceClient) -> bool:
     """Check if Lakebase Autoscaling API is available in this workspace."""
     if not HAS_AUTOSCALING_SDK:
@@ -981,6 +993,72 @@ def _delete_branch(
             logger.info(f"Branch {branch_name} not found (already deleted)")
             return
         raise
+
+
+def _create_branch_from(
+    ws: WorkspaceClient,
+    project_name: str,
+    source_branch: str,
+    target_branch: str,
+) -> dict[str, Any]:
+    """Create a new Lakebase branch as a child of `source_branch`.
+
+    Waits on the create operation, then polls list_endpoints on the new
+    branch until an endpoint with a populated host appears
+    (up to _BRANCH_ENDPOINT_TIMEOUT_S). Raises DeploymentError on timeout.
+
+    Returns a lakebase_result-shaped dict pointing at the new branch.
+    """
+    if not HAS_AUTOSCALING_SDK:
+        raise DeploymentError(
+            "Autoscaling SDK not available — cannot create Lakebase branch. "
+            "Upgrade databricks-sdk."
+        )
+
+    source_path = f"projects/{project_name}/branches/{source_branch}"
+    target_parent = f"projects/{project_name}"
+    target_path = f"projects/{project_name}/branches/{target_branch}"
+
+    logger.info(f"Creating branch {target_branch} from {source_branch}")
+    operation = ws.postgres.create_branch(
+        parent=target_parent,
+        branch=Branch(spec=BranchSpec(source_branch=source_path)),
+        branch_id=target_branch,
+    )
+    operation.wait()
+    logger.info(f"Branch {target_branch} created")
+
+    # Poll for endpoint readiness
+    deadline = time.time() + _BRANCH_ENDPOINT_TIMEOUT_S
+    endpoint = None
+    while time.time() < deadline:
+        endpoints = list(ws.postgres.list_endpoints(parent=target_path))
+        ready = [
+            e for e in endpoints
+            if getattr(e, "status", None)
+            and getattr(e.status, "hosts", None)
+            and getattr(e.status.hosts, "host", None)
+        ]
+        if ready:
+            endpoint = ready[0]
+            break
+        time.sleep(_BRANCH_ENDPOINT_POLL_INTERVAL_S)
+
+    if endpoint is None:
+        raise DeploymentError(
+            f"Branch {target_branch} created but no endpoint ready within "
+            f"{_BRANCH_ENDPOINT_TIMEOUT_S}s"
+        )
+
+    return {
+        "name": project_name,
+        "type": "autoscaling",
+        "status": "created",
+        "host": endpoint.status.hosts.host,
+        "endpoint_name": endpoint.name,
+        "project_id": project_name,
+        "instance_name": None,
+    }
 
 
 def _write_requirements(

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -1030,7 +1030,7 @@ def _create_branch_from(
     logger.info(f"Creating branch {target_branch} from {source_branch}")
     operation = ws.postgres.create_branch(
         parent=target_parent,
-        branch=Branch(spec=BranchSpec(source_branch=source_path)),
+        branch=Branch(spec=BranchSpec(source_branch=source_path, no_expiry=True)),
         branch_id=target_branch,
     )
     operation.wait()

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -961,6 +961,28 @@ def _branch_exists(
         raise
 
 
+def _delete_branch(
+    ws: WorkspaceClient, project_name: str, branch_name: str
+) -> None:
+    """Delete a Lakebase branch. Idempotent — no-op if the branch is missing.
+
+    Waits on the long-running delete operation. Any error other than
+    not-found is surfaced.
+    """
+    try:
+        operation = ws.postgres.delete_branch(
+            name=f"projects/{project_name}/branches/{branch_name}"
+        )
+        operation.wait()
+        logger.info(f"Deleted Lakebase branch: {branch_name}")
+    except Exception as e:
+        error_str = str(e).lower()
+        if "not found" in error_str or "does not exist" in error_str:
+            logger.info(f"Branch {branch_name} not found (already deleted)")
+            return
+        raise
+
+
 def _write_requirements(
     staging_dir: Path,
     app_version: Optional[str],

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -1061,6 +1061,20 @@ def _create_branch_from(
     }
 
 
+def _recreate_ephemeral_branch(
+    ws: WorkspaceClient,
+    project_name: str,
+    source_branch: str,
+    target_branch: str,
+) -> dict[str, Any]:
+    """Delete `target_branch` if it exists, then create it from `source_branch`.
+
+    Returns the lakebase_result dict for the newly-created branch.
+    """
+    _delete_branch(ws, project_name, target_branch)
+    return _create_branch_from(ws, project_name, source_branch, target_branch)
+
+
 def _write_requirements(
     staging_dir: Path,
     app_version: Optional[str],

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -787,7 +787,10 @@ def _get_or_create_lakebase_autoscaling(
 
 
 def _ensure_sp_autoscaling_role(
-    ws: WorkspaceClient, project_name: str, client_id: str
+    ws: WorkspaceClient,
+    project_name: str,
+    client_id: str,
+    branch_name: str = "production",
 ) -> None:
     """Create or verify the SP's Postgres role on an autoscaling project.
 
@@ -803,6 +806,7 @@ def _ensure_sp_autoscaling_role(
         ws: WorkspaceClient
         project_name: Autoscaling project name (e.g. "teller-dev-mohamed")
         client_id: The app service principal's client ID (UUID)
+        branch_name: Branch under the project to attach the role to (default "production").
     """
     if not HAS_ROLE_SDK:
         logger.warning(
@@ -812,7 +816,7 @@ def _ensure_sp_autoscaling_role(
         print("   Warning: SDK too old for role API — SP role must be configured manually")
         return
 
-    branch_path = f"projects/{project_name}/branches/production"
+    branch_path = f"projects/{project_name}/branches/{branch_name}"
     role_id = f"sp-{client_id}"
     role_path = f"{branch_path}/roles/{role_id}"
 

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -730,7 +730,10 @@ def _probe_autoscaling_available(ws: WorkspaceClient) -> bool:
 
 
 def _get_or_create_lakebase_autoscaling(
-    ws: WorkspaceClient, database_name: str, capacity: str
+    ws: WorkspaceClient,
+    database_name: str,
+    capacity: str,
+    branch_name: str = "production",
 ) -> dict[str, Any]:
     """Get or create a Lakebase Autoscaling project.
 
@@ -764,11 +767,12 @@ def _get_or_create_lakebase_autoscaling(
 
     # Get the primary endpoint for connection info
     endpoints = list(ws.postgres.list_endpoints(
-        parent=f"projects/{database_name}/branches/production"
+        parent=f"projects/{database_name}/branches/{branch_name}"
     ))
     if not endpoints:
         raise DeploymentError(
-            f"No endpoints found for autoscaling project {database_name}"
+            f"No endpoints found for autoscaling project {database_name} "
+            f"on branch {branch_name}"
         )
 
     endpoint = ws.postgres.get_endpoint(name=endpoints[0].name)

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -444,6 +444,16 @@ def update_local(
             encryption_key = _check_branching_preconditions(ws, config)
             print(f"   Preflight OK (source: {branch_from_env})")
 
+            # Verify the app exists BEFORE branch recreation so we don't leave
+            # an orphan staging branch when the user runs update before create.
+            try:
+                app = ws.apps.get(name=app_name)
+            except Exception as e:
+                raise DeploymentError(
+                    f"App '{app_name}' does not exist — "
+                    f"run 'deploy_local.sh create --env {env}' first"
+                ) from e
+
             print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
             lakebase_result = _recreate_ephemeral_branch(
                 ws, lakebase_name, branch_from_env, env
@@ -453,13 +463,17 @@ def update_local(
                 f"(endpoint: {lakebase_result['host']})"
             )
 
-            # Register SP role on the new staging branch
-            app = ws.apps.get(name=app_name)
+            # Register SP role on the new staging branch.
+            # (`app` was fetched above — reuse it; no need to re-GET.)
             client_id = _get_app_client_id(app)
             if client_id:
                 print("Configuring SP role on new branch...")
                 _ensure_sp_autoscaling_role(
                     ws, lakebase_name, client_id, branch_name=env
+                )
+            else:
+                print(
+                    "   Warning: Could not get SP client ID — role setup skipped"
                 )
 
             # Grant schema perms on the new branch
@@ -552,6 +566,13 @@ def delete_local(env: str, profile: str, reset_database: bool = False) -> dict[s
     """Delete a Databricks App (and its ephemeral branch, if branching)."""
     config = load_deployment_config(env)
     branch_from_env = config.get("branch_from_env")
+
+    if branch_from_env and reset_database:
+        print(
+            "WARNING: --reset-db is a no-op for branching envs "
+            "(the branch itself is about to be deleted). Ignoring."
+        )
+        reset_database = False
 
     result = delete(
         app_name=config["app_name"],

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -47,17 +47,36 @@ from databricks_tellr.deploy import (
 )
 
 
+def _load_branch_source_config(
+    environments: dict, source_env_name: str
+) -> dict:
+    """Return {workspace_path, schema, database_name} from the source env.
+
+    Raises:
+        DeploymentError: if source env is missing.
+    """
+    if source_env_name not in environments:
+        raise DeploymentError(
+            f'branch_from "{source_env_name}" not found in deployment config'
+        )
+    src = environments[source_env_name]
+    src_lb = src.get("lakebase", {})
+    return {
+        "workspace_path": src.get("workspace_path"),
+        "schema": src_lb.get("schema"),
+        "database_name": src_lb.get("database_name"),
+    }
+
+
 def load_deployment_config(env: str) -> dict[str, Any]:
     """Load deployment configuration for the specified environment.
 
-    Args:
-        env: Environment name (development, staging, production)
-
-    Returns:
-        Dictionary with deployment configuration
+    Supports `lakebase.branch_from: <env>` — when set, the target env
+    inherits `schema` from the source env and the output dict carries
+    `branch_from_env` + `branch_from_workspace_path` so callers can run the
+    branching flow.
     """
     config_path = PROJECT_ROOT / "config" / "deployment.yaml"
-
     if not config_path.exists():
         raise DeploymentError(f"Deployment config not found: {config_path}")
 
@@ -75,6 +94,30 @@ def load_deployment_config(env: str) -> dict[str, Any]:
     env_config = environments[env]
     lakebase_config = env_config.get("lakebase", {})
 
+    branch_from = lakebase_config.get("branch_from")
+    schema_name = lakebase_config.get("schema")
+    branch_from_workspace_path = None
+
+    if branch_from:
+        src = _load_branch_source_config(environments, branch_from)
+        if src["database_name"] != lakebase_config.get("database_name"):
+            raise DeploymentError(
+                f"branching requires same database_name; "
+                f'{env}={lakebase_config.get("database_name")}, '
+                f'{branch_from}={src["database_name"]}'
+            )
+        # Inherit schema from source env. If this env also specified a schema
+        # and it differs, raise — avoid silent mismatches.
+        if schema_name and schema_name != src["schema"]:
+            raise DeploymentError(
+                f"branching env '{env}' declared schema '{schema_name}' "
+                f"which differs from source env '{branch_from}' schema "
+                f"'{src['schema']}'. Remove the schema field from '{env}' "
+                f"or change it to match."
+            )
+        schema_name = src["schema"]
+        branch_from_workspace_path = src["workspace_path"]
+
     return {
         "app_name": env_config.get("app_name"),
         "description": env_config.get("description", "AI Slide Generator"),
@@ -82,7 +125,9 @@ def load_deployment_config(env: str) -> dict[str, Any]:
         "compute_size": env_config.get("compute_size", "MEDIUM"),
         "lakebase_name": lakebase_config.get("database_name"),
         "lakebase_capacity": lakebase_config.get("capacity", "CU_1"),
-        "schema_name": lakebase_config.get("schema"),
+        "schema_name": schema_name,
+        "branch_from_env": branch_from,
+        "branch_from_workspace_path": branch_from_workspace_path,
     }
 
 

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "packages" / "databricks-tellr"))
 from databricks_tellr.deploy import (
     DeploymentError,
     _branch_exists,
+    _delete_branch,
     _get_workspace_client,
     _get_or_create_lakebase,
     _probe_autoscaling_available,
@@ -548,25 +549,26 @@ def update_local(
 
 
 def delete_local(env: str, profile: str, reset_database: bool = False) -> dict[str, Any]:
-    """Delete a Databricks App.
-
-    Args:
-        env: Environment name (development, staging, production)
-        profile: Databricks CLI profile name
-        reset_database: If True, drop the schema before deleting
-
-    Returns:
-        Dictionary with deletion status
-    """
+    """Delete a Databricks App (and its ephemeral branch, if branching)."""
     config = load_deployment_config(env)
+    branch_from_env = config.get("branch_from_env")
 
-    return delete(
+    result = delete(
         app_name=config["app_name"],
         lakebase_name=config["lakebase_name"],
         schema_name=config["schema_name"],
         reset_database=reset_database,
         profile=profile,
     )
+
+    if branch_from_env:
+        ws = _get_workspace_client(profile=profile)
+        print(f"Deleting ephemeral branch '{env}'...")
+        _delete_branch(ws, config["lakebase_name"], env)
+        print(f"   Branch '{env}' deleted")
+        result["branch_deleted"] = env
+
+    return result
 
 
 def main() -> None:

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -31,9 +31,12 @@ sys.path.insert(0, str(PROJECT_ROOT / "packages" / "databricks-tellr"))
 
 from databricks_tellr.deploy import (
     DeploymentError,
+    _branch_exists,
     _get_workspace_client,
     _get_or_create_lakebase,
+    _probe_autoscaling_available,
     _read_existing_encryption_key,
+    _recreate_ephemeral_branch,
     _write_requirements,
     _write_app_yaml,
     _upload_files,
@@ -203,6 +206,53 @@ def upload_wheel(
         )
 
     return f"./wheels/{wheel_path.name}"
+
+
+def _check_branching_preconditions(
+    ws: WorkspaceClient, config: dict[str, Any]
+) -> str:
+    """Run preconditions for branching-mode deploy. Return prod's encryption key.
+
+    Raises DeploymentError if any precondition fails, BEFORE any mutating
+    ws.postgres call.
+    """
+    branch_from_env = config["branch_from_env"]
+    branch_from_workspace_path = config["branch_from_workspace_path"]
+    project_name = config["lakebase_name"]
+
+    # 1+2 handled by load_deployment_config. By the time we get here,
+    # branch_from_env is already resolved and database_name matches.
+
+    # 3 + 4: source app.yaml exists and has a key
+    encryption_key = _read_existing_encryption_key(ws, branch_from_workspace_path)
+    if not encryption_key:
+        raise DeploymentError(
+            f"{branch_from_env} not deployed — deploy {branch_from_env} first "
+            f"(could not read GOOGLE_OAUTH_ENCRYPTION_KEY from "
+            f"{branch_from_workspace_path}/app.yaml)"
+        )
+
+    # 5: Lakebase is autoscaling
+    if not _probe_autoscaling_available(ws):
+        raise DeploymentError(
+            f"Lakebase branching requires autoscaling; "
+            f"{project_name} is not an autoscaling project"
+        )
+    try:
+        ws.postgres.get_project(name=f"projects/{project_name}")
+    except Exception as e:
+        raise DeploymentError(
+            f"Lakebase branching requires autoscaling; "
+            f"{project_name} is not an autoscaling project (get_project failed: {e})"
+        ) from e
+
+    # 6: source branch exists
+    if not _branch_exists(ws, project_name, branch_from_env):
+        raise DeploymentError(
+            f'source branch "{branch_from_env}" not found in project {project_name}'
+        )
+
+    return encryption_key
 
 
 def create_local(

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -414,17 +414,7 @@ def update_local(
     reset_database: bool = False,
     seed_databricks_defaults: bool = True,
 ) -> dict[str, Any]:
-    """Update an existing Databricks App using locally-built wheels.
-
-    Args:
-        env: Environment name (development, staging, production)
-        profile: Databricks CLI profile name
-        reset_database: If True, drop and recreate the schema
-        seed_databricks_defaults: If True, seed Databricks-specific content
-
-    Returns:
-        Dictionary with deployment info
-    """
+    """Update an existing Databricks App using locally-built wheels."""
     config = load_deployment_config(env)
     ws = _get_workspace_client(profile=profile)
 
@@ -432,21 +422,65 @@ def update_local(
     workspace_path = config["workspace_path"]
     lakebase_name = config["lakebase_name"]
     schema_name = config["schema_name"]
+    branch_from_env = config.get("branch_from_env")
+
+    if branch_from_env and reset_database:
+        print(
+            "WARNING: --reset-db is a no-op for branching envs "
+            "(each deploy is already a fresh branch). Ignoring."
+        )
+        reset_database = False
 
     print(f"Updating AI Slide Generator (local wheels): {app_name}")
+    if branch_from_env:
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{env}')")
     print()
 
     try:
-        # Get current Lakebase state (needed for connection info and type)
-        print("Checking Lakebase database...")
-        lakebase_result = _get_or_create_lakebase(
-            ws, lakebase_name, config["lakebase_capacity"]
-        )
+        # Branching mode: preflight + recreate branch
+        if branch_from_env:
+            print("Running branching preflight checks...")
+            encryption_key = _check_branching_preconditions(ws, config)
+            print(f"   Preflight OK (source: {branch_from_env})")
+
+            print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, env
+            )
+            print(
+                f"   Branch '{env}' ready "
+                f"(endpoint: {lakebase_result['host']})"
+            )
+
+            # Register SP role on the new staging branch
+            app = ws.apps.get(name=app_name)
+            client_id = _get_app_client_id(app)
+            if client_id:
+                print("Configuring SP role on new branch...")
+                _ensure_sp_autoscaling_role(
+                    ws, lakebase_name, client_id, branch_name=env
+                )
+
+            # Grant schema perms on the new branch
+            print("Granting schema permissions on new branch...")
+            _setup_database_schema(
+                ws, app, lakebase_name, schema_name,
+                lakebase_result=lakebase_result,
+            )
+            print(f"   Schema '{schema_name}' permissions configured")
+        else:
+            # Standard path (prod/dev): get current Lakebase state
+            print("Checking Lakebase database...")
+            lakebase_result = _get_or_create_lakebase(
+                ws, lakebase_name, config["lakebase_capacity"]
+            )
+            encryption_key = _read_existing_encryption_key(ws, workspace_path)
+
         lakebase_type = lakebase_result.get("type", "provisioned")
         print(f"   Lakebase: {lakebase_result['name']} (type={lakebase_type})")
         print()
 
-        # Reset database if requested
+        # Reset database if requested (non-branching only; warning already printed)
         if reset_database:
             print("Resetting database schema...")
             app = ws.apps.get(name=app_name)
@@ -466,9 +500,6 @@ def update_local(
         local_wheel_ref = upload_wheel(ws, wheel_path, workspace_path)
         print(f"   Uploaded: {local_wheel_ref}")
         print()
-
-        # Preserve the existing encryption key so we don't invalidate encrypted data
-        encryption_key = _read_existing_encryption_key(ws, workspace_path)
 
         # Generate and upload deployment files
         print("Preparing deployment files...")
@@ -508,6 +539,7 @@ def update_local(
             "deployment_id": result.deployment_id,
             "wheel": wheel_path.name,
             "status": "updated",
+            "branch": env if branch_from_env else None,
             "database_reset": reset_database,
         }
 

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -32,7 +32,6 @@ sys.path.insert(0, str(PROJECT_ROOT / "packages" / "databricks-tellr"))
 from databricks_tellr.deploy import (
     DeploymentError,
     _branch_exists,
-    _delete_branch,
     _get_workspace_client,
     _get_or_create_lakebase,
     _probe_autoscaling_available,
@@ -307,12 +306,12 @@ def create_local(
             encryption_key = _check_branching_preconditions(ws, config)
             print(f"   Preflight OK (source: {branch_from_env})")
 
-            print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
+            print(f"Creating ephemeral branch off '{branch_from_env}'...")
             lakebase_result = _recreate_ephemeral_branch(
                 ws, lakebase_name, branch_from_env, env
             )
             print(
-                f"   Branch '{env}' ready "
+                f"   Branch '{lakebase_result['branch_id']}' ready "
                 f"(endpoint: {lakebase_result['host']})"
             )
         else:
@@ -370,7 +369,12 @@ def create_local(
             client_id = _get_app_client_id(app)
             if client_id:
                 print("Configuring SP role on autoscaling project...")
-                sp_branch = env if branch_from_env else "production"
+                # For branching envs, use the unique branch_id the helper
+                # generated (e.g. "staging-1777000000"). For non-branching,
+                # fall back to the production branch.
+                sp_branch = (
+                    lakebase_result.get("branch_id") if branch_from_env else "production"
+                )
                 _ensure_sp_autoscaling_role(
                     ws, lakebase_name, client_id, branch_name=sp_branch
                 )
@@ -459,7 +463,7 @@ def update_local(
                 ws, lakebase_name, branch_from_env, env
             )
             print(
-                f"   Branch '{env}' ready "
+                f"   Branch '{lakebase_result['branch_id']}' ready "
                 f"(endpoint: {lakebase_result['host']})"
             )
 
@@ -469,7 +473,8 @@ def update_local(
             if client_id:
                 print("Configuring SP role on new branch...")
                 _ensure_sp_autoscaling_role(
-                    ws, lakebase_name, client_id, branch_name=env
+                    ws, lakebase_name, client_id,
+                    branch_name=lakebase_result["branch_id"],
                 )
             else:
                 print(
@@ -582,12 +587,10 @@ def delete_local(env: str, profile: str, reset_database: bool = False) -> dict[s
         profile=profile,
     )
 
-    if branch_from_env:
-        ws = _get_workspace_client(profile=profile)
-        print(f"Deleting ephemeral branch '{env}'...")
-        _delete_branch(ws, config["lakebase_name"], env)
-        print(f"   Branch '{env}' deleted")
-        result["branch_deleted"] = env
+    # Intentionally do NOT delete ephemeral branches here. Lakebase's delete
+    # is async and its purge window causes fixed-ID reuse to collide. We rely
+    # on the branch TTL (_BRANCH_TTL_SECONDS in databricks_tellr.deploy) to
+    # garbage-collect. Leftover branches are harmless and auto-expire.
 
     return result
 

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -277,12 +277,15 @@ def create_local(
     workspace_path = config["workspace_path"]
     lakebase_name = config["lakebase_name"]
     schema_name = config["schema_name"]
+    branch_from_env = config.get("branch_from_env")
 
     print("Deploying AI Slide Generator (local wheels)...")
     print(f"   App name: {app_name}")
     print(f"   Workspace path: {workspace_path}")
     print(f"   Lakebase: {lakebase_name}")
     print(f"   Schema: {schema_name}")
+    if branch_from_env:
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{env}')")
     print()
 
     try:
@@ -296,11 +299,28 @@ def create_local(
         print(f"   Uploaded: {local_wheel_ref}")
         print()
 
-        # Create Lakebase instance (autoscaling first with fallback)
-        print("Setting up Lakebase database...")
-        lakebase_result = _get_or_create_lakebase(
-            ws, lakebase_name, config["lakebase_capacity"]
-        )
+        # Branching mode: preflight + recreate branch
+        encryption_key = None
+        if branch_from_env:
+            print("Running branching preflight checks...")
+            encryption_key = _check_branching_preconditions(ws, config)
+            print(f"   Preflight OK (source: {branch_from_env})")
+
+            print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, env
+            )
+            print(
+                f"   Branch '{env}' ready "
+                f"(endpoint: {lakebase_result['host']})"
+            )
+        else:
+            # Standard path: get/create project + read production endpoint
+            print("Setting up Lakebase database...")
+            lakebase_result = _get_or_create_lakebase(
+                ws, lakebase_name, config["lakebase_capacity"]
+            )
+
         lakebase_type = lakebase_result.get("type", "provisioned")
         print(f"   Lakebase: {lakebase_result['name']} ({lakebase_result['status']})")
         print(f"   Type: {lakebase_type}")
@@ -318,6 +338,7 @@ def create_local(
                 lakebase_name,
                 schema_name,
                 seed_databricks_defaults=seed_databricks_defaults,
+                encryption_key=encryption_key,  # None → _write_app_yaml generates one
                 lakebase_result=lakebase_result,
             )
             print("   Generated app.yaml")
@@ -343,12 +364,15 @@ def create_local(
         print("   App registered")
         print()
 
-        # For autoscaling, create SP role via Postgres API before schema setup
+        # Register SP role on the target branch (staging branch or production branch)
         if lakebase_type == "autoscaling":
             client_id = _get_app_client_id(app)
             if client_id:
                 print("Configuring SP role on autoscaling project...")
-                _ensure_sp_autoscaling_role(ws, lakebase_name, client_id)
+                sp_branch = env if branch_from_env else "production"
+                _ensure_sp_autoscaling_role(
+                    ws, lakebase_name, client_id, branch_name=sp_branch
+                )
             else:
                 print("   Warning: Could not get SP client ID — role setup skipped")
 
@@ -376,6 +400,7 @@ def create_local(
             "lakebase_name": lakebase_name,
             "schema_name": schema_name,
             "wheel": wheel_path.name,
+            "branch": env if branch_from_env else None,
             "status": "created",
         }
 

--- a/tests/unit/test_deploy_autoscaling.py
+++ b/tests/unit/test_deploy_autoscaling.py
@@ -583,3 +583,37 @@ class TestUpdateDatabricks:
         )
 
         assert result["lakebase_type"] == "autoscaling"
+
+
+class TestGetOrCreateLakebaseAutoscalingBranchName:
+    def test_default_branch_is_production(self, mock_ws):
+        # Mock get_project so we skip the create path
+        mock_ws.postgres.get_project.return_value = MagicMock()
+        endpoint = MagicMock()
+        endpoint.name = "projects/db-tellr/branches/production/endpoints/ep1"
+        endpoint.status = MagicMock(hosts=MagicMock(host="prod-host"))
+        mock_ws.postgres.list_endpoints.return_value = iter([endpoint])
+        mock_ws.postgres.get_endpoint.return_value = endpoint
+
+        _get_or_create_lakebase_autoscaling(mock_ws, "db-tellr", "CU_1")
+
+        mock_ws.postgres.list_endpoints.assert_called_once_with(
+            parent="projects/db-tellr/branches/production"
+        )
+
+    def test_custom_branch_name(self, mock_ws):
+        mock_ws.postgres.get_project.return_value = MagicMock()
+        endpoint = MagicMock()
+        endpoint.name = "projects/db-tellr/branches/staging/endpoints/ep1"
+        endpoint.status = MagicMock(hosts=MagicMock(host="staging-host"))
+        mock_ws.postgres.list_endpoints.return_value = iter([endpoint])
+        mock_ws.postgres.get_endpoint.return_value = endpoint
+
+        result = _get_or_create_lakebase_autoscaling(
+            mock_ws, "db-tellr", "CU_1", branch_name="staging"
+        )
+
+        mock_ws.postgres.list_endpoints.assert_called_once_with(
+            parent="projects/db-tellr/branches/staging"
+        )
+        assert result["host"] == "staging-host"

--- a/tests/unit/test_deploy_autoscaling.py
+++ b/tests/unit/test_deploy_autoscaling.py
@@ -307,6 +307,40 @@ class TestEnsureSpAutoscalingRole:
         assert kwargs["parent"] == "projects/my-project/branches/production"
 
 
+class TestEnsureSpAutoscalingRoleBranchName:
+    """Tests that _ensure_sp_autoscaling_role uses the branch_name kwarg."""
+
+    def test_default_branch_is_production(self, mock_ws):
+        # get_role raises not-found so we go down the create path
+        mock_ws.postgres.get_role.side_effect = Exception("not found")
+        create_op = MagicMock()
+        mock_ws.postgres.create_role.return_value = create_op
+
+        with patch("databricks_tellr.deploy.HAS_ROLE_SDK", True):
+            _ensure_sp_autoscaling_role(mock_ws, "db-tellr", "client-123")
+
+        # Inspect parent path used for role creation
+        assert (
+            mock_ws.postgres.create_role.call_args.kwargs["parent"]
+            == "projects/db-tellr/branches/production"
+        )
+
+    def test_custom_branch_name_threads_through(self, mock_ws):
+        mock_ws.postgres.get_role.side_effect = Exception("not found")
+        create_op = MagicMock()
+        mock_ws.postgres.create_role.return_value = create_op
+
+        with patch("databricks_tellr.deploy.HAS_ROLE_SDK", True):
+            _ensure_sp_autoscaling_role(
+                mock_ws, "db-tellr", "client-123", branch_name="staging"
+            )
+
+        assert (
+            mock_ws.postgres.create_role.call_args.kwargs["parent"]
+            == "projects/db-tellr/branches/staging"
+        )
+
+
 # ---------------------------------------------------------------------------
 # _create_app
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -68,52 +68,62 @@ from databricks_tellr.deploy import _create_branch_from
 
 
 class TestCreateBranchFrom:
-    def test_creates_branch_with_correct_source(self, mock_ws):
-        # Set up mocks for the create_branch call
+    def test_creates_branch_with_correct_source(self, mock_ws, monkeypatch):
+        # Freeze time so the generated branch_id is deterministic.
+        monkeypatch.setattr("databricks_tellr.deploy.time.time", lambda: 1777000000)
+        expected_branch_id = "staging-1777000000"
+
         create_op = MagicMock()
         mock_ws.postgres.create_branch.return_value = create_op
 
-        # Set up endpoints polling: first call returns empty, then returns one
         endpoint_ready = MagicMock()
-        endpoint_ready.name = "projects/db-tellr/branches/staging/endpoints/ep1"
+        endpoint_ready.name = (
+            f"projects/db-tellr/branches/{expected_branch_id}/endpoints/ep1"
+        )
         endpoint_ready.status = MagicMock(
             hosts=MagicMock(host="staging-ep1.example.com")
         )
-        # list_endpoints returns an iterator; mock returns ready endpoint.
-        # Use side_effect so each call gets a fresh iterator (avoids
-        # one-shot iter() exhaustion if polling ever loops).
+        # Fresh iterator per call — avoids one-shot iter() exhaustion if polling loops.
         mock_ws.postgres.list_endpoints.side_effect = (
             lambda **kw: iter([endpoint_ready])
         )
-        mock_ws.postgres.get_endpoint.return_value = endpoint_ready
 
         result = _create_branch_from(
             mock_ws,
             project_name="db-tellr",
             source_branch="production",
-            target_branch="staging",
+            target_branch_prefix="staging",
         )
 
         # Verify create_branch call shape
         call_kwargs = mock_ws.postgres.create_branch.call_args.kwargs
         assert call_kwargs["parent"] == "projects/db-tellr"
-        assert call_kwargs["branch_id"] == "staging"
+        # branch_id is {prefix}-{timestamp} — a fresh unique ID per deploy.
+        assert call_kwargs["branch_id"] == expected_branch_id
         branch_arg = call_kwargs["branch"]
         assert branch_arg.spec.source_branch == "projects/db-tellr/branches/production"
-        # Databricks API requires an expiration policy on every branch.
-        # We manage the lifecycle explicitly (delete+recreate per deploy).
-        assert branch_arg.spec.no_expiry is True
+        # Databricks API requires an expiration policy. We use ttl=1 day and
+        # rely on TTL-driven auto-cleanup rather than explicit delete.
+        assert branch_arg.spec.ttl is not None
+        assert branch_arg.spec.ttl.seconds == 86400
+        # no_expiry MUST NOT be set when ttl is — they're mutually exclusive.
+        assert not branch_arg.spec.no_expiry
 
-        # Verify operation waited
         create_op.wait.assert_called_once()
 
         # Verify returned lakebase_result shape
         assert result["type"] == "autoscaling"
         assert result["name"] == "db-tellr"
         assert result["host"] == "staging-ep1.example.com"
-        assert result["endpoint_name"] == "projects/db-tellr/branches/staging/endpoints/ep1"
+        assert (
+            result["endpoint_name"]
+            == f"projects/db-tellr/branches/{expected_branch_id}/endpoints/ep1"
+        )
         assert result["project_id"] == "db-tellr"
         assert result["instance_name"] is None
+        # New field: callers (SP role registration, schema grants) use this
+        # to reference the unique branch name.
+        assert result["branch_id"] == expected_branch_id
 
     def test_raises_when_no_endpoint_after_timeout(self, mock_ws, monkeypatch):
         """If list_endpoints never returns a ready endpoint, raise DeploymentError."""
@@ -121,14 +131,9 @@ class TestCreateBranchFrom:
 
         create_op = MagicMock()
         mock_ws.postgres.create_branch.return_value = create_op
-        # Always empty — use side_effect so every poll gets a fresh empty
-        # iterator (return_value = iter([]) exhausts after the first call,
-        # making subsequent list(...) calls silently also return []).
         mock_ws.postgres.list_endpoints.side_effect = lambda **kw: iter([])
 
-        # Patch sleep so the test doesn't actually wait
         monkeypatch.setattr("databricks_tellr.deploy.time.sleep", lambda *_: None)
-        # Shrink the timeout for fast test
         monkeypatch.setattr("databricks_tellr.deploy._BRANCH_ENDPOINT_TIMEOUT_S", 0.1)
 
         with pytest.raises(DeploymentError, match="no endpoint ready"):
@@ -139,32 +144,29 @@ from databricks_tellr.deploy import _recreate_ephemeral_branch
 
 
 class TestRecreateEphemeralBranch:
-    def test_deletes_then_creates(self, mock_ws, monkeypatch):
+    def test_delegates_to_create_without_deleting(self, mock_ws, monkeypatch):
+        """Delete step removed — TTL handles cleanup. Verify we ONLY create."""
         calls = []
 
         def fake_delete(ws, project, branch):
             calls.append(("delete", branch))
 
-        def fake_create(ws, project, source, target):
-            calls.append(("create", source, target))
-            return {"host": "x", "endpoint_name": "e", "type": "autoscaling"}
+        def fake_create(ws, project, source, prefix):
+            calls.append(("create", source, prefix))
+            return {"host": "x", "endpoint_name": "e", "type": "autoscaling",
+                    "branch_id": f"{prefix}-12345"}
 
-        monkeypatch.setattr(
-            "databricks_tellr.deploy._delete_branch", fake_delete
-        )
-        monkeypatch.setattr(
-            "databricks_tellr.deploy._create_branch_from", fake_create
-        )
+        monkeypatch.setattr("databricks_tellr.deploy._delete_branch", fake_delete)
+        monkeypatch.setattr("databricks_tellr.deploy._create_branch_from", fake_create)
 
         result = _recreate_ephemeral_branch(
             mock_ws,
             project_name="db-tellr",
             source_branch="production",
-            target_branch="staging",
+            target_branch_prefix="staging",
         )
 
-        assert calls == [
-            ("delete", "staging"),
-            ("create", "production", "staging"),
-        ]
+        # No delete — only create.
+        assert calls == [("create", "production", "staging")]
         assert result["host"] == "x"
+        assert result["branch_id"] == "staging-12345"

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -79,8 +79,12 @@ class TestCreateBranchFrom:
         endpoint_ready.status = MagicMock(
             hosts=MagicMock(host="staging-ep1.example.com")
         )
-        # list_endpoints returns an iterator; mock returns ready endpoint
-        mock_ws.postgres.list_endpoints.return_value = iter([endpoint_ready])
+        # list_endpoints returns an iterator; mock returns ready endpoint.
+        # Use side_effect so each call gets a fresh iterator (avoids
+        # one-shot iter() exhaustion if polling ever loops).
+        mock_ws.postgres.list_endpoints.side_effect = (
+            lambda **kw: iter([endpoint_ready])
+        )
         mock_ws.postgres.get_endpoint.return_value = endpoint_ready
 
         result = _create_branch_from(
@@ -114,8 +118,10 @@ class TestCreateBranchFrom:
 
         create_op = MagicMock()
         mock_ws.postgres.create_branch.return_value = create_op
-        # Always empty
-        mock_ws.postgres.list_endpoints.return_value = iter([])
+        # Always empty — use side_effect so every poll gets a fresh empty
+        # iterator (return_value = iter([]) exhausts after the first call,
+        # making subsequent list(...) calls silently also return []).
+        mock_ws.postgres.list_endpoints.side_effect = lambda **kw: iter([])
 
         # Patch sleep so the test doesn't actually wait
         monkeypatch.setattr("databricks_tellr.deploy.time.sleep", lambda *_: None)

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -62,3 +62,65 @@ class TestDeleteBranch:
         mock_ws.postgres.delete_branch.side_effect = Exception("permission denied")
         with pytest.raises(Exception, match="permission denied"):
             _delete_branch(mock_ws, "db-tellr", "staging")
+
+
+from databricks_tellr.deploy import _create_branch_from
+
+
+class TestCreateBranchFrom:
+    def test_creates_branch_with_correct_source(self, mock_ws):
+        # Set up mocks for the create_branch call
+        create_op = MagicMock()
+        mock_ws.postgres.create_branch.return_value = create_op
+
+        # Set up endpoints polling: first call returns empty, then returns one
+        endpoint_ready = MagicMock()
+        endpoint_ready.name = "projects/db-tellr/branches/staging/endpoints/ep1"
+        endpoint_ready.status = MagicMock(
+            hosts=MagicMock(host="staging-ep1.example.com")
+        )
+        # list_endpoints returns an iterator; mock returns ready endpoint
+        mock_ws.postgres.list_endpoints.return_value = iter([endpoint_ready])
+        mock_ws.postgres.get_endpoint.return_value = endpoint_ready
+
+        result = _create_branch_from(
+            mock_ws,
+            project_name="db-tellr",
+            source_branch="production",
+            target_branch="staging",
+        )
+
+        # Verify create_branch call shape
+        call_kwargs = mock_ws.postgres.create_branch.call_args.kwargs
+        assert call_kwargs["parent"] == "projects/db-tellr"
+        assert call_kwargs["branch_id"] == "staging"
+        branch_arg = call_kwargs["branch"]
+        assert branch_arg.spec.source_branch == "projects/db-tellr/branches/production"
+
+        # Verify operation waited
+        create_op.wait.assert_called_once()
+
+        # Verify returned lakebase_result shape
+        assert result["type"] == "autoscaling"
+        assert result["name"] == "db-tellr"
+        assert result["host"] == "staging-ep1.example.com"
+        assert result["endpoint_name"] == "projects/db-tellr/branches/staging/endpoints/ep1"
+        assert result["project_id"] == "db-tellr"
+        assert result["instance_name"] is None
+
+    def test_raises_when_no_endpoint_after_timeout(self, mock_ws, monkeypatch):
+        """If list_endpoints never returns a ready endpoint, raise DeploymentError."""
+        from databricks_tellr.deploy import DeploymentError
+
+        create_op = MagicMock()
+        mock_ws.postgres.create_branch.return_value = create_op
+        # Always empty
+        mock_ws.postgres.list_endpoints.return_value = iter([])
+
+        # Patch sleep so the test doesn't actually wait
+        monkeypatch.setattr("databricks_tellr.deploy.time.sleep", lambda *_: None)
+        # Shrink the timeout for fast test
+        monkeypatch.setattr("databricks_tellr.deploy._BRANCH_ENDPOINT_TIMEOUT_S", 0.1)
+
+        with pytest.raises(DeploymentError, match="no endpoint ready"):
+            _create_branch_from(mock_ws, "db-tellr", "production", "staging")

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -100,6 +100,9 @@ class TestCreateBranchFrom:
         assert call_kwargs["branch_id"] == "staging"
         branch_arg = call_kwargs["branch"]
         assert branch_arg.spec.source_branch == "projects/db-tellr/branches/production"
+        # Databricks API requires an expiration policy on every branch.
+        # We manage the lifecycle explicitly (delete+recreate per deploy).
+        assert branch_arg.spec.no_expiry is True
 
         # Verify operation waited
         create_op.wait.assert_called_once()

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -124,3 +124,38 @@ class TestCreateBranchFrom:
 
         with pytest.raises(DeploymentError, match="no endpoint ready"):
             _create_branch_from(mock_ws, "db-tellr", "production", "staging")
+
+
+from databricks_tellr.deploy import _recreate_ephemeral_branch
+
+
+class TestRecreateEphemeralBranch:
+    def test_deletes_then_creates(self, mock_ws, monkeypatch):
+        calls = []
+
+        def fake_delete(ws, project, branch):
+            calls.append(("delete", branch))
+
+        def fake_create(ws, project, source, target):
+            calls.append(("create", source, target))
+            return {"host": "x", "endpoint_name": "e", "type": "autoscaling"}
+
+        monkeypatch.setattr(
+            "databricks_tellr.deploy._delete_branch", fake_delete
+        )
+        monkeypatch.setattr(
+            "databricks_tellr.deploy._create_branch_from", fake_create
+        )
+
+        result = _recreate_ephemeral_branch(
+            mock_ws,
+            project_name="db-tellr",
+            source_branch="production",
+            target_branch="staging",
+        )
+
+        assert calls == [
+            ("delete", "staging"),
+            ("create", "production", "staging"),
+        ]
+        assert result["host"] == "x"

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -32,3 +32,33 @@ class TestBranchExists:
         mock_ws.postgres.get_branch.side_effect = Exception("permission denied")
         with pytest.raises(Exception, match="permission denied"):
             _branch_exists(mock_ws, "db-tellr", "production")
+
+
+from databricks_tellr.deploy import _delete_branch
+
+
+class TestDeleteBranch:
+    def test_calls_delete_with_correct_path_and_waits(self, mock_ws):
+        operation = MagicMock()
+        mock_ws.postgres.delete_branch.return_value = operation
+
+        _delete_branch(mock_ws, "db-tellr", "staging")
+
+        mock_ws.postgres.delete_branch.assert_called_once_with(
+            name="projects/db-tellr/branches/staging"
+        )
+        operation.wait.assert_called_once()
+
+    def test_noop_on_not_found(self, mock_ws):
+        mock_ws.postgres.delete_branch.side_effect = Exception("Resource not found")
+        # Should not raise
+        _delete_branch(mock_ws, "db-tellr", "staging")
+
+    def test_noop_on_does_not_exist(self, mock_ws):
+        mock_ws.postgres.delete_branch.side_effect = Exception("branch does not exist")
+        _delete_branch(mock_ws, "db-tellr", "staging")
+
+    def test_surfaces_other_errors(self, mock_ws):
+        mock_ws.postgres.delete_branch.side_effect = Exception("permission denied")
+        with pytest.raises(Exception, match="permission denied"):
+            _delete_branch(mock_ws, "db-tellr", "staging")

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -1,0 +1,34 @@
+"""Tests for Lakebase branch helpers in databricks_tellr.deploy."""
+from unittest.mock import MagicMock, patch
+import pytest
+
+pytest.importorskip("databricks_tellr", reason="databricks-tellr package not installed")
+
+from databricks_tellr.deploy import _branch_exists
+
+
+@pytest.fixture
+def mock_ws():
+    return MagicMock()
+
+
+class TestBranchExists:
+    def test_returns_true_when_branch_exists(self, mock_ws):
+        mock_ws.postgres.get_branch.return_value = MagicMock(name="branch")
+        assert _branch_exists(mock_ws, "db-tellr", "production") is True
+        mock_ws.postgres.get_branch.assert_called_once_with(
+            name="projects/db-tellr/branches/production"
+        )
+
+    def test_returns_false_on_not_found(self, mock_ws):
+        mock_ws.postgres.get_branch.side_effect = Exception("Resource not found")
+        assert _branch_exists(mock_ws, "db-tellr", "staging") is False
+
+    def test_returns_false_on_does_not_exist(self, mock_ws):
+        mock_ws.postgres.get_branch.side_effect = Exception("branch does not exist")
+        assert _branch_exists(mock_ws, "db-tellr", "staging") is False
+
+    def test_surfaces_other_errors(self, mock_ws):
+        mock_ws.postgres.get_branch.side_effect = Exception("permission denied")
+        with pytest.raises(Exception, match="permission denied"):
+            _branch_exists(mock_ws, "db-tellr", "production")

--- a/tests/unit/test_deploy_local_config_branching.py
+++ b/tests/unit/test_deploy_local_config_branching.py
@@ -1,5 +1,7 @@
 """Tests for branch_from resolution in load_deployment_config."""
 from pathlib import Path
+from unittest.mock import MagicMock
+
 import pytest
 import yaml
 
@@ -92,3 +94,29 @@ class TestLoadDeploymentConfig:
         (tmp_path / "config" / "deployment.yaml").write_text(yaml.safe_dump(bad))
         with pytest.raises(Exception, match="same database_name"):
             load_deployment_config("staging")
+
+
+class TestResetDbNoopWarning:
+    def test_reset_db_warning_printed_for_branching_env(
+        self, config_path, capsys, monkeypatch
+    ):
+        """update_local with a branching env + reset_database prints a warning and ignores the flag."""
+        from scripts import deploy_local
+
+        # Patch every side-effecting call in update_local down to the warning print
+        monkeypatch.setattr(
+            deploy_local, "_get_workspace_client", lambda profile=None: MagicMock()
+        )
+        # Make preflight fail loudly with a recognisable error — we just want to
+        # get past the warning print, not execute the rest of the flow.
+        def boom(*a, **kw):
+            raise deploy_local.DeploymentError("STOP")
+        monkeypatch.setattr(deploy_local, "_check_branching_preconditions", boom)
+
+        with pytest.raises(deploy_local.DeploymentError, match="STOP"):
+            deploy_local.update_local(
+                env="staging", profile="p", reset_database=True
+            )
+
+        captured = capsys.readouterr()
+        assert "--reset-db is a no-op for branching envs" in captured.out

--- a/tests/unit/test_deploy_local_config_branching.py
+++ b/tests/unit/test_deploy_local_config_branching.py
@@ -120,3 +120,34 @@ class TestResetDbNoopWarning:
 
         captured = capsys.readouterr()
         assert "--reset-db is a no-op for branching envs" in captured.out
+
+
+class TestUpdateLocalMissingApp:
+    """Regression: update_local branching path raises a clear error when the app doesn't exist."""
+
+    def test_missing_app_raises_actionable_error(
+        self, config_path, monkeypatch
+    ):
+        from scripts import deploy_local
+
+        # Return a mock ws whose apps.get raises NotFound-style exception
+        mock_ws = MagicMock()
+        mock_ws.apps.get.side_effect = Exception("Resource not found")
+        monkeypatch.setattr(
+            deploy_local, "_get_workspace_client", lambda profile=None: mock_ws
+        )
+        # Preflight passes (we want to exercise the NEW early-app-check, not preflight failure)
+        monkeypatch.setattr(
+            deploy_local, "_check_branching_preconditions",
+            lambda ws, cfg: "dummy-key",
+        )
+
+        with pytest.raises(
+            deploy_local.DeploymentError,
+            match=r"App .* does not exist.*run 'deploy_local.sh create --env staging' first",
+        ):
+            deploy_local.update_local(env="staging", profile="p")
+
+        # Confirm we never called _recreate_ephemeral_branch — the whole point.
+        mock_ws.postgres.create_branch.assert_not_called()
+        mock_ws.postgres.delete_branch.assert_not_called()

--- a/tests/unit/test_deploy_local_config_branching.py
+++ b/tests/unit/test_deploy_local_config_branching.py
@@ -1,0 +1,94 @@
+"""Tests for branch_from resolution in load_deployment_config."""
+from pathlib import Path
+import pytest
+import yaml
+
+from scripts.deploy_local import load_deployment_config
+
+FIXTURE_YAML = {
+    "environments": {
+        "production": {
+            "app_name": "db-tellr-prod",
+            "description": "prod",
+            "workspace_path": "/Workspace/Users/x/.apps/prod/tellr",
+            "compute_size": "LARGE",
+            "lakebase": {
+                "database_name": "db-tellr",
+                "schema": "app_data_prod",
+                "capacity": "CU_1",
+            },
+        },
+        "staging": {
+            "app_name": "db-tellr-staging",
+            "description": "staging",
+            "workspace_path": "/Workspace/Users/x/.apps/staging/tellr",
+            "compute_size": "MEDIUM",
+            "lakebase": {
+                "database_name": "db-tellr",
+                "branch_from": "production",
+                "capacity": "CU_1",
+            },
+        },
+        "development": {
+            "app_name": "db-tellr-dev",
+            "description": "dev",
+            "workspace_path": "/Workspace/Users/x/.apps/dev/tellr",
+            "compute_size": "MEDIUM",
+            "lakebase": {
+                "database_name": "db-tellr",
+                "schema": "tellr_app_data_dev",
+                "capacity": "CU_1",
+            },
+        },
+    },
+}
+
+
+@pytest.fixture
+def config_path(tmp_path, monkeypatch):
+    """Write FIXTURE_YAML to tmp and point load_deployment_config at it."""
+    cfg = tmp_path / "deployment.yaml"
+    cfg.write_text(yaml.safe_dump(FIXTURE_YAML))
+    # load_deployment_config resolves PROJECT_ROOT / "config" / "deployment.yaml"
+    # Patch PROJECT_ROOT to tmp_path, and put the yaml at tmp_path/config/deployment.yaml
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "deployment.yaml").write_text(yaml.safe_dump(FIXTURE_YAML))
+    monkeypatch.setattr("scripts.deploy_local.PROJECT_ROOT", tmp_path)
+    return tmp_path
+
+
+class TestLoadDeploymentConfig:
+    def test_non_branching_env_unchanged(self, config_path):
+        """production config is unaffected by branch_from logic."""
+        cfg = load_deployment_config("production")
+        assert cfg["schema_name"] == "app_data_prod"
+        assert cfg.get("branch_from_env") is None
+        assert cfg.get("branch_from_workspace_path") is None
+
+    def test_dev_env_unchanged(self, config_path):
+        cfg = load_deployment_config("development")
+        assert cfg["schema_name"] == "tellr_app_data_dev"
+        assert cfg.get("branch_from_env") is None
+
+    def test_staging_inherits_prod_schema(self, config_path):
+        cfg = load_deployment_config("staging")
+        assert cfg["schema_name"] == "app_data_prod"
+        assert cfg["branch_from_env"] == "production"
+        assert cfg["branch_from_workspace_path"] == "/Workspace/Users/x/.apps/prod/tellr"
+        # database_name still staging's own (same value)
+        assert cfg["lakebase_name"] == "db-tellr"
+
+    def test_branch_from_unknown_env_errors(self, config_path, tmp_path, monkeypatch):
+        bad = yaml.safe_load(yaml.safe_dump(FIXTURE_YAML))
+        bad["environments"]["staging"]["lakebase"]["branch_from"] = "nonexistent"
+        (tmp_path / "config" / "deployment.yaml").write_text(yaml.safe_dump(bad))
+        with pytest.raises(Exception, match="branch_from.*nonexistent.*not found"):
+            load_deployment_config("staging")
+
+    def test_database_name_mismatch_errors(self, config_path, tmp_path, monkeypatch):
+        bad = yaml.safe_load(yaml.safe_dump(FIXTURE_YAML))
+        bad["environments"]["staging"]["lakebase"]["database_name"] = "other-db"
+        (tmp_path / "config" / "deployment.yaml").write_text(yaml.safe_dump(bad))
+        with pytest.raises(Exception, match="same database_name"):
+            load_deployment_config("staging")

--- a/tests/unit/test_deploy_local_preflight.py
+++ b/tests/unit/test_deploy_local_preflight.py
@@ -1,0 +1,116 @@
+"""Tests for branching-mode preflight checks."""
+from unittest.mock import MagicMock, patch
+import pytest
+
+pytest.importorskip("databricks_tellr", reason="databricks-tellr package not installed")
+
+from databricks_tellr.deploy import DeploymentError
+
+
+@pytest.fixture
+def mock_ws():
+    return MagicMock()
+
+
+@pytest.fixture
+def good_config():
+    return {
+        "lakebase_name": "db-tellr",
+        "branch_from_env": "production",
+        "branch_from_workspace_path": "/Workspace/Users/x/.apps/prod/tellr",
+    }
+
+
+class TestCheckBranchingPreconditions:
+    def test_happy_path_returns_encryption_key(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        # Patch all the Workspace/SDK calls
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="prod-key-123",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available", return_value=True
+        ):
+            mock_ws.postgres.get_project.return_value = MagicMock()
+            with patch(
+                "scripts.deploy_local._branch_exists", return_value=True
+            ):
+                key = _check_branching_preconditions(mock_ws, good_config)
+        assert key == "prod-key-123"
+
+    def test_missing_prod_app_yaml(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value=None,
+        ):
+            with pytest.raises(
+                DeploymentError, match="production not deployed"
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_provisioned_lakebase_errors(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="k",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available",
+            return_value=False,
+        ):
+            with pytest.raises(
+                DeploymentError, match="requires autoscaling"
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_project_missing(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="k",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available",
+            return_value=True,
+        ):
+            mock_ws.postgres.get_project.side_effect = Exception("not found")
+            with pytest.raises(
+                DeploymentError, match="not an autoscaling project"
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_source_branch_missing(self, mock_ws, good_config):
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value="k",
+        ), patch(
+            "scripts.deploy_local._probe_autoscaling_available",
+            return_value=True,
+        ), patch(
+            "scripts.deploy_local._branch_exists", return_value=False
+        ):
+            mock_ws.postgres.get_project.return_value = MagicMock()
+            with pytest.raises(
+                DeploymentError, match='source branch "production" not found'
+            ):
+                _check_branching_preconditions(mock_ws, good_config)
+
+    def test_preflight_does_not_mutate_on_any_failure(self, mock_ws, good_config):
+        """Confirm no mutating ws.postgres call is made when preflight fails."""
+        from scripts.deploy_local import _check_branching_preconditions
+
+        with patch(
+            "scripts.deploy_local._read_existing_encryption_key",
+            return_value=None,
+        ):
+            with pytest.raises(DeploymentError):
+                _check_branching_preconditions(mock_ws, good_config)
+
+        mock_ws.postgres.create_branch.assert_not_called()
+        mock_ws.postgres.delete_branch.assert_not_called()
+        mock_ws.postgres.create_role.assert_not_called()


### PR DESCRIPTION
## Summary

- Makes `deploy_local.sh {create|update} --env staging` fork an ephemeral Lakebase branch off `branches/production` on every deploy. Staging app connects to the branch with prod's schema (`app_data_prod`) and prod's `GOOGLE_OAUTH_ENCRYPTION_KEY`, so it's a near-mirror of prod for integration testing. Branches auto-expire after 24h via Lakebase TTL — redeploy to get a fresh copy.
- Adds a new `lakebase.branch_from: <env>` field in `deployment.yaml`. When set, staging's schema and encryption-key source are inherited from the named env (validated: same `database_name` required). When absent, deploys behave exactly as before. Prod and dev are unchanged.
- Preflight checks before any mutating Lakebase call: source app deployed, encryption key readable, project is autoscaling, source branch exists. If any fails, no branch or app is mutated.
- On `delete --env staging`, the app is removed; branches are left to TTL-expire (Lakebase's `delete_branch` is async and its purge window blocks fast-ID reuse, so we don't explicitly delete — unique-per-deploy IDs sidestep the collision entirely).
- 23 new unit tests, 3 new test files, 2 existing helpers parameterized with a `branch_name` kwarg defaulting to `production` for back-compat.
- Verified end-to-end against the `tellr-dev` workspace (create → update → back-to-back update → delete).

## Design / plan docs

- Spec: `docs/superpowers/specs/2026-04-24-lakebase-branching-staging-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-lakebase-branching-staging.md`

**Note:** the spec + plan describe an earlier design (fixed branch name `staging`, delete+recreate on each deploy). Two real Databricks API constraints surfaced during integration that forced a change:
1. `BranchSpec` requires one of `expire_time` / `ttl` / `no_expiry`. We use `ttl=86400s`.
2. `delete_branch` is async with an unpredictable purge window; immediate ID reuse fails. We sidestep this with unique `{env}-{unix_timestamp}` IDs and let TTL GC old branches.

The final-commit message (`80462bb0`) explains both. A spec/plan doc reconciliation commit is an easy follow-up.

## Test plan

- [x] Unit tests: 1096 passed, 2 pre-existing failures (`TestGetOrCreateLakebase::test_returns_autoscaling_when_available`, `test_falls_back_when_autoscaling_creation_fails`) that existed on `main` at branch-point and are unrelated to this change.
- [x] Manual integration against `tellr-dev`: `create`, `update`, back-to-back `update`, `delete` all work correctly. Branches have unique IDs per deploy; prod branch untouched; staging app correctly points at its branch's endpoint.

This pull request and its description were written by Isaac.