### PR TITLE
fix(chat): rename reserved 'message' key in logger extra

### DIFF
--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -1672,7 +1672,7 @@ class ChatService:
             if re.search(pattern, lower_message):
                 logger.info(
                     "Detected add slide intent in message",
-                    extra={"message": message[:50], "matched_pattern": pattern},
+                    extra={"user_message": message[:50], "matched_pattern": pattern},
                 )
                 return True
         return False
@@ -1700,7 +1700,7 @@ class ChatService:
             if re.search(pattern, lower_message):
                 logger.info(
                     "Detected 'beginning' position intent - absolute position 0",
-                    extra={"message": message[:50], "matched_pattern": pattern},
+                    extra={"user_message": message[:50], "matched_pattern": pattern},
                 )
                 return ("beginning", 0)
         
@@ -1715,7 +1715,7 @@ class ChatService:
             if re.search(pattern, lower_message):
                 logger.info(
                     "Detected 'before' position intent - relative to selection",
-                    extra={"message": message[:50], "matched_pattern": pattern},
+                    extra={"user_message": message[:50], "matched_pattern": pattern},
                 )
                 return ("before", None)
         
@@ -1746,7 +1746,7 @@ class ChatService:
             if re.search(pattern, lower_message):
                 logger.info(
                     "Detected generation intent",
-                    extra={"message": message[:50], "matched_pattern": pattern},
+                    extra={"user_message": message[:50], "matched_pattern": pattern},
                 )
                 return True
         return False
@@ -1774,7 +1774,7 @@ class ChatService:
             if re.search(pattern, lower_message):
                 logger.info(
                     "Detected explicit replace intent",
-                    extra={"message": message[:50], "matched_pattern": pattern},
+                    extra={"user_message": message[:50], "matched_pattern": pattern},
                 )
                 return True
         return False
@@ -1799,7 +1799,7 @@ class ChatService:
             if re.search(pattern, lower_message):
                 logger.info(
                     "Detected edit intent",
-                    extra={"message": message[:50], "matched_pattern": pattern},
+                    extra={"user_message": message[:50], "matched_pattern": pattern},
                 )
                 return True
         return False

--- a/src/services/agent.py
+++ b/src/services/agent.py
@@ -824,7 +824,7 @@ class SlideGeneratorAgent:
             if re.search(pattern, lower_message):
                 logger.info(
                     "Detected add slide intent",
-                    extra={"message": message[:50], "matched_pattern": pattern},
+                    extra={"user_message": message[:50], "matched_pattern": pattern},
                 )
                 return True
         return False

--- a/tests/unit/test_intent_detectors_log_extra.py
+++ b/tests/unit/test_intent_detectors_log_extra.py
@@ -1,0 +1,76 @@
+"""Regression tests for intent detectors: `extra={"message": ...}` must not
+collide with LogRecord reserved attribute, which would raise
+KeyError("Attempt to overwrite 'message' in LogRecord") and break the
+first chat message in a new deck.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def enable_info_logging():
+    """Force the intent-detector module loggers to INFO.
+
+    In production (LOG_LEVEL=DEBUG/INFO), `logger.info(..., extra={"message": ...})`
+    invokes stdlib makeRecord which rejects reserved keys. In a default test
+    environment, the root logger is WARNING and logger.info is a no-op, which
+    hides the bug. This fixture raises the level so the regression is visible.
+    """
+    loggers = [
+        logging.getLogger("src.api.services.chat_service"),
+        logging.getLogger("src.services.agent"),
+    ]
+    prev_levels = [(lg, lg.level) for lg in loggers]
+    for lg in loggers:
+        lg.setLevel(logging.DEBUG)
+    yield
+    for lg, level in prev_levels:
+        lg.setLevel(level)
+
+
+class TestChatServiceIntentDetectors:
+    """Intent detectors on ChatService must not pass reserved LogRecord keys."""
+
+    @pytest.fixture
+    def service(self):
+        from src.api.services.chat_service import ChatService
+
+        return ChatService()
+
+    def test_detect_generation_intent_does_not_raise(self, service, enable_info_logging):
+        # "Create slides about X" matches _detect_generation_intent, which
+        # previously logged extra={"message": ...} and raised KeyError.
+        assert service._detect_generation_intent("create slides about Q3 sales") is True
+
+    def test_detect_add_intent_does_not_raise(self, service, enable_info_logging):
+        assert service._detect_add_intent("add a slide at the end") is True
+
+    def test_detect_add_position_does_not_raise(self, service, enable_info_logging):
+        pos, _ = service._detect_add_position("add a slide at the beginning")
+        assert pos == "beginning"
+
+    def test_detect_explicit_replace_intent_does_not_raise(self, service, enable_info_logging):
+        assert service._detect_explicit_replace_intent("replace the deck") is True
+
+    def test_detect_edit_intent_does_not_raise(self, service, enable_info_logging):
+        assert service._detect_edit_intent("change slide 3") is True
+
+
+class TestAgentIntentDetector:
+    """SlideGeneratorAgent._detect_add_slide_intent must not pass reserved keys."""
+
+    def test_agent_detect_add_intent_does_not_raise(self, enable_info_logging):
+        # Call the unbound method directly — it's a pure function of (self, message)
+        # and doesn't touch any agent state.
+        from src.services.agent import SlideGeneratorAgent
+
+        assert (
+            SlideGeneratorAgent._detect_add_intent(
+                None, "add a new slide about revenue"
+            )
+            is True
+        )


### PR DESCRIPTION
## Summary
- Intent detectors in `chat_service` and `agent` passed `extra={"message": message[:50], ...}` to `logger.info`. Python's `logging.Logger.makeRecord` rejects any `extra` key colliding with a reserved `LogRecord` attribute (`message` is reserved) and raises `KeyError("Attempt to overwrite 'message' in LogRecord")`, aborting the first chat message of a new deck.
- Only reproduces when a detection regex matches *and* the logger's effective level is INFO or lower. Local dev defaults to WARNING (bug hidden); staging/dev deploys run `LOG_LEVEL=DEBUG`, so the bug is live — hence intermittent.
- Renamed the extra key to `user_message` at all 7 sites (6 in `chat_service.py`, 1 in `agent.py`).
- Added `tests/unit/test_intent_detectors_log_extra.py` with a fixture that forces the detector modules' loggers to DEBUG so the bug stays caught under the default WARNING test env.

## Test plan
- [x] New regression test reproduces the exact `KeyError` before the fix; all 6 cases pass after.
- [x] `pytest tests/unit/test_agent.py tests/unit/test_chat_service_no_singleton.py` — 18 passed.
- [ ] Deploy to staging and send a new-deck message ("create slides about X") — no chat error in the browser console.

This pull request and its description were written by Isaac.