### PR TITLE
chore(release): bump packages to 0.2.8

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.2.7"
+version = "0.2.8"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.2.7"
+version = "0.2.8"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump `databricks-tellr` and `databricks-tellr-app` from `0.2.7` → `0.2.8`
- Both packages have been published to TestPyPI for pre-release validation

## TestPyPI links
- https://test.pypi.org/project/databricks-tellr/0.2.8/
- https://test.pypi.org/project/databricks-tellr-app/0.2.8/

## Production release
Merging this PR does not publish to production PyPI. To release, push a matching tag after merge:

```bash
git tag v0.2.8
git push origin v0.2.8
```

This triggers `.github/workflows/publish.yml`, which validates the tag matches both `pyproject.toml` versions and publishes to PyPI via Trusted Publishing.

## Test plan
- [x] Both packages built cleanly (sdist + wheel)
- [x] Uploaded to TestPyPI successfully
- [ ] (Optional) Smoke install from TestPyPI:
  ```bash
  pip install --index-url https://test.pypi.org/simple/ \
    --extra-index-url https://pypi.org/simple/ \
    databricks-tellr==0.2.8 databricks-tellr-app==0.2.8
  ```