### PR TITLE
fix(mcp): accept POST /mcp without trailing slash

### DIFF
--- a/docs/superpowers/plans/2026-04-29-tellr-mcp-trailing-slash.md
+++ b/docs/superpowers/plans/2026-04-29-tellr-mcp-trailing-slash.md
@@ -1,0 +1,504 @@
+# Tellr MCP — accept `/mcp` and `/mcp/` interchangeably — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the `POST /mcp` (no trailing slash) failure mode by adding an ASGI middleware that rewrites the request scope's path to `/mcp/` before route resolution, so MCP clients that omit the slash succeed in a single round-trip instead of receiving 405 (production, with SPA catch-all) or 307 (tests, without SPA catch-all).
+
+**Architecture:** One small `@app.middleware("http")` in `src/api/main.py`, registered immediately after the `FastAPI(...)` constructor. The middleware checks for an exact-equality match on `/mcp` with a non-`GET` method and rewrites `scope["path"]` and `scope["raw_path"]` to `/mcp/` before delegating to `call_next`. Then one new integration test asserts both URL forms produce identical 200 JSON-RPC responses, plus stale-comment cleanup and client-facing doc updates.
+
+**Tech Stack:** FastAPI / Starlette ASGI middleware, FastMCP (`mcp.server.fastmcp`), pytest with FastAPI `TestClient`, Python 3.11.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-tellr-mcp-trailing-slash-design.md`
+
+---
+
+## File Map
+
+| File | Change | Why |
+|---|---|---|
+| `src/api/main.py` | Modify (add middleware after `app = FastAPI(...)` block ~line 219) | Adds the ASGI path rewrite. |
+| `tests/integration/test_mcp_endpoint.py` | Modify (add new test, fix stale module docstring & comment near `MCP_PATH`) | New regression guard; corrects two stale comments that asserted 307 behavior. |
+| `docs/technical/mcp-server.md` | Modify (sections 1, 6, "Common gotchas", troubleshooting table) | Update protocol-level reference: both forms are accepted, no canonical-slash rule. |
+| `docs/technical/mcp-integration-guide.md` | Modify ("Trailing slash on the URL" gotcha) | Update integrator-facing how-to: the slash is no longer required. |
+| `scripts/mcp_smoke/mcp_smoke_httpx.py` | Modify (one comment near `MCP_PATH_SUFFIX`) | One-line note that the slash is optional post-fix; URL value unchanged. |
+| `scripts/mcp_smoke/README.md` | Modify ("Notes" bullet about the trailing slash) | Same. |
+| `mcp-test-client/app.py` | Modify (one comment near `mcp_url = f"{tellr_base_url}/mcp/"`) | Same. |
+
+Each task below produces a self-contained commit. Order matters: Task 1 lands the failing test, Task 2 lands the middleware (turning the test green), then Tasks 3–5 are pure documentation/comment cleanup that depend on Tasks 1–2 having merged.
+
+---
+
+## Task 1: Add the failing regression test
+
+**Files:**
+- Modify: `tests/integration/test_mcp_endpoint.py` (add new test function at end of file)
+
+- [ ] **Step 1: Open `tests/integration/test_mcp_endpoint.py` and append the new test at the bottom of the file.**
+
+Add this function after the last existing test in the file (file currently ends at the last `def test_*` definition; place the new test below it, with two blank lines between definitions to match the existing PEP-8 spacing):
+
+```python
+def test_mcp_endpoint_accepts_both_slash_forms(client, mock_identity_client):
+    """Regression guard: POST /mcp and POST /mcp/ behave identically.
+
+    The SPA catch-all (``@app.get("/{full_path:path}")`` added by
+    ``_mount_frontend`` in production) used to make ``POST /mcp`` return
+    405 with ``allow: GET``, since Starlette's ``Mount`` cannot tell the
+    outer router which methods FastMCP accepts. In tests
+    ``IS_PRODUCTION`` is false so ``_mount_frontend`` doesn't run and
+    Mount itself returns a 307 redirect for the bare path. The
+    ``normalize_mcp_path`` middleware in ``main.py`` rewrites
+    ``/mcp -> /mcp/`` in the ASGI scope so both forms reach the FastMCP
+    sub-app's POST handler in a single round-trip.
+
+    ``follow_redirects=False`` is critical: without it, ``TestClient``
+    would silently follow a 307 from ``/mcp`` to ``/mcp/`` and the test
+    would pass even if the middleware regressed.
+    """
+    # Run the standard MCP handshake against the canonical slashed path
+    # first so any FastMCP-internal state (none today, since stateless)
+    # mirrors what the existing tests do.
+    _initialize_session(client)
+
+    body = _jsonrpc("tools/list", rid=2)
+
+    no_slash = client.post(
+        "/mcp",
+        headers=_mcp_headers(),
+        json=body,
+        follow_redirects=False,
+    )
+    with_slash = client.post(
+        "/mcp/",
+        headers=_mcp_headers(),
+        json=body,
+        follow_redirects=False,
+    )
+
+    assert no_slash.status_code == 200, (
+        f"POST /mcp should return 200 after the middleware rewrite, "
+        f"got {no_slash.status_code}: {no_slash.text!r}"
+    )
+    assert with_slash.status_code == 200, with_slash.text
+
+    no_slash_body = _decode_mcp_response(no_slash)
+    with_slash_body = _decode_mcp_response(with_slash)
+
+    no_slash_tools = {
+        t["name"] for t in no_slash_body["result"]["tools"]
+    }
+    with_slash_tools = {
+        t["name"] for t in with_slash_body["result"]["tools"]
+    }
+    assert no_slash_tools == with_slash_tools, (
+        f"tool sets differ between paths: "
+        f"no_slash={no_slash_tools} with_slash={with_slash_tools}"
+    )
+    assert {
+        "create_deck", "get_deck_status", "edit_deck", "get_deck",
+    } <= no_slash_tools, f"unexpected tool set: {no_slash_tools}"
+```
+
+- [ ] **Step 2: Run the test to confirm it fails for the right reason**
+
+Run: `pytest tests/integration/test_mcp_endpoint.py::test_mcp_endpoint_accepts_both_slash_forms -v`
+
+Expected: **FAIL** with an assertion error like `POST /mcp should return 200 after the middleware rewrite, got 307: ''` (the test environment hits Mount's built-in slash redirect because `_mount_frontend` doesn't run there). If the failure is anything else — module import error, fixture not found, redirect actually followed — investigate before continuing; the test must fail at the `no_slash.status_code == 200` assertion specifically, otherwise the middleware in Task 2 won't be exercising the right path.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/integration/test_mcp_endpoint.py
+git commit -m "$(cat <<'EOF'
+test(mcp): assert /mcp and /mcp/ behave identically
+
+Adds a failing regression guard for the trailing-slash equivalence the
+next commit introduces. follow_redirects=False ensures TestClient
+surfaces any 307/405 instead of silently following.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+Verify: `git log -1 --stat` shows exactly one file changed (`tests/integration/test_mcp_endpoint.py`).
+
+---
+
+## Task 2: Add the path-rewrite middleware
+
+**Files:**
+- Modify: `src/api/main.py` (insert middleware between the `FastAPI(...)` constructor and the `_resolve_frontend_dist` helper)
+
+- [ ] **Step 1: Insert the middleware**
+
+Open `src/api/main.py`. Locate this block (around line 213-220):
+
+```python
+# Initialize FastAPI app
+app = FastAPI(
+    title="AI Slide Generator API",
+    description="Generate presentation slides from natural language using AI",
+    version="0.3.0 (Phase 3 - Databricks Apps)",
+    lifespan=lifespan,
+)
+```
+
+Insert the following **immediately after the closing `)` of the `FastAPI(...)` call**, before `def _resolve_frontend_dist():`. Leave one blank line before and after the new middleware:
+
+```python
+
+
+@app.middleware("http")
+async def normalize_mcp_path(request: Request, call_next):
+    """Make POST /mcp behave like POST /mcp/.
+
+    The SPA catch-all (``@app.get("/{full_path:path}")`` added by
+    ``_mount_frontend``) intercepts non-GET requests to ``/mcp`` and
+    causes Starlette to return 405 instead of routing to the FastMCP
+    Mount. Rewriting the ASGI scope path before route resolution
+    sidesteps that interaction and avoids emitting a 307 the client
+    has to follow (which can drop ``Authorization`` or method-downgrade
+    in misbehaving HTTP clients — Claude Code v2.1.123 via stdio→HTTP
+    proxy was the original report).
+
+    GET is left alone so ``/mcp`` continues to render the SPA in a
+    browser. The match is exact so ``/mcp/``, ``/mcp/anything``, and
+    ``/mcp-something`` are all unaffected; query strings live in
+    ``scope["query_string"]`` and are not touched.
+    """
+    if request.url.path == "/mcp" and request.method != "GET":
+        request.scope["path"] = "/mcp/"
+        request.scope["raw_path"] = b"/mcp/"
+    return await call_next(request)
+```
+
+`Request` is already imported at the top of the file (`from fastapi import FastAPI, HTTPException, Request`), so no new imports are needed. Verify by grepping:
+
+```bash
+grep -n "^from fastapi" src/api/main.py
+```
+
+Expected: a line containing `Request` in the `from fastapi import ...` list.
+
+- [ ] **Step 2: Run the regression test to confirm it now passes**
+
+Run: `pytest tests/integration/test_mcp_endpoint.py::test_mcp_endpoint_accepts_both_slash_forms -v`
+
+Expected: **PASS**.
+
+- [ ] **Step 3: Run the full MCP integration suite to confirm nothing else broke**
+
+Run: `pytest tests/integration/test_mcp_endpoint.py -v`
+
+Expected: all tests **PASS**. The existing tests use `MCP_PATH = "/mcp/"` (slashed form) which the middleware does not touch, so they should be unaffected.
+
+- [ ] **Step 4: Commit the middleware**
+
+```bash
+git add src/api/main.py
+git commit -m "$(cat <<'EOF'
+fix(mcp): accept POST /mcp without trailing slash
+
+Adds an ASGI path-rewrite middleware so /mcp and /mcp/ are accepted
+interchangeably. Resolves the production 405 reported by Claude Code
+v2.1.123 callers whose HTTP layer doesn't follow / can't follow the
+implicit slash redirect. See
+docs/superpowers/specs/2026-04-29-tellr-mcp-trailing-slash-design.md.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+Verify: `git log -1 --stat` shows exactly one file changed (`src/api/main.py`).
+
+---
+
+## Task 3: Fix stale comments in the integration test file
+
+**Files:**
+- Modify: `tests/integration/test_mcp_endpoint.py` (module docstring lines 22-25; the `MCP_PATH` comment lines 40-44)
+
+These two comments still claim "POST /mcp returns a 307 redirect" — true historically, true in tests today, but no longer the user-facing behavior thanks to the middleware. Replace them so a future reader doesn't get confused.
+
+- [ ] **Step 1: Update the module docstring**
+
+In `tests/integration/test_mcp_endpoint.py`, replace lines 22-25 (the second numbered gotcha):
+
+Old:
+```python
+2. ``POST /mcp`` returns a 307 redirect to ``/mcp/``. Hitting the
+   trailing-slash path directly avoids TestClient's redirect handling
+   (which may or may not follow redirects automatically depending on
+   the httpx version).
+```
+
+New:
+```python
+2. The ``normalize_mcp_path`` middleware in ``src/api/main.py`` rewrites
+   ``POST /mcp`` to ``POST /mcp/`` in the ASGI scope so both forms reach
+   the FastMCP sub-app. The test fixture here doesn't run
+   ``_mount_frontend`` (production-only), so without the middleware
+   ``POST /mcp`` would 307; with the middleware it returns 200 directly.
+   Existing tests still use ``MCP_PATH = "/mcp/"`` for stability —
+   ``test_mcp_endpoint_accepts_both_slash_forms`` is the dedicated
+   regression guard for the no-slash case.
+```
+
+- [ ] **Step 2: Update the `MCP_PATH` constant comment**
+
+In the same file, replace lines 40-44:
+
+Old:
+```python
+# Trailing slash: the FastMCP streamable-HTTP transport internally
+# mounts its route at "/", and main.py mounts that sub-app at "/mcp".
+# External POST to "/mcp" returns a 307 to "/mcp/"; going straight to
+# the slashed form bypasses that round trip.
+MCP_PATH = "/mcp/"
+```
+
+New:
+```python
+# FastMCP's streamable-HTTP transport mounts its route at "/", and
+# main.py mounts that sub-app at "/mcp". External clients can POST to
+# either ``/mcp`` or ``/mcp/`` thanks to the ``normalize_mcp_path``
+# middleware. Existing tests pin to the slashed form for stability;
+# ``test_mcp_endpoint_accepts_both_slash_forms`` covers the no-slash
+# case explicitly.
+MCP_PATH = "/mcp/"
+```
+
+- [ ] **Step 3: Run the test suite to confirm nothing regressed**
+
+Run: `pytest tests/integration/test_mcp_endpoint.py -v`
+
+Expected: all tests **PASS** (this task changes only comments, no behavior).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_mcp_endpoint.py
+git commit -m "$(cat <<'EOF'
+docs(test): refresh stale 307 comments after slash-rewrite middleware
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+## Task 4: Update client-facing technical docs
+
+**Files:**
+- Modify: `docs/technical/mcp-server.md` (lines 41, 47, 525, 543, plus URL examples on lines 69, 102, 112, 126, 351, 370, 437)
+- Modify: `docs/technical/mcp-integration-guide.md` (line 404 gotcha; URL examples on lines 123, 250, 261, 296, 308, 352, 356, 365, 386, 402, 428)
+
+Both forms are now accepted. We pick **`/mcp` (no slash)** as the documented canonical URL going forward — it's the form most CLIs default to when copying URLs around. Existing client code using `/mcp/` keeps working; we are not breaking anyone, just retiring the "mandatory slash" claim.
+
+- [ ] **Step 1: Update `docs/technical/mcp-server.md`**
+
+In the URL row of the table around line 41:
+
+Old:
+```
+| URL | `https://<your-tellr-app-url>/mcp/` |
+```
+
+New:
+```
+| URL | `https://<your-tellr-app-url>/mcp` (or `/mcp/` — both accepted) |
+```
+
+Replace the "Mandatory trailing slash" callout around line 47:
+
+Old:
+```
+**Mandatory trailing slash.** `POST /mcp` returns `307 Temporary Redirect` to `/mcp/`. Always POST to `/mcp/` directly — the redirect will strip `POST` semantics with some clients.
+```
+
+New:
+```
+**Both `/mcp` and `/mcp/` are accepted.** A path-rewrite middleware in `src/api/main.py` makes the two forms behave identically — single round-trip, no redirect. Documented examples below use the no-slash form; existing clients hard-coded to `/mcp/` continue to work unchanged.
+```
+
+In the "Common gotchas" table around line 525:
+
+Old row:
+```
+| Trailing slash | Always POST to `/mcp/`. `POST /mcp` returns `307 Temporary Redirect`, which some HTTP clients silently downgrade to `GET`. |
+```
+
+New row:
+```
+| Trailing slash | Either `/mcp` or `/mcp/` works. A middleware rewrites the bare path before routing. |
+```
+
+In the troubleshooting table around line 543:
+
+Old row:
+```
+| Client receives HTML instead of JSON on the first POST | Target URL is `/mcp` (no trailing slash) and the client followed the 307 to a GET | Always POST to `/mcp/` directly |
+```
+
+New row:
+```
+| Client receives HTML instead of JSON on the first POST | Either the SPA catch-all is intercepting (deployed app missing the path-rewrite middleware) or the URL points at the wrong host. | Verify `MCP server mounted at /mcp` appears in the app logs, and curl `POST /mcp` directly with `Accept: application/json, text/event-stream` to confirm a JSON-RPC envelope returns. |
+```
+
+For the URL examples in this file (lines 69, 102, 112, 126, 351, 370, 437), drop the trailing slash to match the new canonical form:
+
+```bash
+# In docs/technical/mcp-server.md only:
+sed -i '' 's|<your-tellr-app-url>/mcp/|<your-tellr-app-url>/mcp|g' docs/technical/mcp-server.md
+sed -i '' 's|TELLR_URL}/mcp/|TELLR_URL}/mcp|g' docs/technical/mcp-server.md
+```
+
+After running, quickly read the diff (`git diff docs/technical/mcp-server.md`) and confirm only URL strings changed — no prose accidentally touched.
+
+- [ ] **Step 2: Update `docs/technical/mcp-integration-guide.md`**
+
+Replace the "Trailing slash on the URL" callout around line 404:
+
+Old:
+```
+**Trailing slash on the URL.** Always POST to `/mcp/` (with slash). `/mcp` (no slash) returns a 307 redirect that some clients silently downgrade to GET and break on. The `claude mcp add` command sometimes strips the trailing slash — double-check with `claude mcp list`.
+```
+
+New:
+```
+**Trailing slash on the URL.** Both `/mcp` and `/mcp/` work; a path-rewrite middleware in tellr accepts either. The `claude mcp add` command sometimes strips the slash — that's now harmless. (Historical note: deployments before April 2026 returned 405 for `/mcp` with no slash; if you're integrating against a pinned-old build, append the slash.)
+```
+
+For the URL examples in this file (lines 123, 250, 261, 296, 308, 352, 356, 365, 386, 402, 428), drop the trailing slash:
+
+```bash
+# In docs/technical/mcp-integration-guide.md only:
+sed -i '' 's|tellr-app-url>/mcp/|tellr-app-url>/mcp|g' docs/technical/mcp-integration-guide.md
+sed -i '' 's|tellr_base}/mcp/|tellr_base}/mcp|g' docs/technical/mcp-integration-guide.md
+sed -i '' "s|app's \`/mcp/\` endpoint|app's \`/mcp\` endpoint|g" docs/technical/mcp-integration-guide.md
+sed -i '' "s|external \`/mcp/\` calls|external \`/mcp\` calls|g" docs/technical/mcp-integration-guide.md
+sed -i '' "s|\`/mcp/\` still returns 403|\`/mcp\` still returns 403|g" docs/technical/mcp-integration-guide.md
+```
+
+Read the diff (`git diff docs/technical/mcp-integration-guide.md`) and verify only URL/path strings changed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/technical/mcp-server.md docs/technical/mcp-integration-guide.md
+git commit -m "$(cat <<'EOF'
+docs(mcp): document /mcp and /mcp/ both being accepted
+
+Refreshes the protocol reference and integration guide for the
+path-rewrite middleware. Picks /mcp (no slash) as the canonical
+documented form going forward; existing /mcp/ examples in client
+code remain valid.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+---
+
+## Task 5: Refresh smoke-script and test-client comments
+
+**Files:**
+- Modify: `scripts/mcp_smoke/mcp_smoke_httpx.py` (lines 25-27 comment)
+- Modify: `scripts/mcp_smoke/README.md` (the trailing-slash bullet under "Notes")
+- Modify: `mcp-test-client/app.py` (line 140 comment / nearby docstring)
+
+These three files keep using `/mcp/` for now. We don't change the URLs — just the comments — so the smoke script continues exercising the historically-broken path until we have post-deploy confidence in the middleware.
+
+- [ ] **Step 1: `scripts/mcp_smoke/mcp_smoke_httpx.py`**
+
+Replace lines 25-27:
+
+Old:
+```python
+# The MCP endpoint path has a mandatory trailing slash; POST /mcp
+# returns 307 -> /mcp/.
+MCP_PATH_SUFFIX = "/mcp/"
+```
+
+New:
+```python
+# As of 2026-04-29 the tellr server accepts both ``/mcp`` and ``/mcp/``
+# (path-rewrite middleware in ``src/api/main.py``). We keep the slashed
+# form here so the smoke test continues to exercise the historical path
+# real users have hard-coded.
+MCP_PATH_SUFFIX = "/mcp/"
+```
+
+- [ ] **Step 2: `scripts/mcp_smoke/README.md`**
+
+Replace the existing "trailing slash" bullet under "Notes":
+
+Old:
+```
+- The MCP endpoint path has a mandatory trailing slash. The script
+  uses `/mcp/` directly to avoid the 307 redirect that `POST /mcp`
+  returns.
+```
+
+New:
+```
+- The tellr server accepts both `/mcp` and `/mcp/`. The script uses
+  `/mcp/` so it continues to cover the historical client path; either
+  form works against current deployments.
+```
+
+- [ ] **Step 3: `mcp-test-client/app.py`**
+
+The relevant code is around line 140:
+
+```python
+mcp_url = f"{tellr_base_url}/mcp/"
+```
+
+Add a one-line comment immediately above that assignment:
+
+```python
+    # tellr accepts both ``/mcp`` and ``/mcp/``; we keep the slashed
+    # form here to match the test-client's pre-2026-04-29 baseline.
+    mcp_url = f"{tellr_base_url}/mcp/"
+```
+
+(Note: `mcp-test-client/app.py` lives in the sibling directory `mcp-test-client/`, not under `ai-slide-generator/`. Edit it from its own working directory: `/Users/robert.whiffin/Documents/slide-gen-branch-eval/mcp-test-client/app.py`. If that file has its own git repo, commit it there with its own commit message; if it shares the tellr repo, fold it into the same commit below.)
+
+- [ ] **Step 4: Commit**
+
+If `mcp-test-client/app.py` is part of the tellr repo, run:
+
+```bash
+git add scripts/mcp_smoke/mcp_smoke_httpx.py scripts/mcp_smoke/README.md ../mcp-test-client/app.py
+git commit -m "$(cat <<'EOF'
+docs(mcp): note both slash forms work in smoke + test-client
+
+Comment-only update; URLs unchanged so historical paths still get
+exercised by the smoke flow.
+
+Co-authored-by: Isaac
+EOF
+)"
+```
+
+If `mcp-test-client/` is a separate repo, run two commits — one in each repo — with the same message body.
+
+Verify: `git log --oneline -5` shows the five commits from Tasks 1–5 in order.
+
+---
+
+## Self-review
+
+The plan covers every spec section:
+
+- **Component 1 (middleware)** — Task 2.
+- **Component 2 (regression test)** — Task 1 (failing) + Task 2 (passing) + Task 3 (stale comments).
+- **Component 3 (documentation updates)** — Task 4 (`mcp-server.md`, `mcp-integration-guide.md`) + Task 5 (smoke + test-client comments).
+- **Verification plan** — Steps 2–3 of Task 2 cover the pre-merge `pytest` run; the spec's post-deploy manual check is operational and lives in the spec itself, not in this implementation plan.
+
+No placeholders. Method/property names match across tasks (`normalize_mcp_path` everywhere, `MCP_PATH` left as `/mcp/`, no name drift between test fixtures and code under test). Each task is independently committable. Every code change shows the actual code; every command shows the expected output.

--- a/docs/superpowers/specs/2026-04-29-tellr-mcp-trailing-slash-design.md
+++ b/docs/superpowers/specs/2026-04-29-tellr-mcp-trailing-slash-design.md
@@ -1,0 +1,223 @@
+# Tellr MCP — accept `/mcp` and `/mcp/` interchangeably
+
+**Date:** 2026-04-29
+**Status:** Design (pending implementation)
+
+## Problem
+
+Tellr's MCP endpoint is mounted at `/mcp` via FastAPI's `app.mount`. Today
+clients that send `POST /mcp` (no trailing slash) receive
+`HTTP 405 Method Not Allowed, allow: GET` instead of either a successful
+JSON-RPC response or a redirect to `/mcp/`. Clients that send `POST /mcp/`
+(with the slash) work as expected.
+
+This has bitten at least one production user (Claude Code v2.1.123 invoked
+via a stdio→HTTP proxy using `databricks-sdk` external-browser OAuth and
+`urllib.request`). The user's stdio→HTTP layer surfaces the 405 as a
+JSON-RPC connection error and stops; there is no Location header to
+follow. The user worked around it by adding the trailing slash to their
+`--server-url`. Other clients (Cursor, Databricks UC HTTP-connection
+proxy, Genie clients) have not been tested by us against this endpoint
+but are at risk of the same failure.
+
+## Root cause
+
+When `_mount_frontend` runs during lifespan startup (production builds
+only), it registers a SPA catch-all:
+
+```python
+@app.get("/{full_path:path}")
+async def serve_spa(full_path: str): ...
+```
+
+This route claims every URL — including `/mcp` — for `GET` only. When a
+`POST /mcp` arrives:
+
+1. FastAPI's router considers the Mount at `/mcp`. Starlette's `Mount`
+   matches the path (the prefix matches), strips the prefix, and forwards
+   `path=""` to FastMCP's sub-app, whose only route is `/`. The empty
+   path does not match `/`, so the sub-app does not handle the request.
+2. The router then considers the SPA catch-all. Path matches, but the
+   route is `GET`-only.
+3. With at least one path-matching candidate registered for `GET`, the
+   router returns `405 Method Not Allowed, allow: GET` rather than `404`.
+
+Because the redirect-on-trailing-slash behavior in Starlette's `Mount` is
+only emitted when no other route matches the path at all, the SPA
+catch-all suppresses it. There is no 307 for clients to follow.
+
+This also explains why the existing integration test
+(`tests/integration/test_mcp_endpoint.py`) uses `MCP_PATH = "/mcp/"`
+directly — the comment at lines 22-23 claims the bare path "returns a
+307 redirect"; that comment was written before the SPA catch-all started
+intercepting and is now stale.
+
+## Decision
+
+Add a small ASGI-level path-rewrite middleware that, when it sees a
+non-`GET` request to exactly `/mcp`, rewrites the request scope's path
+to `/mcp/` before route resolution runs. Routing then proceeds as if
+the client had sent the slash from the start. The Mount forwards
+`path="/"` to FastMCP, which handles the request normally. The client
+receives a single `200` JSON-RPC response, no redirect, no method
+downgrade, no header re-attachment.
+
+This was chosen over two alternatives:
+
+- **Return a 307 redirect for the bare path.** Still a redirect; clients
+  that drop `Authorization` on redirect (a known HTTP-library
+  misbehavior) or downgrade `307`→`303` (a known HTTP/1.0 fallback)
+  would still fail. Doesn't fix the brittleness, just documents it.
+- **Re-mount FastMCP at the root with `streamable_http_path = "/mcp"`.**
+  Pulls FastMCP into the top-level app namespace, increases collision
+  risk with other routes, and is a much bigger refactor for the same
+  end-state.
+
+The middleware approach is the smallest change that produces a single
+round-trip success path for both URL forms.
+
+## Implementation
+
+### Component 1 — middleware in `src/api/main.py`
+
+Registered immediately after the `FastAPI(...)` constructor, before any
+routers or `app.mount(...)` calls. Keeping it adjacent to app
+construction makes it easy to find on a future read; for an `http`
+middleware the registration order versus routes does not matter
+functionally.
+
+```python
+@app.middleware("http")
+async def normalize_mcp_path(request: Request, call_next):
+    """Make POST /mcp behave like POST /mcp/.
+
+    The SPA catch-all (`@app.get("/{full_path:path}")` added by
+    `_mount_frontend`) intercepts non-GET requests to /mcp and causes
+    Starlette to return 405 instead of routing to the FastMCP Mount.
+    Rewriting the ASGI scope path before route resolution sidesteps
+    that interaction and avoids emitting a 307 the client has to
+    follow (which can drop Authorization or method-downgrade in
+    misbehaving HTTP clients).
+
+    GET is left alone so /mcp continues to render the SPA in a browser.
+    """
+    if request.url.path == "/mcp" and request.method != "GET":
+        request.scope["path"] = "/mcp/"
+        request.scope["raw_path"] = b"/mcp/"
+    return await call_next(request)
+```
+
+The match is exact (`== "/mcp"`), so `/mcp/`, `/mcp/anything`, and
+`/mcp-something` are all unaffected. Query strings live in
+`scope["query_string"]` and pass through untouched.
+
+### Component 2 — regression test in `tests/integration/test_mcp_endpoint.py`
+
+One new test, plus correcting the stale comment at lines 22-23. The
+test runs through the existing `TestClient` fixture and uses the
+existing `_mcp_headers` and `_decode_mcp_response` helpers.
+
+```python
+def test_mcp_endpoint_accepts_both_slash_forms(client):
+    """Regression guard: POST /mcp and POST /mcp/ behave identically.
+
+    The SPA catch-all (`@app.get("/{full_path:path}")`) used to make POST
+    /mcp return 405 with allow: GET, since Starlette's Mount can't tell
+    the outer router which methods FastMCP accepts. The normalize_mcp_path
+    middleware in main.py rewrites /mcp -> /mcp/ in the ASGI scope so both
+    forms reach the FastMCP sub-app's POST handler.
+    """
+    init = client.post(
+        "/mcp/", headers=_mcp_headers(), json=_init_payload(),
+        follow_redirects=False,
+    )
+    assert init.status_code == 200
+
+    body = {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+
+    no_slash = client.post(
+        "/mcp", headers=_mcp_headers(), json=body,
+        follow_redirects=False,
+    )
+    with_slash = client.post(
+        "/mcp/", headers=_mcp_headers(), json=body,
+        follow_redirects=False,
+    )
+
+    assert no_slash.status_code == 200
+    assert with_slash.status_code == 200
+    no_slash_tools = {
+        t["name"]
+        for t in _decode_mcp_response(no_slash)["result"]["tools"]
+    }
+    with_slash_tools = {
+        t["name"]
+        for t in _decode_mcp_response(with_slash)["result"]["tools"]
+    }
+    assert no_slash_tools == with_slash_tools
+    assert {
+        "create_deck", "get_deck_status", "edit_deck", "get_deck"
+    } <= no_slash_tools
+```
+
+Two things make this test load-bearing:
+
+- `follow_redirects=False` — if a future change reintroduces a `307`,
+  `308`, or `405` for the bare path, the status assertion fails loudly
+  rather than silently following a redirect.
+- Asserting equality of the two tool sets (not just non-empty) catches
+  the case where one path resolves to a different handler than the
+  other.
+
+### Component 3 — documentation updates
+
+Two doc files reference the trailing slash today:
+
+- `docs/technical/mcp-server.md`
+- `docs/technical/mcp-integration-guide.md`
+
+Both should be updated to:
+
+- State that **both `/mcp` and `/mcp/` are accepted**, either form works.
+- Pick `/mcp` (no slash) as the documented canonical URL going forward,
+  since it is the form most CLIs and SDKs default to. Existing client
+  code that hard-codes `/mcp/` keeps working — no breaking change.
+
+The smoke script (`scripts/mcp_smoke/mcp_smoke_httpx.py`) and the
+test-client app (`mcp-test-client/app.py`) keep using `/mcp/` for now,
+since both deliberately exercise the path the historical clients used.
+Their docstrings get a one-line note that the slash is no longer
+required.
+
+## What this fix does NOT change
+
+- FastMCP itself (no version bump, no monkey-patch).
+- The Mount path, prefix, or `streamable_http_path` setting.
+- Authentication (`mcp_auth.mcp_auth_scope`, OBO/PAT flows).
+- Stateless-vs-stateful HTTP transport (still stateless per
+  `mcp_server.py:141`).
+- Behavior of the SPA catch-all for browser GETs to `/mcp`.
+
+The blast radius is: requests with method ≠ `GET` and path exactly
+`/mcp` (no slash). Everything else is byte-identical to current
+behavior.
+
+## Verification plan
+
+Pre-merge (CI):
+
+1. `pytest tests/integration/test_mcp_endpoint.py -v` passes locally
+   and in CI.
+
+Post-deploy (manual, one-time):
+
+1. Run `mcp_smoke_httpx.py` against staging with `MCP_PATH_SUFFIX`
+   temporarily set to `"/mcp"` (no slash). Expect success identical to
+   the current `"/mcp/"` run.
+2. Revert the smoke script change so it continues to exercise the
+   historical path. The CI test now covers the new path.
+
+## Open questions
+
+None — the failure mode is reproduced and explained, the fix is
+targeted, and the test asserts equivalence of both URL forms.

--- a/docs/technical/mcp-integration-guide.md
+++ b/docs/technical/mcp-integration-guide.md
@@ -401,7 +401,7 @@ For unattended runs longer than an hour (CI, background agents):
 
 **App-level access is a separate check.** OAuth authenticates *who you are*; the Apps proxy additionally checks you're on the app's user list. If sign-in succeeds but `/mcp` still returns 403, ask the app owner to grant your user access.
 
-**Trailing slash on the URL.** Both `/mcp` and `/mcp/` work; a path-rewrite middleware in tellr accepts either. The `claude mcp add` command sometimes strips the slash — that's now harmless. (Historical note: deployments before April 2026 returned 405 for `/mcp` with no slash; if you're integrating against a pinned-old build, append the slash.)
+**Trailing slash on the URL.** Both `/mcp` and `/mcp/` work; a path-rewrite middleware in tellr accepts either. The `claude mcp add` command sometimes strips the slash — that's fine. (Older builds returned `405 Method Not Allowed` for `/mcp` without a slash; if you're hitting that against a pinned-old deployment, add the slash.)
 
 **Handshake.** After `initialize`, MCP requires a `notifications/initialized` before any `tools/*`. Official MCP clients handle this for you; if you're writing raw HTTP, don't skip it.
 

--- a/docs/technical/mcp-integration-guide.md
+++ b/docs/technical/mcp-integration-guide.md
@@ -120,7 +120,7 @@ def _open_session(client: httpx.Client, url: str) -> dict:
 
 def generate_deck(tellr_base: str, prompt_text: str, status) -> dict:
     """Submit create_deck → poll get_deck_status → return ready payload."""
-    mcp = f"{tellr_base}/mcp/"
+    mcp = f"{tellr_base}/mcp"
     correlation = f"my-app-{uuid.uuid4().hex[:8]}"
 
     # No Authorization header, no x-forwarded-access-token — the proxy
@@ -247,7 +247,7 @@ Whichever path you pick, the one thing you **can't** do is use a PAT — see §3
 
 ### 3.1 Auth constraint: OAuth U2M only, not PATs
 
-**Verified gotcha:** even a PAT that works against workspace APIs returns HTTP 401 from an app's `/mcp/` endpoint. The Apps proxy has its own authorization layer and only accepts OAuth U2M tokens for app-scoped access. Concretely:
+**Verified gotcha:** even a PAT that works against workspace APIs returns HTTP 401 from an app's `/mcp` endpoint. The Apps proxy has its own authorization layer and only accepts OAuth U2M tokens for app-scoped access. Concretely:
 
 ```bash
 # PAT against workspace API — works:
@@ -258,7 +258,7 @@ curl -sS -o /dev/null -w "%{http_code}\n" \
 
 # Same PAT against the tellr app's MCP endpoint — rejected:
 curl -sS -o /dev/null -w "%{http_code}\n" -X POST \
-  "https://<tellr-app-url>/mcp/" \
+  "https://<tellr-app-url>/mcp" \
   -H "Authorization: Bearer dapi<...>" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
@@ -293,7 +293,7 @@ First-tool-call UX: a browser tab pops open for consent. Afterwards, invisible.
 *Claude Code:*
 
 ```bash
-claude mcp add --transport http tellr "https://<tellr-app-url>/mcp/"
+claude mcp add --transport http tellr "https://<tellr-app-url>/mcp"
 # (no --header flag — that's what triggers the OAuth flow on first use)
 ```
 
@@ -305,7 +305,7 @@ Then in a Claude session, invoke any tellr tool (or run `/mcp`); a browser windo
 {
   "mcpServers": {
     "tellr": {
-      "url": "https://<tellr-app-url>/mcp/",
+      "url": "https://<tellr-app-url>/mcp",
       "transport": "streamable-http"
     }
   }
@@ -349,11 +349,11 @@ Wire it up:
 *Claude Code:*
 
 ```bash
-claude mcp add --transport http tellr "https://<tellr-app-url>/mcp/" \
+claude mcp add --transport http tellr "https://<tellr-app-url>/mcp" \
   --header "Authorization: Bearer $(databricks auth token -p tellr-dev-oauth | jq -r .access_token)"
 
 claude mcp list | grep tellr
-# → tellr: https://<tellr-app-url>/mcp/ (HTTP) - ✓ Connected
+# → tellr: https://<tellr-app-url>/mcp (HTTP) - ✓ Connected
 ```
 
 *Cursor / generic:*
@@ -362,7 +362,7 @@ claude mcp list | grep tellr
 {
   "mcpServers": {
     "tellr": {
-      "url": "https://<tellr-app-url>/mcp/",
+      "url": "https://<tellr-app-url>/mcp",
       "transport": "streamable-http",
       "headers": {
         "Authorization": "Bearer <paste output of `databricks auth token -p tellr-dev-oauth | jq -r .access_token` here>"
@@ -383,7 +383,7 @@ Re-register with a fresh token. Keep it as a shell function:
 ```bash
 tellr-refresh() {
   claude mcp remove tellr 2>/dev/null
-  claude mcp add --transport http tellr "https://<tellr-app-url>/mcp/" \
+  claude mcp add --transport http tellr "https://<tellr-app-url>/mcp" \
     --header "Authorization: Bearer $(databricks auth token -p tellr-dev-oauth | jq -r .access_token)"
 }
 ```
@@ -399,9 +399,9 @@ For unattended runs longer than an hour (CI, background agents):
 
 **PATs → 401 from the Apps proxy.** Don't use long-lived PATs for app access; see §3.1.
 
-**App-level access is a separate check.** OAuth authenticates *who you are*; the Apps proxy additionally checks you're on the app's user list. If sign-in succeeds but `/mcp/` still returns 403, ask the app owner to grant your user access.
+**App-level access is a separate check.** OAuth authenticates *who you are*; the Apps proxy additionally checks you're on the app's user list. If sign-in succeeds but `/mcp` still returns 403, ask the app owner to grant your user access.
 
-**Trailing slash on the URL.** Always POST to `/mcp/` (with slash). `/mcp` (no slash) returns a 307 redirect that some clients silently downgrade to GET and break on. The `claude mcp add` command sometimes strips the trailing slash — double-check with `claude mcp list`.
+**Trailing slash on the URL.** Both `/mcp` and `/mcp/` work; a path-rewrite middleware in tellr accepts either. The `claude mcp add` command sometimes strips the slash — that's now harmless. (Historical note: deployments before April 2026 returned 405 for `/mcp` with no slash; if you're integrating against a pinned-old build, append the slash.)
 
 **Handshake.** After `initialize`, MCP requires a `notifications/initialized` before any `tools/*`. Official MCP clients handle this for you; if you're writing raw HTTP, don't skip it.
 
@@ -425,7 +425,7 @@ Full schemas and examples: [`mcp-server.md`](./mcp-server.md) section 5.
 | Error text | Cause | Fix |
 |---|---|---|
 | `Authentication required: no credentials presented` | No auth headers arrived (proxy stripped them, or external caller didn't send a Bearer). | App-to-app: confirm `x-forwarded-email` is set on your app's inbound requests. External: check your Bearer header is reaching tellr (curl the `/api/health` endpoint with the same token). |
-| `HTTP 401` (empty body `{}`) on external `/mcp/` calls | You're using a PAT (`dapi...`); the Apps proxy rejects PATs for app access. | Switch to an OAuth U2M token via a `databricks-cli` auth profile — see §3.1. |
+| `HTTP 401` (empty body `{}`) on external `/mcp` calls | You're using a PAT (`dapi...`); the Apps proxy rejects PATs for app access. | Switch to an OAuth U2M token via a `databricks-cli` auth profile — see §3.1. |
 | `HTTP 401` mid-session after working fine earlier | OAuth access token (~1-hour lifetime) has expired; `claude mcp add` stored it as a static header. | Re-register the MCP server with a fresh token — see §3.3 (`tellr-refresh` one-liner). |
 | `HTTP 404 {"message": "Session not found"}` | Your client is echoing an `mcp-session-id` against tellr's stateless endpoint while the request is routed to a different worker than the one that (historically) issued the id. Should not occur with current tellr builds. | Treat `mcp-session-id` as optional — read with `.get()`, only echo when present. Upgrade to a current tellr build if calls against a prior deployment produce this error. |
 | `create_deck tool error: ...` | Tool execution failed after auth succeeded (LLM error, input validation, etc.). | Read the error text — it's the underlying reason. |

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -38,13 +38,13 @@ The caller does not need any tellr-specific configuration — no client credenti
 
 | Item | Value |
 |------|-------|
-| URL | `https://<your-tellr-app-url>/mcp/` |
+| URL | `https://<your-tellr-app-url>/mcp` (or `/mcp/` — both accepted) |
 | Protocol | MCP Streamable HTTP, spec revision `2025-03-26` |
 | Transport | JSON-RPC 2.0 over HTTP POST |
 | Required `Accept` header | `application/json, text/event-stream` |
 | Session mode | **Stateless** — server does not issue `mcp-session-id` |
 
-**Mandatory trailing slash.** `POST /mcp` returns `307 Temporary Redirect` to `/mcp/`. Always POST to `/mcp/` directly — the redirect will strip `POST` semantics with some clients.
+**Both `/mcp` and `/mcp/` are accepted.** A path-rewrite middleware in `src/api/main.py` makes the two forms behave identically — single round-trip, no redirect. Documented examples below use the no-slash form; existing clients hard-coded to `/mcp/` continue to work unchanged.
 
 **Stateless transport.** tellr runs FastMCP with `stateless_http=True` because the app is served by multiple uvicorn workers and the Databricks Apps proxy does not guarantee session affinity. Each HTTP POST is handled independently on whichever worker picks it up. Consequences for callers:
 
@@ -109,7 +109,7 @@ External MCP runtimes register tellr in their `mcp_servers.json`-style config. P
 {
   "mcpServers": {
     "tellr": {
-      "url": "https://<your-tellr-app-url>/mcp/",
+      "url": "https://<your-tellr-app-url>/mcp",
       "transport": "streamable-http",
       "headers": {
         "Authorization": "Bearer ${DATABRICKS_TOKEN}"
@@ -367,7 +367,7 @@ Lightly edited from `scripts/mcp_smoke/mcp_smoke_httpx.py`; drop into any Python
 import json, os, time, httpx
 
 TELLR_URL = os.environ["TELLR_URL"].rstrip("/")
-MCP_URL = f"{TELLR_URL}/mcp/"
+MCP_URL = f"{TELLR_URL}/mcp"
 HEADERS = {
     "Authorization": f"Bearer {os.environ['DATABRICKS_TOKEN']}",
     "Content-Type": "application/json",
@@ -434,7 +434,7 @@ else:
 {
   "mcpServers": {
     "tellr": {
-      "url": "https://<your-tellr-app-url>/mcp/",
+      "url": "https://<your-tellr-app-url>/mcp",
       "transport": "streamable-http",
       "headers": {
         "Authorization": "Bearer ${DATABRICKS_TOKEN}"
@@ -522,7 +522,7 @@ The `.slide` wrapper invariant is preserved — tellr never emits a slide withou
 | Error retry | Respect any `retry_after_seconds` hint on rate-limit responses; otherwise back off exponentially. `isError: true` on a tool result is *application* failure, not transport failure — do not retry blindly. |
 | Identity | Forward the end user's OBO token (section 4.2 recipe A) for any user-initiated flow — it is the recommended path and guarantees the deck surfaces to that user. Service-principal tokens are accepted and legitimate for batch / automation use cases, but the resulting deck is attributed to the SP and will not appear in any human user's tellr UI. |
 | Correlation IDs | Pass a `correlation_id` on every `create_deck` / `edit_deck` call. It flows through server logs, worker state, and the chat request row, making cross-system traces trivial. |
-| Trailing slash | Always POST to `/mcp/`. `POST /mcp` returns `307 Temporary Redirect`, which some HTTP clients silently downgrade to `GET`. |
+| Trailing slash | Either `/mcp` or `/mcp/` works. A middleware rewrites the bare path before routing. |
 | Handshake | After `initialize`, send `notifications/initialized` before any `tools/*` call. |
 | Hand-off vs. render | Prefer `deck_url` when the user needs the full tellr editor (presentation mode, Google Slides / PPTX export, Monaco HTML editing, save points). Render `html_document` / iterate `deck.slides` for passive previews or custom editing UIs. |
 | Session lifetime | One session = one deck. Reuse the same `session_id` for subsequent `edit_deck` / `get_deck` calls so you benefit from the session lock and chat history. A new `create_deck` call starts a fresh session. |
@@ -540,7 +540,7 @@ The `.slide` wrapper invariant is preserved — tellr never emits a slide withou
 | Chart.js fails to load in an air-gapped environment | Default CDN unreachable | See section 8.3 — rewrite the CDN URL through a proxy; v1.1 will expose `chart_js_cdn` as a tool parameter. |
 | `initialize` returns no `mcp-session-id` header | Expected — tellr runs stateless (see section 3). If the endpoint also returns HTML or non-JSON, the deployment did not pick up the MCP router; redeploy and confirm `app.mount("/mcp", ...)` ran by looking for `MCP server mounted at /mcp` in the app logs. |
 | Intermittent HTTP 404 `Session not found` from a multi-worker deployment | Only applies if FastMCP is running stateful (`stateless_http=False`); a 3-step handshake can split across workers that don't share session state | Leave tellr in its default stateless mode (section 3). If you've deliberately flipped it back, either pin to a single worker (`UVICORN_WORKERS=1`) or re-enable stateless. |
-| Client receives HTML instead of JSON on the first POST | Target URL is `/mcp` (no trailing slash) and the client followed the 307 to a GET | Always POST to `/mcp/` directly |
+| Client receives HTML instead of JSON on the first POST | Either the SPA catch-all is intercepting (deployed app missing the path-rewrite middleware) or the URL points at the wrong host. | Verify `MCP server mounted at /mcp` appears in the app logs, and curl `POST /mcp` directly with `Accept: application/json, text/event-stream` to confirm a JSON-RPC envelope returns. |
 
 ---
 

--- a/docs/technical/mcp-server.md
+++ b/docs/technical/mcp-server.md
@@ -123,7 +123,7 @@ Refresh the token when it expires (PATs last as configured by the workspace admi
 
 #### C. Direct HTTP
 
-For CI scripts, smoke tests, or notebooks, speak JSON-RPC to `/mcp/` directly. See the full recipe in section 7, or the reference implementation in `scripts/mcp_smoke/mcp_smoke_httpx.py`.
+For CI scripts, smoke tests, or notebooks, speak JSON-RPC to `/mcp` directly. See the full recipe in section 7, or the reference implementation in `scripts/mcp_smoke/mcp_smoke_httpx.py`.
 
 ---
 
@@ -348,7 +348,7 @@ Each tool subsection below mirrors the `@mcp.tool` descriptions in `src/api/mcp_
 |------|----------------|----------|
 | `src/api/mcp_server.py` | Declares `FastMCP` instance; registers the four `@mcp.tool` handlers; builds request-scoped auth scope for each call. | `ChatService`, `SessionManager`, `PermissionService`, `job_queue` |
 | `src/api/mcp_auth.py` | Dual-token resolution: reads `x-forwarded-access-token` or `Authorization: Bearer`, calls `current_user.me()`, binds `current_user` / `user_client` / `permission_context` ContextVars. | Databricks SDK (`WorkspaceClient`) |
-| `src/api/main.py` | Mounts the FastMCP sub-app at `/mcp` with `streamable_http_path="/"`, so external POSTs to `/mcp/` route correctly. Starts the 10-minute timeout sweeper on lifespan. | `tellr_mcp.streamable_http_app()` |
+| `src/api/main.py` | Mounts the FastMCP sub-app at `/mcp` with `streamable_http_path="/"`, and registers a path-rewrite middleware so external POSTs to `/mcp` (or `/mcp/`) route correctly. Starts the 10-minute timeout sweeper on lifespan. | `tellr_mcp.streamable_http_app()` |
 | `src/api/services/job_queue.py` | In-process asyncio queue for chat jobs. Timeout sweeper flips stuck `running` jobs to `failed` after `JOB_HARD_TIMEOUT_SECONDS = 600`. | `chat_requests` table |
 | `src/domain/slide_deck.py` | `SlideDeck.to_html_document()` emits the standalone HTML payload returned in `html_document`. CSS is sanitized; slide content is HTML-escaped to prevent XSS through MCP consumers. | — |
 | `src/services/permission_service.py` | `can_view_deck` / `can_edit_deck` checks used before every tool that touches a deck. Creator short-circuit lets a freshly created session be viewed/edited before any `DeckContributor` row exists. | `user_sessions`, `deck_contributors` |

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -219,6 +219,30 @@ app = FastAPI(
 )
 
 
+@app.middleware("http")
+async def normalize_mcp_path(request: Request, call_next):
+    """Make POST /mcp behave like POST /mcp/.
+
+    The SPA catch-all (``@app.get("/{full_path:path}")`` added by
+    ``_mount_frontend``) intercepts non-GET requests to ``/mcp`` and
+    causes Starlette to return 405 instead of routing to the FastMCP
+    Mount. Rewriting the ASGI scope path before route resolution
+    sidesteps that interaction and avoids emitting a 307 the client
+    has to follow (which can drop ``Authorization`` or method-downgrade
+    in misbehaving HTTP clients — Claude Code v2.1.123 via stdio→HTTP
+    proxy was the original report).
+
+    GET is left alone so ``/mcp`` continues to render the SPA in a
+    browser. The match is exact so ``/mcp/``, ``/mcp/anything``, and
+    ``/mcp-something`` are all unaffected; query strings live in
+    ``scope["query_string"]`` and are not touched.
+    """
+    if request.url.path == "/mcp" and request.method != "GET":
+        request.scope["path"] = "/mcp/"
+        request.scope["raw_path"] = b"/mcp/"
+    return await call_next(request)
+
+
 def _resolve_frontend_dist() -> tuple[ExitStack, Path] | None:
     """Resolve frontend assets bundled in the app package."""
     try:

--- a/tests/integration/test_mcp_endpoint.py
+++ b/tests/integration/test_mcp_endpoint.py
@@ -19,10 +19,14 @@ Two SDK-specific gotchas to keep in mind when reading these tests:
    and patch ``init_db`` + migration helpers to no-ops so no DB is
    touched during lifespan.
 
-2. ``POST /mcp`` returns a 307 redirect to ``/mcp/``. Hitting the
-   trailing-slash path directly avoids TestClient's redirect handling
-   (which may or may not follow redirects automatically depending on
-   the httpx version).
+2. The ``normalize_mcp_path`` middleware in ``src/api/main.py`` rewrites
+   ``POST /mcp`` to ``POST /mcp/`` in the ASGI scope so both forms reach
+   the FastMCP sub-app. The test fixture here doesn't run
+   ``_mount_frontend`` (production-only), so without the middleware
+   ``POST /mcp`` would 307; with the middleware it returns 200 directly.
+   Existing tests still use ``MCP_PATH = "/mcp/"`` for stability —
+   ``test_mcp_endpoint_accepts_both_slash_forms`` is the dedicated
+   regression guard for the no-slash case.
 """
 
 from __future__ import annotations
@@ -37,10 +41,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-# Trailing slash: the FastMCP streamable-HTTP transport internally
-# mounts its route at "/", and main.py mounts that sub-app at "/mcp".
-# External POST to "/mcp" returns a 307 to "/mcp/"; going straight to
-# the slashed form bypasses that round trip.
+# FastMCP's streamable-HTTP transport mounts its route at "/", and
+# main.py mounts that sub-app at "/mcp". External clients can POST to
+# either ``/mcp`` or ``/mcp/`` thanks to the ``normalize_mcp_path``
+# middleware. Existing tests pin to the slashed form for stability;
+# ``test_mcp_endpoint_accepts_both_slash_forms`` covers the no-slash
+# case explicitly.
 MCP_PATH = "/mcp/"
 
 

--- a/tests/integration/test_mcp_endpoint.py
+++ b/tests/integration/test_mcp_endpoint.py
@@ -476,3 +476,64 @@ def test_permission_denied_on_other_users_deck(client, mock_identity_client):
     assert (
         "permission" in lowered or "not found" in lowered
     ), f"denial error didn't mention permission/not-found: {text!r}"
+
+
+def test_mcp_endpoint_accepts_both_slash_forms(client, mock_identity_client):
+    """Regression guard: POST /mcp and POST /mcp/ behave identically.
+
+    The SPA catch-all (``@app.get("/{full_path:path}")`` added by
+    ``_mount_frontend`` in production) used to make ``POST /mcp`` return
+    405 with ``allow: GET``, since Starlette's ``Mount`` cannot tell the
+    outer router which methods FastMCP accepts. In tests
+    ``IS_PRODUCTION`` is false so ``_mount_frontend`` doesn't run and
+    Mount itself returns a 307 redirect for the bare path. The
+    ``normalize_mcp_path`` middleware in ``main.py`` rewrites
+    ``/mcp -> /mcp/`` in the ASGI scope so both forms reach the FastMCP
+    sub-app's POST handler in a single round-trip.
+
+    ``follow_redirects=False`` is critical: without it, ``TestClient``
+    would silently follow a 307 from ``/mcp`` to ``/mcp/`` and the test
+    would pass even if the middleware regressed.
+    """
+    # Run the standard MCP handshake against the canonical slashed path
+    # first so any FastMCP-internal state (none today, since stateless)
+    # mirrors what the existing tests do.
+    _initialize_session(client)
+
+    body = _jsonrpc("tools/list", rid=2)
+
+    no_slash = client.post(
+        "/mcp",
+        headers=_mcp_headers(),
+        json=body,
+        follow_redirects=False,
+    )
+    with_slash = client.post(
+        "/mcp/",
+        headers=_mcp_headers(),
+        json=body,
+        follow_redirects=False,
+    )
+
+    assert no_slash.status_code == 200, (
+        f"POST /mcp should return 200 after the middleware rewrite, "
+        f"got {no_slash.status_code}: {no_slash.text!r}"
+    )
+    assert with_slash.status_code == 200, with_slash.text
+
+    no_slash_body = _decode_mcp_response(no_slash)
+    with_slash_body = _decode_mcp_response(with_slash)
+
+    no_slash_tools = {
+        t["name"] for t in no_slash_body["result"]["tools"]
+    }
+    with_slash_tools = {
+        t["name"] for t in with_slash_body["result"]["tools"]
+    }
+    assert no_slash_tools == with_slash_tools, (
+        f"tool sets differ between paths: "
+        f"no_slash={no_slash_tools} with_slash={with_slash_tools}"
+    )
+    assert {
+        "create_deck", "get_deck_status", "edit_deck", "get_deck",
+    } <= no_slash_tools, f"unexpected tool set: {no_slash_tools}"


### PR DESCRIPTION
## Summary

- Resolves a real production failure: Claude Code v2.1.123 (via stdio→HTTP proxy with `databricks-sdk` external-browser OAuth) was getting `405 Method Not Allowed` from `POST /mcp` because the SPA catch-all `@app.get("/{full_path:path}")` was claiming the path GET-only and Starlette's Mount couldn't tell the outer router which methods FastMCP supported.
- Adds an ASGI middleware in `src/api/main.py` that rewrites `request.scope["path"]` from `/mcp` to `/mcp/` for non-GET methods before route resolution. Single round-trip, no 307, no client-side redirect handling involved.
- Adds a regression test that asserts `POST /mcp` and `POST /mcp/` produce identical 200 JSON-RPC responses (with `follow_redirects=False` so any future regression surfaces as a non-200 instead of silently following).
- Refreshes stale 307-related comments in the test file and updates `docs/technical/mcp-server.md` + `docs/technical/mcp-integration-guide.md` to document that both forms are accepted (with `/mcp` as the new canonical form).

## Design and plan docs

- Spec: `docs/superpowers/specs/2026-04-29-tellr-mcp-trailing-slash-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-tellr-mcp-trailing-slash.md`

## Blast radius

Requests with method ≠ GET and path *exactly* `/mcp` (no slash). Everything else — `/mcp/`, `/mcp/anything`, `/mcp-something`, `GET /mcp` for the SPA, all other routes — is byte-identical to current behavior.

## Test plan

- [x] `pytest tests/integration/test_mcp_endpoint.py -v` — 6/6 passing locally (was 5/6 with the new test failing as a TDD guard before the middleware landed).
- [ ] Post-deploy: run `scripts/mcp_smoke/mcp_smoke_httpx.py` against staging with `MCP_PATH_SUFFIX="/mcp"` (no slash) once to confirm the middleware behaves end-to-end through the Apps proxy. Revert afterwards so the smoke script keeps exercising the historical client path.

## Followups (deferred to a separate PR)

- Task 5 from the plan was scoped out: smoke-script and test-client comments still describe the "mandatory trailing slash" pre-fix behavior. The URLs they use (`/mcp/`) keep working unchanged; only the comments are stale. Files: `scripts/mcp_smoke/mcp_smoke_httpx.py:25-27`, `scripts/mcp_smoke/README.md` notes section, and `mcp-test-client/app.py:140` (which lives in a sibling repo, hence the deferral).

This pull request and its description were written by Isaac.