### PR TITLE
chore(release): bump databricks-tellr and databricks-tellr-app to 0.2.9

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.2.8"
+version = "0.2.9"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.2.8"
+version = "0.2.9"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bumps both `databricks-tellr` and `databricks-tellr-app` from 0.2.8 → 0.2.9.
- Includes the MCP trailing-slash fix landed in #179.

## Test plan

- [x] `git diff` shows only the two `pyproject.toml` version lines changed.

This pull request and its description were written by Isaac.