### PR TITLE
feat: Claude Design path bootstrap (depends on #182)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,13 @@ jobs:
       - name: Install build tools
         run: pip install build
 
+      - name: Build huashu bootstrap artifacts
+        # Produces services/pptx-emit-huashu/{node_modules,sys-libs-bullseye}.tar.gz
+        # which setup.py copies into the wheel's _assets/sidecars/pptx-emit-huashu/.
+        # setup.sh extracts them at boot on the deployed app. Apt-downloads
+        # Bullseye runtime libs (libnspr4, libnss3, etc.) for Chromium.
+        run: bash services/pptx-emit-huashu/build-artifacts.sh
+
       - name: Build databricks-tellr
         run: python -m build --sdist --wheel packages/databricks-tellr
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,13 @@ mlruns/
 
 # Frontend / Node.js
 node_modules/
+
+# Claude Design (huashu) bootstrap artifacts — built by
+# services/pptx-emit-huashu/build-artifacts.sh in CI, never committed.
+services/pptx-emit-huashu/node_modules.tar.gz
+services/pptx-emit-huashu/sys-libs-bullseye.tar.gz
+services/pptx-emit-huashu/sys-libs/
+services/pptx-emit-huashu/sys-libs-bullseye/
 frontend/.vite/
 frontend/dist/
 *.local

--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.3.0"
+version = "0.3.1"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr-app/setup.py
+++ b/packages/databricks-tellr-app/setup.py
@@ -8,12 +8,23 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 
 
+# Files in services/pptx-emit-huashu/ NOT to ship in the wheel:
+#   - node_modules/ and sys-libs/ are bulky uncompressed trees; the wheel
+#     instead ships the gzipped tarballs (node_modules.tar.gz and
+#     sys-libs-bullseye.tar.gz) which setup.sh extracts at boot. The
+#     tarballs are produced by services/pptx-emit-huashu/build-artifacts.sh
+#     and are not in _SIDECAR_IGNORE so they DO ship.
+#   - package-lock.json is needed at build-artifacts.sh time but not at
+#     runtime (the lockfile is consumed when the tarball is built).
+#   - build-artifacts.sh is a CI/build helper, never a runtime script.
 _SIDECAR_IGNORE = shutil.ignore_patterns(
     "node_modules",
     "sys-libs",
+    "sys-libs-bullseye",
     ".databricks",
     "*.log",
     "package-lock.json",
+    "build-artifacts.sh",
 )
 
 

--- a/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
+++ b/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
@@ -6,7 +6,19 @@ command:
   - "sh"
   - "-c"
   - |
-    pip install --upgrade --no-cache-dir ${PIP_INDEX_ARGS}-r requirements.txt && python -c "from databricks_tellr_app.run import init_database; ${INIT_DATABASE_CALL}" && python -m databricks_tellr_app.run
+    set -e
+    pip install --upgrade --no-cache-dir ${PIP_INDEX_ARGS}-r requirements.txt
+    python -c "from databricks_tellr_app.run import init_database; ${INIT_DATABASE_CALL}"
+    # Backgrounded huashu (Claude Design path) bootstrap. Extracts the
+    # bundled node_modules + sys-libs tarballs and runs `playwright install
+    # chromium`. While running, the /huashu/available endpoint reports
+    # not-ready and the frontend falls back to the records pipeline. Once
+    # the cache exists, the route flips on automatically.
+    HUASHU_SETUP=$(python -c "import os, databricks_tellr_app; print(os.path.join(os.path.dirname(databricks_tellr_app.__file__), '_assets', 'sidecars', 'pptx-emit-huashu', 'setup.sh'))" 2>/dev/null || true)
+    if [ -n "$HUASHU_SETUP" ] && [ -f "$HUASHU_SETUP" ]; then
+      sh "$HUASHU_SETUP" &
+    fi
+    python -m databricks_tellr_app.run
 
 env:
   - name: ENVIRONMENT
@@ -48,3 +60,12 @@ env:
   # ContextVar "different Context" warnings under FastAPI). See docs/technical/llm-as-judge-verification.md
   # - name: TELLR_MLFLOW_LANGCHAIN_AUTOLOG
   #   value: "1"
+  # Opt-in to the Claude Design (huashu) PPTX path. When "1", the backend
+  # serves /api/export/pptx/editable/huashu/from-html using server-side
+  # Chromium + Playwright (faster + higher fidelity than the records
+  # pipeline). Default off — the backgrounded setup.sh in the boot
+  # command above prepares artifacts either way, so flipping this to "1"
+  # later is a no-redeploy change. Frontend falls back to the records
+  # pipeline when this is off OR when setup.sh is still running.
+  - name: HUASHU_PIPELINE_ENABLED
+    value: "0"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.3.0"
+version = "0.3.1"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/services/pptx-emit-huashu/build-artifacts.sh
+++ b/services/pptx-emit-huashu/build-artifacts.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# Build the two tarballs (node_modules.tar.gz + sys-libs-bullseye.tar.gz)
+# that setup.sh extracts at boot. Run from CI (publish.yml) before
+# `python -m build`, or locally for testing.
+#
+# Requirements:
+#   - npm + node (for `npm ci`)
+#   - apt-get + dpkg-deb (Debian/Ubuntu — works on the Apps Bullseye base
+#     image and on github actions ubuntu-latest)
+#
+# Output:
+#   ./node_modules.tar.gz       (~12 MB compressed)
+#   ./sys-libs-bullseye.tar.gz  (~15 MB compressed)
+#
+# Both must be present when `setup.py::BuildWithFrontend` runs, otherwise
+# the wheel ships without bootstrap artifacts and the huashu pipeline
+# stays unavailable on every install.
+
+set -e
+cd "$(dirname "$0")"
+SIDECAR_DIR="$(pwd)"
+
+echo "=== build-artifacts.sh in $SIDECAR_DIR ==="
+
+# ---------- 1. node_modules.tar.gz --------------------------------------
+echo "--- node_modules.tar.gz ---"
+rm -rf node_modules node_modules.tar.gz
+
+if [ -f package-lock.json ]; then
+  npm ci --omit=dev
+else
+  echo "WARN: no package-lock.json — falling back to 'npm install --omit=dev'"
+  npm install --omit=dev
+fi
+
+# Tar the dir, then remove the on-disk copy so wheel build doesn't see
+# both `node_modules/` and `node_modules.tar.gz`.
+tar czf node_modules.tar.gz node_modules
+rm -rf node_modules
+echo "    $(du -h node_modules.tar.gz)"
+
+# ---------- 2. sys-libs-bullseye.tar.gz ---------------------------------
+# Linux runtime libs needed by Chromium that the Apps non-root container
+# doesn't ship. Sourced from apt — Bullseye-pinned because that matches
+# the Apps base image today. List enumerated from the user's working
+# .pw-linux-build/sys-libs-bullseye/ artifact on mohamed-tellr-darwish.
+echo "--- sys-libs-bullseye.tar.gz ---"
+rm -rf sys-libs sys-libs-bullseye sys-libs-bullseye.tar.gz
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "ERROR: apt-get not available. This script must run on a Debian/Ubuntu"
+  echo "       host (e.g. github actions ubuntu-latest) so the runtime libs"
+  echo "       can be apt-downloaded for the Apps Bullseye base image."
+  exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Comprehensive list of Bullseye packages whose .so's Chromium loads.
+# Adding a new package is safe (extra .so's just sit in the bundle and
+# get picked up via LD_LIBRARY_PATH if Chromium needs them).
+PACKAGES="
+  libnspr4
+  libnss3
+  libgcc-s1
+  libstdc++6
+  libxkbcommon0
+  libxcomposite1
+  libxdamage1
+  libxfixes3
+  libxrandr2
+  libxext6
+  libx11-6
+  libx11-xcb1
+  libxcb1
+  libxshmfence1
+  libgbm1
+  libasound2
+  libatk1.0-0
+  libatk-bridge2.0-0
+  libatspi2.0-0
+  libcups2
+  libpango-1.0-0
+  libpangocairo-1.0-0
+  libcairo2
+  libdrm2
+  libdbus-1-3
+  libexpat1
+  libffi7
+  libfontconfig1
+  libfreetype6
+  libfribidi0
+  libgcrypt20
+  libgdk-pixbuf-2.0-0
+  libgio-2.0-0
+  libglib2.0-0
+  libgmodule-2.0-0
+  libgobject-2.0-0
+  libgthread-2.0-0
+  libgraphite2-3
+  libharfbuzz0b
+  libjpeg62-turbo
+  libpcre3
+  libpixman-1-0
+  libpng16-16
+  libssl1.1
+  libsystemd0
+  libthai0
+  libtiff5
+  libuuid1
+  libwayland-client0
+  libwayland-cursor0
+  libwebp6
+  libdatrie1
+  zlib1g
+"
+
+cd "$TMP"
+echo "    apt-get download into $TMP"
+# shellcheck disable=SC2086
+apt-get download $PACKAGES 2>&1 | tail -n 5 || \
+  echo "    WARN: some packages failed to download (they may not exist on this distro)"
+
+mkdir extracted
+for deb in *.deb; do
+  [ -f "$deb" ] || continue
+  dpkg-deb -x "$deb" extracted/
+done
+
+mkdir -p "$SIDECAR_DIR/sys-libs-bullseye"
+# Flatten: copy every .so* (preserving symlinks) into a single dir.
+find extracted -name "*.so*" -print0 | while IFS= read -r -d '' f; do
+  cp -P "$f" "$SIDECAR_DIR/sys-libs-bullseye/"
+done
+
+cd "$SIDECAR_DIR"
+echo "    sys-libs-bullseye/ has $(ls sys-libs-bullseye | wc -l) .so files"
+
+tar czf sys-libs-bullseye.tar.gz sys-libs-bullseye
+rm -rf sys-libs-bullseye
+echo "    $(du -h sys-libs-bullseye.tar.gz)"
+
+echo "=== build-artifacts.sh done ==="

--- a/services/pptx-emit-huashu/setup.sh
+++ b/services/pptx-emit-huashu/setup.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Boot-time bootstrap for the Claude Design (huashu) PPTX path.
+#
+# Runs in two situations:
+#  - From a wheel install: `_assets/sidecars/pptx-emit-huashu/setup.sh`
+#    (relative to the installed databricks_tellr_app package).
+#  - From a synced repo: `services/pptx-emit-huashu/setup.sh`.
+#
+# In both cases it does the same three things, idempotently:
+#   1. Extract node_modules.tar.gz if node_modules/ is missing.
+#   2. Extract sys-libs-bullseye.tar.gz into sys-libs/ if missing.
+#   3. Run `node node_modules/playwright/cli.js install chromium` to
+#      download the Chromium binary (Playwright caches under
+#      ~/.cache/ms-playwright/ so subsequent boots skip it).
+#
+# Logs to /tmp/huashu-setup.log so the diagnostic /huashu/available
+# endpoint can surface progress to ops.
+
+set -e
+SIDECAR_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SIDECAR_DIR"
+
+LOG=/tmp/huashu-setup.log
+echo "=== huashu setup at $(date -u +%FT%TZ) ===" > "$LOG"
+echo "sidecar dir: $SIDECAR_DIR" >> "$LOG"
+
+# 1. node_modules — extract from tarball if not already present.
+if [ -d node_modules ]; then
+  echo "[setup] node_modules already present, skipping extract" >> "$LOG"
+elif [ -f node_modules.tar.gz ]; then
+  echo "[setup] extracting node_modules.tar.gz" >> "$LOG"
+  tar xzf node_modules.tar.gz >> "$LOG" 2>&1
+  echo "[setup] node_modules ready" >> "$LOG"
+else
+  echo "[setup] WARN: no node_modules dir and no node_modules.tar.gz" >> "$LOG"
+fi
+
+# 2. sys-libs — extracted dir should be named sys-libs/ (the Python wrapper
+# looks for that path). The tarball contains a top-level sys-libs-bullseye/
+# dir, which we rename. Idempotent.
+if [ -d sys-libs ]; then
+  echo "[setup] sys-libs already present, skipping extract" >> "$LOG"
+elif [ -f sys-libs-bullseye.tar.gz ]; then
+  echo "[setup] extracting sys-libs-bullseye.tar.gz" >> "$LOG"
+  tar xzf sys-libs-bullseye.tar.gz >> "$LOG" 2>&1
+  if [ -d sys-libs-bullseye ]; then
+    mv sys-libs-bullseye sys-libs
+    echo "[setup] sys-libs ready" >> "$LOG"
+  fi
+else
+  echo "[setup] WARN: no sys-libs dir and no sys-libs-bullseye.tar.gz" >> "$LOG"
+fi
+
+# 3. Chromium — Playwright CLI does the download + caches under
+# ~/.cache/ms-playwright/. No-op once the cache exists.
+PW_CLI=
+if [ -f node_modules/playwright/cli.js ]; then
+  PW_CLI=node_modules/playwright/cli.js
+elif [ -f node_modules/playwright-core/cli.js ]; then
+  PW_CLI=node_modules/playwright-core/cli.js
+fi
+
+if [ -n "$PW_CLI" ]; then
+  echo "[setup] running: node $PW_CLI install chromium" >> "$LOG"
+  node "$PW_CLI" install chromium >> "$LOG" 2>&1 || \
+    echo "[setup] WARN: chromium install rc=$?" >> "$LOG"
+  echo "[setup] chromium step done" >> "$LOG"
+else
+  echo "[setup] WARN: no playwright CLI in node_modules — skipping chromium install" >> "$LOG"
+fi
+
+echo "[setup] done at $(date -u +%FT%TZ)" >> "$LOG"


### PR DESCRIPTION
## Depends on #182

This PR is stacked on top of #182 (the Claude Design path code + records fallback + schema migration + packaging fix). Until #182 merges, this PR's diff shows BOTH PRs' commits. After #182 merges, only the bootstrap commit (`f42b069`) will remain in the diff.

## What this adds

PR #182 ships the code for the Claude Design (huashu) PPTX path but the **runtime artifacts** (Linux node_modules, system libs, Chromium binary) aren't shipped, so the path stays unavailable on PyPI-deployed apps. The frontend's defensive fallback to the records pipeline picks up the slack — users get a slower-but-working export.

This PR makes the wheel self-bootstrapping so the fast path turns on automatically once you opt in:

- **`services/pptx-emit-huashu/setup.sh`** — boot script. Extracts `node_modules.tar.gz` + `sys-libs-bullseye.tar.gz` (idempotent), runs `playwright install chromium`. Logs to `/tmp/huashu-setup.log`.
- **`services/pptx-emit-huashu/build-artifacts.sh`** — CI helper. Builds the two tarballs from a fresh `npm ci` + `apt-get download` of Bullseye runtime libs.
- **`packages/databricks-tellr-app/setup.py`** — extends `_SIDECAR_IGNORE` so build-artifacts.sh stays out of the wheel; tarballs and setup.sh ship via the existing `_assets/sidecars/...` glob.
- **`app.yaml.template`** — boot command runs setup.sh in background after `pip install` + `init_database`. Adds `HUASHU_PIPELINE_ENABLED` env var (default `"0"`, opt-in).
- **`.github/workflows/publish.yml`** — runs `build-artifacts.sh` before `python -m build`.
- **`.gitignore`** — keeps the CI-built tarballs out of git.

## Wheel size

Goes from ~5 MB to ~30 MB (12 MB node_modules.tar.gz + 18 MB sys-libs-bullseye.tar.gz). Fine for PyPI; PyPI handles 100+ MB wheels routinely. Chromium binary (~150 MB) is NOT in the wheel — downloaded fresh at boot via `playwright install chromium` per Playwright's standard workflow.

## Default behaviour stays identical

- `HUASHU_PIPELINE_ENABLED` defaults to `"0"`. When unset/0, `is_available()` returns False, route 503s, frontend falls back to records pipeline. Same UX as before.
- Setup.sh runs in the background regardless, so the artifacts are ready when you flip the flag — no redeploy needed.
- Flip `HUASHU_PIPELINE_ENABLED` to `"1"` in your deployment YAML when you want exports to use the fast path.

## Verified locally

- Built tarballs from local artifacts → `python -m build --wheel` → wheel contains `setup.sh` + both tarballs at `_assets/sidecars/pptx-emit-huashu/`.
- Fresh-venv install + `sh setup.sh` extracts both trees, drops Chromium into `~/.cache/ms-playwright/`, sets up `sys-libs/`.
- With `HUASHU_PIPELINE_ENABLED=1`, `is_available()` returns True post-extraction; `sidecar_subprocess_env()` correctly prepends the wheel-internal `sys-libs/` to `LD_LIBRARY_PATH`.

## Operational notes

- Bullseye-pinned. The sys-libs match the Apps base image today (Debian Bullseye). If Apps switches base OS, sys-libs needs rebuilding — `build-artifacts.sh` is the place.
- First boot on a fresh container takes ~30–60s for Chromium download (~150 MB). Frontend falls back to records during that window. Subsequent boots are fast (Playwright caches under `~/.cache/ms-playwright/`).
- `/api/export/pptx/editable/huashu/available` is the diagnostic — returns the current readiness state (chromium_cache, setup_log_size, etc).

This pull request and its description were written by Isaac.