### PR TITLE
fix(deploy): escape $ in app.yaml.template + bump to 0.3.2

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.3.1"
+version = "0.3.2"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
+++ b/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
@@ -14,9 +14,9 @@ command:
     # chromium`. While running, the /huashu/available endpoint reports
     # not-ready and the frontend falls back to the records pipeline. Once
     # the cache exists, the route flips on automatically.
-    HUASHU_SETUP=$(python -c "import os, databricks_tellr_app; print(os.path.join(os.path.dirname(databricks_tellr_app.__file__), '_assets', 'sidecars', 'pptx-emit-huashu', 'setup.sh'))" 2>/dev/null || true)
-    if [ -n "$HUASHU_SETUP" ] && [ -f "$HUASHU_SETUP" ]; then
-      sh "$HUASHU_SETUP" &
+    HUASHU_SETUP=$$(python -c "import os, databricks_tellr_app; print(os.path.join(os.path.dirname(databricks_tellr_app.__file__), '_assets', 'sidecars', 'pptx-emit-huashu', 'setup.sh'))" 2>/dev/null || true)
+    if [ -n "$$HUASHU_SETUP" ] && [ -f "$$HUASHU_SETUP" ]; then
+      sh "$$HUASHU_SETUP" &
     fi
     python -m databricks_tellr_app.run
 

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.3.1"
+version = "0.3.2"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

PR #183 (0.3.1) added a backgrounded `setup.sh` invocation to the boot command in `app.yaml.template`. The new lines use bash command substitution `\$(...)` and a bash variable `\$HUASHU_SETUP`, but the template is rendered via Python's `string.Template.substitute`, which interprets every `\$` as the start of a substitution variable. Tariq hit it on his first `tellr.update(...)` after upgrading to 0.3.1:

\`\`\`
DeploymentError: Update failed: Invalid placeholder in string: line 17, col 18
File .../databricks_tellr/deploy.py:564, in _update_databricks
  _write_app_yaml(staging, ...)
\`\`\`

Line 17 col 18 = the `\$` in `HUASHU_SETUP=\$(python -c ...)`.

## Fix

Escape every literal `\$` in the new boot block as `\$\$`. `string.Template` renders `\$\$` → `\$`, so the deployed `app.yaml` ends up with the bash syntax it needs.

Three lines changed (one each for the command substitution and the two `\$HUASHU_SETUP` references).

## Version bump

PyPI rejects re-uploading the same version with different content; 0.3.1 stays as the broken release. Bump both packages to **0.3.2** to keep them in sync.

## Verified locally

\`\`\`python
from string import Template
t = Template(open('packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template').read())
t.substitute({...})  # succeeds
\`\`\`

Rendered output contains plain `HUASHU_SETUP=\$(python ...)` (single `\$`), which is valid bash. Other substitutions (`\${LAKEBASE_INSTANCE}` etc.) still render correctly.

## What Tariq does after merge + publish

\`\`\`
pip install --upgrade databricks-tellr  # picks up 0.3.2
\`\`\`

Then re-run `tellr.update(...)`. No crash. App.yaml gets the new `command:` block + `HUASHU_PIPELINE_ENABLED: "0"` env var. Flip "0" → "1" + restart to engage the fast path.

This pull request and its description were written by Isaac.