### PR TITLE
fix(huashu): bypass validation on /from-html so AI slides actually export (0.3.4)

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.3.3"
+version = "0.3.4"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.3.3"
+version = "0.3.4"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/api/routes/export.py
+++ b/src/api/routes/export.py
@@ -1189,7 +1189,17 @@ async def export_pptx_huashu_from_html(request: ExportPPTXEditableRequest):
     title = slide_deck.get("title") or "slides"
 
     try:
-        pptx_bytes, failures = build_pptx_huashu(title, slides_with_html)
+        # bypass_validation=True so slides that violate huashu's strict
+        # design rules (overflow > 100px, text-near-bottom-edge, layout
+        # dimension mismatch, etc.) still ship in the PPTX. AI-generated
+        # decks routinely fail those rules; without bypass the user gets
+        # a 422 "all slides failed validation" instead of a working file.
+        # Mirrors the Google Slides /from-huashu route's behaviour.
+        # Per-slide failure metadata still comes back in `failures` and
+        # rides on the X-Huashu-Failures response header for the frontend.
+        pptx_bytes, failures = build_pptx_huashu(
+            title, slides_with_html, bypass_validation=True
+        )
     except HuashuExportError as e:
         logger.exception("Huashu sidecar hard-failed")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Why

Tariq's staging hit \`"all slides failed huashu validation"\` (HTTP 422) on Download PPTX after v0.3.3 enabled the fast path. Root cause: the \`/api/export/pptx/editable/huashu/from-html\` route was calling \`build_pptx_huashu(title, slides)\` without \`bypass_validation=True\`. Huashu's design-rule validation (overflow > 100px, text-near-bottom-edge, layout dimension mismatch, etc.) rejected every AI-generated slide.

AI-generated decks aren't hand-tuned to pass huashu's strict rules. With \`bypass=False\` the result is "every slide rejected → empty PPTX → 422" instead of a working file.

## Fix

Pass \`bypass_validation=True\`. Mirrors what the Google Slides \`/from-huashu\` route already does for the same reason — slides that fail rules render anyway (possibly with imperfections) instead of leaving holes.

Per-slide failure metadata still comes back in the \`failures\` list and rides on the \`X-Huashu-Failures\` response header. The frontend can surface a "N of M slides had design warnings" toast in a follow-up.

## Version bump

0.3.3 → **0.3.4**. PyPI immutable.

## Recovery after merge

\`\`\`
git tag v0.3.4 origin/main
git push origin v0.3.4
\`\`\`

Publish completes in ~3 min (build-artifacts.sh just verifies the committed tarballs now). Tariq restarts \`ty-tellr-stage\` → fresh wheel → next "Download PPTX" returns a working file.

This pull request and its description were written by Isaac.