### PR TITLE
fix(huashu): add full Chromium dep set to sys-libs (0.3.7)

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.3.6"
+version = "0.3.7"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.3.6"
+version = "0.3.7"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

After PRs #189 (libavahi) + #190 (re-extract), Tariq's 0.3.6 probe-launch FAILED on the next missing chromium runtime dep:

\`\`\`
libwayland-server.so.0: cannot open shared object file
\`\`\`

Each PR was fixing ONE lib then chromium would error on the next. Stop the whack-a-mole.

## What this PR adds

Pulled Playwright 1.59.1's official chromium dep list from \`node_modules/playwright-core/lib/server/registry/nativeDeps.js\` (debian11-x64.chromium block) and added every X11/wayland lib that wasn't already in our bundle, sourced from Debian Bullseye's package archive:

| .so file | Debian package |
|---|---|
| \`libwayland-server.so.0\` | \`libwayland-server0_1.18.0\` ← confirmed missing |
| \`libwayland-egl.so.1\` | \`libwayland-egl1_1.18.0\` |
| \`libXrender.so.1\` | \`libxrender1_0.9.10\` |
| \`libXss.so.1\` | \`libxss1_1.2.3\` |
| \`libXtst.so.6\` | \`libxtst6_1.2.3\` |
| \`libXi.so.6\` | \`libxi6_1.7.10\` |
| \`libXcursor.so.1\` | \`libxcursor1_1.2.0\` |

Plus their \`.so.X.Y.Z\` target files for the symlink chain.

Bundle: 131 → 149 .so files. Tarball stays at 18 MB.

## Why these aren't already on the Apps base

The newer Apps runtime (\`fevm-db-tellr-dev-workspace\`) has stripped most non-essential shared libraries from \`/usr/lib\`. Older Apps base (\`fevm-darwish\`) had them, which is why darwish "just worked" — chromium was finding them on the host, not our bundle. Now we self-bundle so the wheel works on any Apps base.

## Version

0.3.6 → **0.3.7**.

## Recovery

\`\`\`
git tag v0.3.7 origin/main
git push origin v0.3.7
\`\`\`

After publish (~3 min), Tariq restarts. setup.sh's mtime check from PR #190 detects the new tarball, re-extracts, chromium gets the full lib set, probe-launch returns PROBE_OK on first try.

If chromium STILL fails on yet another lib, we're past Playwright's documented deps and need an ldd-check endpoint to enumerate everything.

This pull request and its description were written by Isaac.