### PR TITLE
fix(deps): relax databricks-sdk pin to >=0.96.0,<1.0

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "python-multipart==0.0.20",
     "pydantic==2.12.4",
     "pydantic-settings==2.12.0",
-    "databricks-sdk==0.91.0",
+    "databricks-sdk>=0.96.0,<1.0",
     "databricks-langchain==0.9.0",
     "langchain==1.0.5",
     "langchain-core==1.0.4",


### PR DESCRIPTION
## Summary

Resolves the `databricks-sdk` install conflict that prevents downstream users from co-installing `databricks-tellr-app` alongside their own `databricks-sdk` version pin.

## Context

- Commit `98c8ee1` deliberately upgraded `databricks-sdk` to `==0.96.0` "for Lakebase Autoscaling support (postgres module: projects, branches, endpoints, roles)".
- Commit `4144bbc` silently reverted the line back to `==0.91.0` inside an unrelated feature PR. The reversion appears to be a stale-base merge artifact rather than an intentional choice — the commit message does not mention the SDK at all.
- The hard `==` pin causes pip's modern resolver to refuse installs whenever a downstream environment pins `databricks-sdk` to any version other than exactly `0.91.0`.

## Change

One-line edit to `packages/databricks-tellr-app/pyproject.toml`:

\`\`\`diff
-    "databricks-sdk==0.91.0",
+    "databricks-sdk>=0.96.0,<1.0",
\`\`\`

- Restores the `0.96.0` baseline established in `98c8ee1`.
- Switches from a hard `==` pin to a range so downstream consumers can install with any compatible SDK version of their choice.
- `<1.0` upper bound is conservative — prevents silent adoption of breaking changes in a future major SDK release.

## Test plan

- [ ] Publish to test-PyPI and verify clean install in a fresh venv with `databricks-sdk==0.96.0` alongside `databricks-tellr-app`
- [ ] Redeploy stage app via test-PyPI and smoke-test huashu export end-to-end
- [ ] Cut real PyPI release only after both test-PyPI checks pass

This pull request and its description were written by Isaac.