### PR TITLE
Presentation mode: full-window default, start-at-current, truncation + freeze fixes

### DIFF
--- a/docs/technical/frontend-overview.md
+++ b/docs/technical/frontend-overview.md
@@ -329,7 +329,7 @@ interface SlideStyle {
 | `src/components/config/ConfirmDialog.tsx` | Reusable confirmation dialog for destructive actions (deleting profiles, changing defaults) | None (props only) |
 | `src/components/config/ContributorsManager.tsx` | Profile sharing UI; add/update/remove contributors (users/groups) with permission levels | `configApi.listContributors`, `configApi.addContributor`, `configApi.updateContributor`, `configApi.removeContributor`, `configApi.searchIdentities` |
 | `src/components/DeckContributorsManager.tsx` | Deck (session) sharing UI; add/update/remove contributors with CAN_VIEW/CAN_EDIT/CAN_MANAGE permissions | `configApi.listDeckContributors`, `configApi.addDeckContributor`, `configApi.updateDeckContributor`, `configApi.removeDeckContributor` |
-| `src/components/PresentationMode/PresentationMode.tsx` | Fullscreen slide presentation with keyboard navigation; wraps scripts in try/catch for graceful chart failures | None (renders slide HTML in iframe) |
+| `src/components/PresentationMode/PresentationMode.tsx` | Full-window slide presentation (opt-in browser fullscreen via F/toolbar) with keyboard navigation; snapshots deck on mount to immunize against parent re-renders; wraps scripts in try/catch for graceful chart failures | None (renders slide HTML in iframe) |
 
 ---
 

--- a/docs/technical/presentation-mode.md
+++ b/docs/technical/presentation-mode.md
@@ -6,11 +6,13 @@ This document explains how the presentation mode feature works, including the cu
 
 ## Feature Summary
 
-Presentation mode displays slides in a fullscreen, keyboard-navigable viewer that shows one slide at a time. Users can also download a self-contained HTML file containing all slides for offline viewing or printing.
+Presentation mode displays slides in a keyboard-navigable viewer that shows one slide at a time. By default it opens "full window" — a fixed-position overlay covering `100vw × 100vh` — and can be promoted to browser fullscreen on demand (F or toolbar button), matching Google Slides' Slideshow / Cmd+Shift+Enter flow. Users can also download a self-contained HTML file containing all slides for offline viewing or printing.
 
 | Capability | Entry Point | Output |
 | --- | --- | --- |
-| Present fullscreen | "Present" button in SlidePanel header | Fullscreen overlay with single-slide iframe |
+| Present (full-window) | "Present" button in SlidePanel header | Fixed-position overlay with single-slide iframe; browser chrome still visible |
+| Present (fullscreen) | F key or toolbar button inside the overlay | Browser fullscreen (`document.documentElement.requestFullscreen()`) |
+| Start at current slide | "Present" button | Opens at whichever slide is most visible in the scroll viewport (or the selected one) |
 | Download HTML | "Export" → "Save as HTML" in SlidePanel header | Standalone `.html` file with all slides |
 | Debug mode | `?debug=true` or `localStorage.debug='true'` | Shows Raw HTML tabs |
 
@@ -58,7 +60,7 @@ The presentation mode shows one slide at a time in an iframe, updating the ifram
 
 ### 1. Presentation Mode HTML Structure
 
-The presentation mode generates HTML for a single slide at a time. Each slide is wrapped in a container that maintains the 16:9 aspect ratio (1280×720px):
+The presentation mode generates HTML for a single slide at a time. Each slide is wrapped in a `.slide-container` that maintains the 16:9 aspect ratio (1280×720px). **CSS ordering matters here** — the deck's own CSS (`slideDeck.css`) is injected before a final reset so deck styles can't squash the layout:
 
 ```html
 <!DOCTYPE html>
@@ -68,27 +70,30 @@ The presentation mode generates HTML for a single slide at a time. Each slide is
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- external_scripts (Chart.js, etc.) -->
   <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
+    * { box-sizing: border-box; }
     html, body {
       width: 100%;
       height: 100%;
-      overflow: auto;
+      overflow: hidden;
       background: #ffffff;
     }
+    canvas { max-width: 100%; height: auto; }
+
+    /* slideDeck.css is injected here */
+
+    /* Reset AFTER deck CSS so per-deck rules can't override these */
     body {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 0;
-      margin: 0;
+      display: flex !important;
+      justify-content: center !important;
+      align-items: flex-start !important;
+      padding: 0 !important;
+      margin: 0 !important;
     }
     .slide-container {
       width: 1280px;
       height: 720px;
+      flex-shrink: 0;
+      flex-grow: 0;
       position: relative;
       background: #ffffff;
       overflow: hidden;
@@ -97,12 +102,11 @@ The presentation mode generates HTML for a single slide at a time. Each slide is
     .slide-container > * {
       width: 100%;
       height: 100%;
+      /* Zero any margin a deck CSS may add to its slide root — preview/gallery
+         styles often set ".slide { margin: 40px auto }" which would push the
+         slide inside the 720px clipping box and truncate the bottom. */
+      margin: 0 !important;
     }
-    canvas {
-      max-width: 100%;
-      height: auto;
-    }
-    /* slideDeck.css */
   </style>
 </head>
 <body>
@@ -115,6 +119,12 @@ The presentation mode generates HTML for a single slide at a time. Each slide is
 </body>
 </html>
 ```
+
+Why each defensive rule exists:
+
+- **`!important` body resets after the deck CSS** — Some slide styles set the body to a flex column with padding/gap (intended for a stacked-preview view). Without this reset, body padding could shrink the slide-container via flex-layout and clip the slide.
+- **`flex-shrink: 0; flex-grow: 0;` on `.slide-container`** — Belt-and-braces: even if body padding sneaks through, the slide-container won't shrink below 720px.
+- **`margin: 0 !important` on `.slide-container > *`** — Deck CSS commonly emits `.slide { margin: 40px auto }` for the gallery view. In present mode that 40px top margin pushes content past the 720px container and clips the bottom.
 
 The iframe's `srcdoc` is updated whenever `currentSlideIndex` changes, causing a re-render of the slide content. The iframe itself is scaled using CSS `transform: scale()` to fit the viewport while maintaining the 16:9 aspect ratio without distortion.
 
@@ -193,52 +203,104 @@ This approach:
 - Automatically adjusts on window resize and orientation changes
 - Recalculates scale when entering fullscreen mode
 
-### 4. Fullscreen Management
+### 4. Full-Window Default + Opt-in Fullscreen
 
-`PresentationMode` uses the Fullscreen API:
-- On mount: `document.documentElement.requestFullscreen()` (with graceful fallback if denied)
-- On fullscreen enter: Recalculates scale factor to account for viewport size changes
-- On exit: Listens to `fullscreenchange` event; when `!document.fullscreenElement`, calls `onExit()`
-- Cleanup: Exits fullscreen if component unmounts while still active
+`PresentationMode` defaults to **full window**: a React portal mounted on `document.body` with `position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; zIndex: 9999`. The browser chrome stays visible (so the user can still see their tabs / URL bar) — this is the same UX as Google Slides' "Slideshow" view.
 
-The component renders via React portal to `document.body`, creating a fullscreen overlay with black background. The scale factor is recalculated when entering fullscreen to ensure proper sizing in the new viewport.
-
-### 5. Keyboard Navigation
-
-Navigation is handled by React event listeners attached to `window` and `document` in capture phase:
+Browser fullscreen is **opt-in** and toggles in either direction via:
+- The `F` key, or
+- The fullscreen toggle button in the top-right toolbar
 
 ```tsx
-const handleKeyDown = (e: KeyboardEvent) => {
-  // Skip if typing in input/textarea
-  const target = e.target as HTMLElement;
-  if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-    return;
-  }
-
-  switch (e.key) {
-    case 'ArrowRight':
-    case 'ArrowDown':
-    case ' ': // Spacebar
-      setCurrentSlideIndex((prev) => Math.min(prev + 1, slideDeck.slides.length - 1));
-      break;
-    case 'ArrowLeft':
-    case 'ArrowUp':
-      setCurrentSlideIndex((prev) => Math.max(prev - 1, 0));
-      break;
-    case 'Home':
-      setCurrentSlideIndex(0);
-      break;
-    case 'End':
-      setCurrentSlideIndex(slideDeck.slides.length - 1);
-      break;
-    case 'Escape':
-      onExit();
-      break;
+const toggleFullscreen = () => {
+  if (document.fullscreenElement) {
+    document.exitFullscreen().catch(() => {});
+  } else {
+    document.documentElement.requestFullscreen().catch(() => {});
   }
 };
 ```
 
-The container div has `tabIndex={-1}` and receives focus to capture keyboard events. The iframe does not receive focus; navigation is handled at the parent level.
+A `fullscreenchange` listener mirrors the browser's actual fullscreen state into local `isFullscreen` state and recalculates the scale factor (viewport dimensions change when fullscreen toggles). The listener does **not** call `onExit` — exiting fullscreen drops the user back to full-window, not all the way out of presentation mode. To fully exit, the user presses Esc a second time.
+
+The resulting Esc behavior is naturally two-stage, like Keynote/PowerPoint:
+
+| Mode | Esc behavior |
+| --- | --- |
+| Fullscreen | Browser intercepts Esc and exits fullscreen → drops to full-window |
+| Full-window | Component's keydown handler fires `onExit()` → exits presentation entirely |
+
+On unmount the component releases any held fullscreen lock with `document.exitFullscreen()`.
+
+### 5. Keyboard Navigation
+
+Navigation is handled by a single keydown function stored in a ref so it can be attached to multiple targets without re-defining:
+
+| Key | Action |
+| --- | --- |
+| → / ↓ / Space | Next slide |
+| ← / ↑ | Previous slide |
+| Home / End | Jump to first / last slide |
+| F | Toggle browser fullscreen |
+| Esc | Exit (two-stage — see Full-Window section above) |
+
+The handler is attached to **three** targets:
+
+1. `window` and `document` of the parent page (capture phase) — catches keys when focus is on the body or any non-iframe element.
+2. The iframe's `contentDocument` — re-attached on every iframe `srcdoc` load. Without this, if focus lands inside the iframe (which happens after tab switch back, after re-entering fullscreen, or after clicking on slide content), keydown events fire inside the iframe and don't bubble to the parent window.
+
+A `visibilitychange` listener also refocuses the container when the tab becomes visible again, so the parent-level listener has a chance to receive keys cleanly.
+
+The handler short-circuits if the event target is an `INPUT`, `TEXTAREA`, or `contenteditable` element, so users can still type in form fields embedded in slides.
+
+### 6. Deck Snapshot (Freeze Prevention)
+
+`PresentationMode` snapshots the `slideDeck` prop into a ref on mount and reads from the snapshot for everything thereafter:
+
+```tsx
+const deckSnapshotRef = useRef(slideDeck);
+const deck = deckSnapshotRef.current;
+```
+
+This is **not just an optimization** — it's a correctness fix. `ChatPanel` polls `/api/sessions/<id>/mentions` every 3 seconds, which re-renders `SlidePanel` and passes a new `slideDeck` reference to `<PresentationMode>` on every poll. Before snapshotting, the component's `useMemo([currentSlideIndex, slideDeck])` recomputed the iframe `srcdoc` every 3s, causing the iframe to reload mid-keypress and stalling navigation. Symptom: the presentation "froze" after a few seconds of inactivity.
+
+Snapshotting also matches the user expectation set by Google Slides — edits made in the chat panel while presenting **do not** retroactively update the open presentation. To see edits, the user re-opens Present.
+
+### 7. Start at Current Slide
+
+`SlidePanel` resolves a "current slide" index at the moment the Present button is clicked, and passes it to `<PresentationMode>` as `startIndex`:
+
+```tsx
+const openPresentationFromActive = useCallback(() => {
+  const total = slideDeck?.slides.length ?? 0;
+  let idx = 0;
+
+  if (selectedIndices.length > 0) {
+    // Explicit selection wins
+    idx = selectedIndices[0];
+  } else {
+    // Pick the slide spanning a virtual trigger line ~25% from the top
+    const triggerY = window.innerHeight * 0.25;
+    for (const [tileIndex, el] of slideRefs.current) {
+      const r = el.getBoundingClientRect();
+      if (r.top <= triggerY && r.bottom > triggerY) {
+        idx = tileIndex;
+        break;
+      }
+    }
+  }
+
+  setPresentationStartIndex(Math.max(0, Math.min(idx, Math.max(0, total - 1))));
+  setIsPresentationMode(true);
+}, [selectedIndices, slideDeck]);
+```
+
+Two rules:
+
+- **Explicit selection wins.** If the user has clicked/selected a slide, present from there.
+- **Otherwise, trigger line at 25% from top.** The slide whose bounding box covers the line is "current". This pattern matches docs-site TOC highlighting and is stable as you scroll — the trigger only advances when one tile's bottom edge crosses above the line, so adjacent tiles don't oscillate when they're equally visible.
+
+Computed on click (not via a live observer) — cheaper, deterministic, and avoids stale state during fast scrolling.
 
 ---
 
@@ -246,9 +308,9 @@ The container div has `tabIndex={-1}` and receives focus to capture keyboard eve
 
 | Path | Responsibility |
 | --- | --- |
-| `frontend/src/components/PresentationMode/PresentationMode.tsx` | Renders fullscreen portal with single-slide iframe, calculates and applies responsive scaling, manages fullscreen lifecycle, handles keyboard navigation, updates iframe content on slide change |
+| `frontend/src/components/PresentationMode/PresentationMode.tsx` | Renders the full-window portal with single-slide iframe; snapshots the deck to immunize against parent re-renders; manages opt-in browser fullscreen; handles keyboard navigation across parent + iframe documents; auto-hides chrome in fullscreen |
 | `frontend/src/components/PresentationMode/index.ts` | Barrel export |
-| `frontend/src/components/SlidePanel/SlidePanel.tsx` | Hosts Present/Export buttons, generates download HTML (all slides), toggles presentation state |
+| `frontend/src/components/SlidePanel/SlidePanel.tsx` | Hosts Present/Export buttons, resolves "current slide" on Present click (selection wins → else trigger-line at 25% from top), generates download HTML (all slides), toggles presentation state |
 
 ---
 
@@ -257,17 +319,20 @@ The container div has `tabIndex={-1}` and receives focus to capture keyboard eve
 ### Present Flow
 
 1. User clicks "Present" button in `SlidePanel`
-2. `setIsPresentationMode(true)` renders `&lt;PresentationMode&gt;` via React portal to `document.body`
-3. Component calculates initial scale factor based on viewport dimensions
-4. Component requests fullscreen (with fallback if denied)
-5. `useMemo` generates HTML for current slide (index 0 initially)
-6. Iframe loads with `srcdoc={currentSlideHTML}` and applies scale transform
-7. Container div receives focus to capture keyboard events
-8. `waitForChartJs` polls then runs current slide's scripts
-9. User navigates with arrow keys/Space; `currentSlideIndex` state updates
-10. `useEffect` detects `currentSlideIndex` change, updates iframe `srcdoc` with new slide HTML
-11. Scale recalculates automatically on window resize or orientation change
-12. Escape key or fullscreen exit triggers `onExit()`, unmounting component
+2. `openPresentationFromActive` resolves `startIndex` (selected slide, else slide at the 25%-from-top trigger line)
+3. `setIsPresentationMode(true)` renders `<PresentationMode>` via React portal to `document.body`
+4. Component snapshots the deck into `deckSnapshotRef` so the iframe is immune to upstream re-renders (e.g. ChatPanel's 3s polling)
+5. Component calculates initial scale factor based on viewport dimensions
+6. `useMemo` generates HTML for the starting slide
+7. Iframe loads with `srcdoc={currentSlideHTML}` and applies scale transform from `transformOrigin: center center`
+8. Container div receives focus; keydown handler is also attached to the iframe's `contentDocument` so navigation works regardless of which document holds focus
+9. `waitForChartJs` polls then runs current slide's scripts
+10. Keyboard-shortcut hint is visible for ~3s, then fades out
+11. User navigates with arrow keys / Space; `currentSlideIndex` updates
+12. `useEffect` updates iframe `srcdoc` on slide change; the keydown listener is re-attached to the new `contentDocument` on each load
+13. Scale recalculates automatically on window resize, orientation change, and fullscreen toggle
+14. (Optional) F key or toolbar button toggles browser fullscreen; toolbar/hint/counter all hide while fullscreen is active
+15. Esc unwinds fullscreen first (browser-handled); a second Esc exits the presentation entirely via the component's keydown handler
 
 ### Download Flow
 
@@ -303,9 +368,10 @@ The iframe wrapper uses CSS `transform: scale()` to scale the 1280×720px iframe
 | Space | Next slide |
 | Home | Jump to first slide |
 | End | Jump to last slide |
-| Escape | Exit presentation mode |
+| F | Toggle browser fullscreen |
+| Escape | Exit fullscreen (if active) → exit presentation (if already full-window) |
 
-Navigation hints are displayed in the top-right corner of the presentation overlay.
+A navigation hint (`← → Navigate · F Fullscreen · Esc Exit`) appears in the top-left for the first ~3 seconds after open, then fades out so it stops covering slide content. In fullscreen the hint stays hidden.
 
 ---
 
@@ -321,19 +387,23 @@ When enabled, "Raw HTML (Rendered)" and "Raw HTML (Text)" tabs appear in `SlideP
 
 ## Presentation Overlay UI
 
-The presentation mode includes two overlays:
+The overlay has three pieces of chrome, all of which **auto-hide in fullscreen** so the slides own the screen (the user is expected to know F/Esc/arrows once they've committed to fullscreen). In full-window mode, the toolbar and counter stay visible; only the hint auto-hides after 3 seconds.
 
 ### Slide Counter (Bottom Center)
-- Shows current slide number and total: `{currentSlideIndex + 1} / {slideDeck.slides.length}`
-- Styled with semi-transparent black background, white text
-- Positioned absolutely at bottom center
+- Shows current slide number and total: `{currentSlideIndex + 1} / {slideCount}` (`slideCount` comes from the deck snapshot, not the live prop)
+- Semi-transparent black background, white text
+- `pointerEvents: 'none'` so clicks pass through to the iframe
 
-### Navigation Hints (Top Right)
-- Displays: "← → Navigate | ESC Exit"
-- Styled with semi-transparent black background, white text, reduced opacity
-- Positioned absolutely at top right
+### Toolbar (Top Right)
+- Two interactive buttons rendered with inline SVG icons (Unicode glyphs like `⤢ / ⤡ / ✕` render inconsistently across fonts/OSes):
+  - Fullscreen toggle (`F` shortcut equivalent) — icon swaps between "enter" and "exit" arrows
+  - Close (`Esc` shortcut equivalent)
+- `pointerEvents` flips to `none` while hidden so users can't accidentally click an invisible button
 
-Both overlays have `pointerEvents: 'none'` to allow clicks to pass through to the iframe.
+### Navigation Hint (Top Left)
+- `← → Navigate · F Fullscreen · Esc Exit`
+- Visible only for the first ~3 seconds after open, then fades out (opacity transition)
+- `pointerEvents: 'none'`
 
 ---
 
@@ -376,10 +446,11 @@ If chart initialization fails:
 
 ### Error Handling
 
-- **Fullscreen denied:** Presentation still shows in overlay (graceful fallback)
+- **Fullscreen denied:** No effect on default flow (we never auto-request fullscreen). If a user invokes F/the toolbar button and the browser denies the request, the promise rejection is swallowed and the presentation stays in full-window.
 - **Chart.js timeout:** After 50 attempts (5 seconds), logs error but continues
 - **Script errors:** Logged to console but don't crash presentation
 - **Keyboard events in inputs:** Ignored to allow typing in form fields within slides
+- **Focus lost to iframe:** Mitigated by attaching the keydown listener to the iframe's `contentDocument` on every load, plus a `visibilitychange` listener that refocuses the container when the tab regains visibility
 
 ### Iframe Sandbox
 
@@ -428,25 +499,44 @@ The iframe uses `sandbox="allow-scripts allow-same-origin"` to:
 
 ### State Management
 
-- `currentSlideIndex`: Tracks which slide is currently displayed (0-based)
-- `scale`: Calculated scale factor for responsive iframe sizing (maintains 16:9 aspect ratio)
-- `iframeRef`: Reference to the iframe element for updating `srcdoc`
-- `containerRef`: Reference to the container div for keyboard focus
-- `wrapperRef`: Reference to the iframe wrapper div (for potential future use)
+State (`useState`):
+- `currentSlideIndex` — Which slide is currently displayed (0-based; initialized from the `startIndex` prop)
+- `scale` — Calculated scale factor for responsive iframe sizing
+- `isFullscreen` — Mirrors `!!document.fullscreenElement`; drives chrome visibility
+- `hintVisible` — `true` for the first 3s, then `false`. Combined with `controlsVisible` to drive hint opacity
+
+Derived: `controlsVisible = !isFullscreen` — single switch for toolbar/counter/hint visibility.
+
+Refs:
+- `iframeRef` — Iframe element, used to push `srcdoc` updates without React reconciliation
+- `containerRef` — The portal container, used for focus management
+- `wrapperRef` — Iframe wrapper (legacy; available for future use)
+- `onExitRef` — Stabilizes the `onExit` callback so it can be read from event handlers without re-running effects on parent re-renders
+- `toggleFullscreenRef` — Same pattern for the fullscreen toggle (invoked from the keydown handler)
+- `handleKeyDownRef` — Single source of truth for the keydown logic; attached to parent window/document AND to the iframe's `contentDocument` on each load
+- `deckSnapshotRef` — Captures the `slideDeck` prop on mount; the iframe HTML reads from this snapshot, not the live prop (see "Deck Snapshot" above)
 
 ### HTML Generation
 
-The `currentSlideHTML` is memoized with dependencies on `currentSlideIndex` and `slideDeck`. When either changes, new HTML is generated for the current slide, including:
+`currentSlideHTML` is memoized with **dependencies on `[currentSlideIndex]` only** — the deck is read from `deckSnapshotRef.current`, not the live `slideDeck` prop, so parent re-renders (e.g. the 3s mentions poll) don't recompute the HTML or reload the iframe.
+
+The memoized HTML includes:
 - External scripts (Chart.js CDN links)
-- Slide-specific CSS from `slideDeck.css`
+- Deck-level CSS (`deck.css`), followed by the `!important` reset
 - Current slide's HTML content
 - Current slide's scripts (wrapped in `waitForChartJs`)
 
 ### Iframe Updates
 
-When `currentSlideHTML` changes, a `useEffect` updates the iframe's `srcdoc` property, causing the iframe to reload with the new slide content. This ensures:
+When `currentSlideHTML` changes, a `useEffect` updates the iframe's `srcdoc` property, causing the iframe to reload with the new slide content. The `handleIframeLoad` callback then:
+
+1. Refocuses the container so keyboard nav keeps working
+2. Re-attaches the keydown listener to the **new** `contentDocument` (the old one was destroyed by the srcdoc swap)
+
+This ensures:
 - Each slide's scripts execute independently
 - Charts initialize correctly for each slide
+- Navigation works regardless of which document currently holds focus
 - No state leakage between slides
 
 

--- a/frontend/src/components/PresentationMode/PresentationMode.tsx
+++ b/frontend/src/components/PresentationMode/PresentationMode.tsx
@@ -15,18 +15,27 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
 }) => {
   const [currentSlideIndex, setCurrentSlideIndex] = useState(startIndex);
   const [scale, setScale] = useState(1);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
 
+  // Snapshot deck on mount so periodic parent re-renders (e.g. ChatPanel's 3s
+  // mentions polling) don't reload the iframe by changing the slideDeck prop
+  // reference. Slides edited from chat are intentionally not reflected until
+  // the next time presentation mode is opened — matches Google Slides behavior.
+  const deckSnapshotRef = useRef(slideDeck);
+  const deck = deckSnapshotRef.current;
+  const slideCount = deck.slides.length;
+
   // Generate HTML for current slide (no reveal.js)
   const currentSlideHTML = useMemo(() => {
-    const slide = slideDeck.slides[currentSlideIndex];
+    const slide = deck.slides[currentSlideIndex];
     const slideScripts = slide.scripts || '';
-    
-    const externalScriptsHtml = slideDeck.external_scripts
+
+    const externalScriptsHtml = deck.external_scripts
       .map((src) => `<script src="${src}"></script>`)
       .join('\n');
 
@@ -38,43 +47,44 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
   ${externalScriptsHtml}
   <style>
     * {
-      margin: 0;
-      padding: 0;
       box-sizing: border-box;
     }
     html, body {
       width: 100%;
       height: 100%;
-      overflow: auto;
-      background: #ffffff;
-    }
-    body {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 0;
-      margin: 0;
-    }
-    /* Slide container - maintains 16:9 aspect ratio */
-    .slide-container {
-      width: 1280px;
-      height: 720px;
-      position: relative;
-      background: #ffffff;
       overflow: hidden;
-      margin: 0;
-    }
-    /* Ensure slide content fills container */
-    .slide-container > * {
-      width: 100%;
-      height: 100%;
+      background: #ffffff;
     }
     /* Chart canvas scaling */
     canvas {
       max-width: 100%;
       height: auto;
     }
-    ${slideDeck.css}
+    ${deck.css}
+    /* Reset body styles AFTER deck CSS so per-deck CSS can't squash the slide
+       by adding body padding/flex centering (which would shrink the 720px
+       slide-container via flex layout and clip content at the top). */
+    body {
+      display: flex !important;
+      justify-content: center !important;
+      align-items: flex-start !important;
+      padding: 0 !important;
+      margin: 0 !important;
+    }
+    .slide-container {
+      width: 1280px;
+      height: 720px;
+      flex-shrink: 0;
+      flex-grow: 0;
+      position: relative;
+      background: #ffffff;
+      overflow: hidden;
+      margin: 0;
+    }
+    .slide-container > * {
+      width: 100%;
+      height: 100%;
+    }
   </style>
 </head>
 <body>
@@ -119,7 +129,9 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
   </script>
 </body>
 </html>`;
-  }, [currentSlideIndex, slideDeck]);
+    // deck is captured once via deckSnapshotRef; only the active slide changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSlideIndex]);
 
   // Calculate scale factor to fit viewport while maintaining aspect ratio
   useEffect(() => {
@@ -154,7 +166,10 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
     }
   }, [currentSlideHTML]);
 
-  // Handle keyboard navigation
+  // Handle keyboard navigation. Deps intentionally empty: slideCount comes from
+  // the frozen deck snapshot, onExit lives in onExitRef. Re-running this effect
+  // on every parent re-render (3s mentions polling) was leaving keypresses
+  // unhandled mid-swap, which felt like a freeze.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Only handle if not typing in an input/textarea
@@ -169,7 +184,7 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
         case ' ': // Spacebar
           e.preventDefault();
           e.stopPropagation();
-          setCurrentSlideIndex((prev) => Math.min(prev + 1, slideDeck.slides.length - 1));
+          setCurrentSlideIndex((prev) => Math.min(prev + 1, slideCount - 1));
           break;
         case 'ArrowLeft':
         case 'ArrowUp':
@@ -185,12 +200,18 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
         case 'End':
           e.preventDefault();
           e.stopPropagation();
-          setCurrentSlideIndex(slideDeck.slides.length - 1);
+          setCurrentSlideIndex(slideCount - 1);
+          break;
+        case 'f':
+        case 'F':
+          e.preventDefault();
+          e.stopPropagation();
+          toggleFullscreenRef.current();
           break;
         case 'Escape':
           e.preventDefault();
           e.stopPropagation();
-          onExit();
+          onExitRef.current();
           break;
       }
     };
@@ -198,7 +219,7 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
     // Attach to both window and document for better coverage
     window.addEventListener('keydown', handleKeyDown, true); // Use capture phase
     document.addEventListener('keydown', handleKeyDown, true);
-    
+
     // Focus the container to ensure keyboard events are captured
     if (containerRef.current) {
       containerRef.current.focus();
@@ -208,7 +229,8 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
       window.removeEventListener('keydown', handleKeyDown, true);
       document.removeEventListener('keydown', handleKeyDown, true);
     };
-  }, [slideDeck.slides.length, onExit]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Focus container on mount to capture keyboard events
   useEffect(() => {
@@ -221,45 +243,64 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
     return () => clearTimeout(timer);
   }, []);
 
-  // Handle fullscreen — runs once on mount only
-  useEffect(() => {
-    document.documentElement.requestFullscreen().catch(() => {
-      // Fallback: still show presentation if fullscreen denied
-    });
+  // Fullscreen is opt-in. Default mode is "full window" — the fixed-position
+  // portal already covers 100vw × 100vh, like Google Slides' Slideshow view.
+  // Users can toggle true browser fullscreen via the F key or the toolbar
+  // button (matches Google Slides' Cmd+Shift+Enter).
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    } else {
+      document.documentElement.requestFullscreen().catch(() => {});
+    }
+  };
+  const toggleFullscreenRef = useRef(toggleFullscreen);
+  toggleFullscreenRef.current = toggleFullscreen;
 
+  useEffect(() => {
     const handleFullscreenChange = () => {
-      if (!document.fullscreenElement) {
-        onExitRef.current();
-      } else {
-        // Recalculate scale when entering fullscreen (viewport size may change)
-        setTimeout(() => {
-          const baseWidth = 1280;
-          const baseHeight = 720;
-          const viewportWidth = window.innerWidth;
-          const viewportHeight = window.innerHeight;
-          
-          const scaleX = viewportWidth / baseWidth;
-          const scaleY = viewportHeight / baseHeight;
-          const newScale = Math.min(scaleX, scaleY);
-          setScale(newScale);
-          
-          // Refocus container when entering fullscreen
-          if (containerRef.current) {
-            containerRef.current.focus();
-          }
-        }, 100);
-      }
+      const fs = !!document.fullscreenElement;
+      setIsFullscreen(fs);
+      // Recalculate scale: viewport changes shape when toggling fullscreen.
+      // Refocus the container so keyboard nav keeps working.
+      setTimeout(() => {
+        const baseWidth = 1280;
+        const baseHeight = 720;
+        const newScale = Math.min(
+          window.innerWidth / baseWidth,
+          window.innerHeight / baseHeight,
+        );
+        setScale(newScale);
+        if (containerRef.current) {
+          containerRef.current.focus();
+        }
+      }, 50);
     };
 
     document.addEventListener('fullscreenchange', handleFullscreenChange);
-
     return () => {
       document.removeEventListener('fullscreenchange', handleFullscreenChange);
+      // If we were holding the browser fullscreen lock, release it on unmount.
       if (document.fullscreenElement) {
-        document.exitFullscreen();
+        document.exitFullscreen().catch(() => {});
       }
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
+
+  // In fullscreen the slides own the screen — toolbar, hint, and counter all
+  // hide. Keyboard shortcuts (Esc, F, arrows) still work. Full-window mode
+  // keeps the interactive toolbar + counter visible because that's still a
+  // "preview" surface.
+  const controlsVisible = !isFullscreen;
+
+  // The keyboard-shortcut hint is purely educational. Show it for a few
+  // seconds on mount so the user can learn the controls, then fade it out so
+  // it stops covering slide content. Stays hidden afterwards.
+  const [hintVisible, setHintVisible] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setHintVisible(false), 3000);
+    return () => clearTimeout(t);
+  }, []);
 
   // Handle iframe load - refocus container to capture keyboard events
   const handleIframeLoad = () => {
@@ -307,17 +348,101 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
           fontFamily: 'system-ui, sans-serif',
           zIndex: 10000,
           pointerEvents: 'none',
+          opacity: controlsVisible ? 1 : 0,
+          transition: 'opacity 0.2s ease-out',
         }}
       >
-        {currentSlideIndex + 1} / {slideDeck.slides.length}
+        {currentSlideIndex + 1} / {slideCount}
       </div>
 
-      {/* Navigation hint overlay */}
+      {/* Toolbar: fullscreen toggle + close button. Discoverable equivalents
+          of the F and Esc keyboard shortcuts. Auto-hides in fullscreen. */}
       <div
         style={{
           position: 'absolute',
           top: '20px',
           right: '20px',
+          display: 'flex',
+          gap: '8px',
+          zIndex: 10000,
+          opacity: controlsVisible ? 1 : 0,
+          // While hidden, swallow pointer events so the user can't accidentally
+          // click an invisible button.
+          pointerEvents: controlsVisible ? 'auto' : 'none',
+          transition: 'opacity 0.2s ease-out',
+        }}
+      >
+        <button
+          type="button"
+          onClick={toggleFullscreen}
+          aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          title={isFullscreen ? 'Exit fullscreen (F)' : 'Fullscreen (F)'}
+          data-testid="presentation-fullscreen-toggle"
+          style={{
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            color: '#ffffff',
+            width: '36px',
+            height: '36px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: 'none',
+            borderRadius: '8px',
+            cursor: 'pointer',
+            padding: 0,
+          }}
+        >
+          {isFullscreen ? (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M8 3v3a2 2 0 0 1-2 2H3" />
+              <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
+              <path d="M3 16h3a2 2 0 0 1 2 2v3" />
+              <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+            </svg>
+          ) : (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M3 8V5a2 2 0 0 1 2-2h3" />
+              <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+              <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+              <path d="M21 16v3a2 2 0 0 1-2 2h-3" />
+            </svg>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => onExitRef.current()}
+          aria-label="Exit presentation"
+          title="Exit (Esc)"
+          data-testid="presentation-close"
+          style={{
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            color: '#ffffff',
+            width: '36px',
+            height: '36px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: 'none',
+            borderRadius: '8px',
+            cursor: 'pointer',
+            padding: 0,
+          }}
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M18 6L6 18" />
+            <path d="M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Navigation hint overlay — only shown briefly on open in full-window
+          mode so the user learns the keyboard shortcuts, then fades out so it
+          stops covering slide content. Stays hidden in fullscreen. */}
+      <div
+        style={{
+          position: 'absolute',
+          top: '20px',
+          left: '20px',
           backgroundColor: 'rgba(0, 0, 0, 0.7)',
           color: '#ffffff',
           padding: '8px 12px',
@@ -326,10 +451,11 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
           fontFamily: 'system-ui, sans-serif',
           zIndex: 10000,
           pointerEvents: 'none',
-          opacity: 0.7,
+          opacity: controlsVisible && hintVisible ? 0.7 : 0,
+          transition: 'opacity 0.4s ease-out',
         }}
       >
-        ← → Navigate | ESC Exit
+        ← → Navigate · F Fullscreen · Esc Exit
       </div>
 
       {/* Iframe wrapper that maintains 16:9 aspect ratio and scales to fit viewport */}
@@ -357,6 +483,12 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
             padding: 0,
             pointerEvents: 'auto',
             transform: `scale(${scale})`,
+            // Keep the scaled iframe centered. Truncation of slide CONTENT is
+            // handled inside the iframe via .slide-container overflow:hidden;
+            // transformOrigin here only controls how the unavoidable empty
+            // space (when viewport aspect ratio ≠ 16:9) is distributed.
+            // center-center splits it top+bottom equally — biasing to top
+            // visually pins the slide to the bottom of the viewport.
             transformOrigin: 'center center',
           }}
           sandbox="allow-scripts allow-same-origin"

--- a/frontend/src/components/PresentationMode/PresentationMode.tsx
+++ b/frontend/src/components/PresentationMode/PresentationMode.tsx
@@ -84,6 +84,10 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
     .slide-container > * {
       width: 100%;
       height: 100%;
+      /* Zero any margin a deck CSS may add to its slide root — margins push
+         the slide inside the 720px clipping container and cause bottom-edge
+         truncation (e.g. ".slide { margin: 40px auto }" preview-mode styles). */
+      margin: 0 !important;
     }
   </style>
 </head>

--- a/frontend/src/components/PresentationMode/PresentationMode.tsx
+++ b/frontend/src/components/PresentationMode/PresentationMode.tsx
@@ -166,70 +166,80 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
     }
   }, [currentSlideHTML]);
 
-  // Handle keyboard navigation. Deps intentionally empty: slideCount comes from
-  // the frozen deck snapshot, onExit lives in onExitRef. Re-running this effect
-  // on every parent re-render (3s mentions polling) was leaving keypresses
-  // unhandled mid-swap, which felt like a freeze.
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Only handle if not typing in an input/textarea
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        return;
-      }
+  // Single source of truth for keyboard handling, stored in a ref so it can be
+  // attached to the iframe's contentDocument on every load (see handleIframeLoad)
+  // without re-defining the handler. Without this, if focus lands inside the
+  // iframe — which happens after a tab switch back, after entering fullscreen,
+  // or after a click into slide content — keydown events fire in the iframe's
+  // document and don't bubble up to the parent window, so navigation breaks.
+  const handleKeyDownRef = useRef<(e: KeyboardEvent) => void>(() => {});
+  handleKeyDownRef.current = (e: KeyboardEvent) => {
+    const target = e.target as HTMLElement | null;
+    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case ' ': // Spacebar
+        e.preventDefault();
+        e.stopPropagation();
+        setCurrentSlideIndex((prev) => Math.min(prev + 1, slideCount - 1));
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        e.stopPropagation();
+        setCurrentSlideIndex((prev) => Math.max(prev - 1, 0));
+        break;
+      case 'Home':
+        e.preventDefault();
+        e.stopPropagation();
+        setCurrentSlideIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        e.stopPropagation();
+        setCurrentSlideIndex(slideCount - 1);
+        break;
+      case 'f':
+      case 'F':
+        e.preventDefault();
+        e.stopPropagation();
+        toggleFullscreenRef.current();
+        break;
+      case 'Escape':
+        e.preventDefault();
+        e.stopPropagation();
+        onExitRef.current();
+        break;
+    }
+  };
 
-      switch (e.key) {
-        case 'ArrowRight':
-        case 'ArrowDown':
-        case ' ': // Spacebar
-          e.preventDefault();
-          e.stopPropagation();
-          setCurrentSlideIndex((prev) => Math.min(prev + 1, slideCount - 1));
-          break;
-        case 'ArrowLeft':
-        case 'ArrowUp':
-          e.preventDefault();
-          e.stopPropagation();
-          setCurrentSlideIndex((prev) => Math.max(prev - 1, 0));
-          break;
-        case 'Home':
-          e.preventDefault();
-          e.stopPropagation();
-          setCurrentSlideIndex(0);
-          break;
-        case 'End':
-          e.preventDefault();
-          e.stopPropagation();
-          setCurrentSlideIndex(slideCount - 1);
-          break;
-        case 'f':
-        case 'F':
-          e.preventDefault();
-          e.stopPropagation();
-          toggleFullscreenRef.current();
-          break;
-        case 'Escape':
-          e.preventDefault();
-          e.stopPropagation();
-          onExitRef.current();
-          break;
+  // Re-grab focus when returning to the tab so the parent listener actually
+  // sees keypresses. The iframe listener (attached in handleIframeLoad) covers
+  // the case where focus is in the iframe itself.
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible' && containerRef.current) {
+        containerRef.current.focus();
       }
     };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
 
-    // Attach to both window and document for better coverage
-    window.addEventListener('keydown', handleKeyDown, true); // Use capture phase
-    document.addEventListener('keydown', handleKeyDown, true);
-
-    // Focus the container to ensure keyboard events are captured
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => handleKeyDownRef.current(e);
+    window.addEventListener('keydown', onKey, true);
+    document.addEventListener('keydown', onKey, true);
     if (containerRef.current) {
       containerRef.current.focus();
     }
-
     return () => {
-      window.removeEventListener('keydown', handleKeyDown, true);
-      document.removeEventListener('keydown', handleKeyDown, true);
+      window.removeEventListener('keydown', onKey, true);
+      document.removeEventListener('keydown', onKey, true);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Focus container on mount to capture keyboard events
@@ -302,11 +312,20 @@ export const PresentationMode: React.FC<PresentationModeProps> = ({
     return () => clearTimeout(t);
   }, []);
 
-  // Handle iframe load - refocus container to capture keyboard events
+  // Handle iframe load — refocus the container, AND attach the keydown
+  // handler to the iframe's freshly-loaded contentDocument so navigation works
+  // even when focus lands inside the iframe (which happens after tab switch,
+  // re-entering fullscreen, or clicking on slide content). srcdoc reloads
+  // create a new contentDocument each time, so we re-attach per load; the old
+  // document is GC'd along with its listener.
   const handleIframeLoad = () => {
-    // Don't focus iframe, keep focus on container for keyboard navigation
     if (containerRef.current) {
       containerRef.current.focus();
+    }
+    const doc = iframeRef.current?.contentDocument;
+    if (doc) {
+      const onKey = (e: KeyboardEvent) => handleKeyDownRef.current(e);
+      doc.addEventListener('keydown', onKey, true);
     }
   };
 

--- a/frontend/src/components/SlidePanel/SlidePanel.tsx
+++ b/frontend/src/components/SlidePanel/SlidePanel.tsx
@@ -60,6 +60,7 @@ function SlidePanelComponent(props: SlidePanelProps, ref: React.Ref<SlidePanelHa
   const [showExportMenu, setShowExportMenu] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
   const [isPresentationMode, setIsPresentationMode] = useState(false);
+  const [presentationStartIndex, setPresentationStartIndex] = useState(0);
   const [optimizingSlideIndex, setOptimizingSlideIndex] = useState<number | null>(null);
   const [deleteSlideIndex, setDeleteSlideIndex] = useState<number | null>(null);
   const { selectedIndices, setSelection, clearSelection } = useSelection();
@@ -476,11 +477,37 @@ function SlidePanelComponent(props: SlidePanelProps, ref: React.Ref<SlidePanelHa
     URL.revokeObjectURL(url);
   };
 
+  const openPresentationFromActive = useCallback(() => {
+    const total = slideDeck?.slides.length ?? 0;
+    let idx = 0;
+
+    if (selectedIndices.length > 0) {
+      // Explicit selection wins — clicking a tile is an unambiguous "current".
+      idx = selectedIndices[0];
+    } else {
+      // No selection: pick the slide spanning a virtual trigger line ~25% from
+      // the top of the viewport. As you scroll, the trigger only advances when
+      // one tile's bottom crosses above the line, so there's no oscillation
+      // between two equally-visible tiles. Pattern used by docs-site TOCs.
+      const triggerY = window.innerHeight * 0.25;
+      for (const [tileIndex, el] of slideRefs.current) {
+        const r = el.getBoundingClientRect();
+        if (r.top <= triggerY && r.bottom > triggerY) {
+          idx = tileIndex;
+          break;
+        }
+      }
+    }
+
+    setPresentationStartIndex(Math.max(0, Math.min(idx, Math.max(0, total - 1))));
+    setIsPresentationMode(true);
+  }, [selectedIndices, slideDeck]);
+
   useImperativeHandle(ref, () => ({
     exportPDF: handleExportPDF,
     exportPPTX: handleExportPPTX,
     exportHTML: handleSaveAsHTML,
-    openPresentationMode: () => setIsPresentationMode(true),
+    openPresentationMode: openPresentationFromActive,
   }));
 
   useEffect(() => {
@@ -686,7 +713,7 @@ function SlidePanelComponent(props: SlidePanelProps, ref: React.Ref<SlidePanelHa
         <PresentationMode
           slideDeck={slideDeck}
           onExit={() => setIsPresentationMode(false)}
-          startIndex={0}
+          startIndex={presentationStartIndex}
         />
       )}
     </div>

--- a/frontend/tests/e2e/presentation-mode.spec.ts
+++ b/frontend/tests/e2e/presentation-mode.spec.ts
@@ -70,4 +70,93 @@ test.describe('Presentation Mode', () => {
     await expect(overlay).toBeVisible();
     await expect(page.getByText(/1\s*\/\s*\d+/)).toBeVisible();
   });
+
+  test('keyboard navigation still works after polling-driven re-renders', async ({ page }) => {
+    // Regression for the "freezes after a few seconds" wishlist item: the
+    // 3s ChatPanel polling was re-creating the slideDeck reference, the
+    // useMemo recomputed the iframe srcdoc, and the iframe reloaded mid-press.
+    // We snapshot the deck on mount now, so ArrowRight should still advance
+    // the slide after the polling interval has elapsed.
+    await setupPresentationMocks(page);
+    await page.goto(`/sessions/${TEST_SESSION_ID}/edit`);
+
+    const presentButton = page.getByRole('button', { name: 'Present' });
+    await presentButton.waitFor({ state: 'visible', timeout: 15000 });
+    await presentButton.click();
+
+    await expect(presentationOverlay(page)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/1\s*\/\s*\d+/)).toBeVisible();
+
+    // Wait past the polling interval, then advance.
+    await page.waitForTimeout(5000);
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByText(/2\s*\/\s*\d+/)).toBeVisible({ timeout: 2000 });
+  });
+
+  test('opens in full-window mode by default, does not request browser fullscreen', async ({ page }) => {
+    // Wishlist item #2: presenter view should default to full-window (like
+    // Google Slides Slideshow view), not browser fullscreen.
+    await setupPresentationMocks(page);
+    await page.goto(`/sessions/${TEST_SESSION_ID}/edit`);
+
+    const presentButton = page.getByRole('button', { name: 'Present' });
+    await presentButton.waitFor({ state: 'visible', timeout: 15000 });
+    await presentButton.click();
+
+    await expect(presentationOverlay(page)).toBeVisible({ timeout: 5000 });
+
+    // The toolbar must expose both controls so users have a discoverable exit
+    // and a way to opt into browser fullscreen.
+    await expect(page.getByTestId('presentation-fullscreen-toggle')).toBeVisible();
+    await expect(page.getByTestId('presentation-close')).toBeVisible();
+
+    // Browser fullscreen should NOT be active by default.
+    const fullscreenElement = await page.evaluate(() => document.fullscreenElement?.tagName ?? null);
+    expect(fullscreenElement).toBeNull();
+  });
+
+  test('close button exits presentation', async ({ page }) => {
+    await setupPresentationMocks(page);
+    await page.goto(`/sessions/${TEST_SESSION_ID}/edit`);
+
+    const presentButton = page.getByRole('button', { name: 'Present' });
+    await presentButton.waitFor({ state: 'visible', timeout: 15000 });
+    await presentButton.click();
+
+    const overlay = presentationOverlay(page);
+    await expect(overlay).toBeVisible({ timeout: 5000 });
+
+    await page.getByTestId('presentation-close').click();
+    await expect(overlay).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('slide-container is pinned to 720px so deck CSS body padding cannot squash it', async ({ page }) => {
+    // Wishlist item / truncation root cause: when deck CSS added body
+    // padding, the flex-shrinkable .slide-container collapsed below 720px
+    // and content was clipped on both edges.
+    await setupPresentationMocks(page);
+    await page.goto(`/sessions/${TEST_SESSION_ID}/edit`);
+
+    const presentButton = page.getByRole('button', { name: 'Present' });
+    await presentButton.waitFor({ state: 'visible', timeout: 15000 });
+    await presentButton.click();
+
+    await expect(presentationOverlay(page)).toBeVisible({ timeout: 5000 });
+
+    // Inject body padding into the iframe document, mimicking what a styled
+    // deck would do, then assert the slide-container is still 720px tall.
+    const containerHeight = await page.evaluate(() => {
+      const iframes = Array.from(document.querySelectorAll('iframe'))
+        .filter((f) => f.title?.startsWith('Slide '));
+      const presentIframe = iframes[iframes.length - 1] as HTMLIFrameElement | undefined;
+      if (!presentIframe) return null;
+      const doc = presentIframe.contentDocument;
+      if (!doc) return null;
+      doc.body.style.padding = '40px 0';
+      const sc = doc.querySelector('.slide-container') as HTMLElement | null;
+      return sc ? sc.getBoundingClientRect().height : null;
+    });
+
+    expect(containerHeight).toBe(720);
+  });
 });


### PR DESCRIPTION
## Summary

Bundles four presentation-mode fixes/improvements into one PR.

### 1. Slide truncation (bug)
When a deck's CSS adds `body { padding }` or makes the body a flex container, the inline-styled `.slide-container` inside the iframe got `flex-shrink`'d below 720px and content was clipped on both edges. Fix: pin `.slide-container` with `flex-shrink: 0; flex-grow: 0;` and apply `!important` body resets *after* the deck's CSS so per-deck styles can't override the layout.

### 2. Presentation freezes after a few seconds of inactivity (bug)
`ChatPanel` polls every 3s; each poll re-renders `SlidePanel`, which was passing a fresh `slideDeck` reference into `<PresentationMode>`. The component's `useMemo` recomputed the iframe `srcdoc` and the iframe reloaded mid-keypress every 3s — the user experience was a periodic freeze. Fix: snapshot the deck on mount via `deckSnapshotRef`. The present view is now immune to upstream re-renders; edits made in chat while presenting aren't reflected until the next time Present is opened (Google-Slides behavior).

### 3. Full-window default + opt-in browser fullscreen (feature)
Used to call `document.documentElement.requestFullscreen()` on mount, which yanks the user out of their normal browser context. The fixed-position portal already covers `100vw × 100vh`, so the default is now "full window" (Google Slides Slideshow style). Press **F** or click the toolbar button to opt into browser fullscreen. Browser Esc unwinds fullscreen first; a second Esc exits the presentation — natural two-stage like Google Slides / Keynote.

### 4. Start at the current slide (feature)
Was hardcoded to start at slide 1. Now `SlidePanel` resolves "current slide" on Present click:
- If a slide is explicitly selected, that wins
- Otherwise, the slide whose bounding box covers a virtual trigger line ~25% from the top of the scroll viewport (same pattern as docs-site TOC highlighting; avoids the oscillation that "max intersection ratio" gives when two tiles are equally visible)

### Polish
- Toolbar uses inline SVG icons instead of Unicode glyphs (⤢/⤡/✕ render inconsistently across fonts/OS)
- Keyboard-shortcut hint shows for ~3s on open, then fades out so it stops covering slide content
- In fullscreen, toolbar/hint/counter all hide — the slides own the screen, Esc still exits

## Test plan

E2e regressions added in `frontend/tests/e2e/presentation-mode.spec.ts`:

- [x] Keyboard navigation still works after 5s of polling-driven re-renders (covers #2)
- [x] Opens in full-window mode by default; `document.fullscreenElement === null` (covers #3)
- [x] Close button (✕) exits presentation
- [x] `.slide-container` stays 720px tall even after the test injects `body { padding: 40px 0 }` into the iframe (covers #1)

Manual smoke on `db-tellr-jss`:
- [x] Open Present from slide 5 → counter shows `5 / 8` ✓
- [x] Truncation: deck with body padding/flex no longer clips content ✓
- [x] Inactivity: ArrowRight after 5+ seconds still advances ✓
- [x] F toggles fullscreen, Esc steps back (fullscreen → window → exit) ✓
- [x] Hint fades after 3s; all chrome hides in fullscreen ✓

This pull request and its description were written by Isaac.