### PR TITLE
fix(chat): stop echoing user message and collapse revised-slide HTML

### DIFF
--- a/frontend/src/components/ChatPanel/Message.tsx
+++ b/frontend/src/components/ChatPanel/Message.tsx
@@ -67,11 +67,17 @@ export const Message: React.FC<MessageProps> = ({ message }) => {
   }
 
   const trimmedContent = message.content.trimStart();
+  // Slide HTML arrives in two shapes: a full document on initial creation
+  // (starts with <!DOCTYPE html>) and bare slide divs on revisions. Real slides
+  // use compound classes like `class="slide content"`, so match the `slide`
+  // class token anywhere in a div's class list — not just an exact
+  // `class="slide"` substring — to mirror the backend's `class_="slide"` parsing.
+  const SLIDE_DIV_PATTERN =
+    /<div\b[^>]*\bclass\s*=\s*["'](?:[^"']*\s)?slide(?:\s[^"']*)?["']/i;
   const isHtmlContent =
     message.role === 'assistant' &&
     (trimmedContent.includes('<!DOCTYPE html') ||
-      trimmedContent.includes('<div class="slide"') ||
-      trimmedContent.includes("<div class='slide'"));
+      SLIDE_DIV_PATTERN.test(trimmedContent));
 
   if (isHtmlContent) {
     return renderCollapsibleContent(

--- a/frontend/tests/e2e/chat-ui.spec.ts
+++ b/frontend/tests/e2e/chat-ui.spec.ts
@@ -357,6 +357,58 @@ test.describe('MessageList', () => {
 });
 
 // ============================================
+// HTML Collapsing Tests
+// ============================================
+
+/**
+ * Build an SSE stream that emits a single assistant message containing raw
+ * slide HTML (as returned when revising slides), then completes.
+ */
+function createAssistantHtmlResponse(html: string): string {
+  const events: string[] = [];
+  events.push('data: {"type": "start", "message": "Working..."}\n\n');
+  events.push(`data: ${JSON.stringify({ type: 'assistant', content: html })}\n\n`);
+  events.push('data: {"type": "complete", "message": "Done"}\n\n');
+  return events.join('');
+}
+
+test.describe('HTML Collapsing', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+  });
+
+  // Revision responses return raw slide divs (no <!DOCTYPE html>) and real slides
+  // use compound classes like `class="slide content"`. The assistant message must
+  // still collapse into the "(HTML)" block rather than leak raw markup into the chat.
+  test('collapses revised slide HTML with a compound slide class', async ({ page }) => {
+    const revisedSlide = [
+      '<div class="slide content">',
+      '<p class="eyebrow">Governance</p>',
+      '<h1>Unity AI Gateway budgets give full spend control</h1>',
+      '</div>',
+    ].join('\n');
+
+    await page.route('http://127.0.0.1:8000/api/chat/stream', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: createAssistantHtmlResponse(revisedSlide),
+      });
+    });
+
+    await goToGenerator(page);
+    await page.getByRole('textbox').fill('remove the subtitle from this slide');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    // The assistant HTML must be collapsed into the labelled block...
+    await expect(page.getByText('AI Assistant (HTML)')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Generated slide HTML')).toBeVisible();
+    // ...and the raw markup must not leak into the chat as plain text.
+    await expect(page.getByText('Unity AI Gateway budgets give full spend control')).not.toBeVisible();
+  });
+});
+
+// ============================================
 // LoadingStates Tests
 // ============================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ description = "AI-powered slide generation using Databricks"
 requires-python = ">=3.10"
 dependencies = [
     "databricks-sdk>=0.85.0",
-    "fastapi>=0.104.0",
+    # Upper bounds: fastapi 0.137 / starlette 1.3 regressed APIRouter handling —
+    # app.include_router() stopped flattening sub-router routes into the app, so
+    # whole route groups (admin, google-slides, …) silently failed to register.
+    # Caught by tests/unit/test_app_wiring.py. Pinned to the last good combo.
+    "fastapi>=0.104.0,<0.137",
+    "starlette<1.3",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.4.0",
     "pydantic-settings>=2.0.0",

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -112,7 +112,7 @@ fi
 
 # Note: Environment names must match keys in config/deployment.yaml
 # Add new environments to the regex below when adding to deployment.yaml
-if [[ ! "$ENV" =~ ^(development|staging|production|test)$ ]]; then
+if [[ ! "$ENV" =~ ^(development|staging|production|test|chatfix)$ ]]; then
     echo -e "${RED}Invalid environment: $ENV${NC}"
     echo "   Check config/deployment.yaml for valid environment names"
     exit 1

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -112,7 +112,7 @@ fi
 
 # Note: Environment names must match keys in config/deployment.yaml
 # Add new environments to the regex below when adding to deployment.yaml
-if [[ ! "$ENV" =~ ^(development|staging|production|test|chatfix)$ ]]; then
+if [[ ! "$ENV" =~ ^(development|staging|production|test)$ ]]; then
     echo -e "${RED}Invalid environment: $ENV${NC}"
     echo "   Check config/deployment.yaml for valid environment names"
     exit 1

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -552,7 +552,16 @@ async def poll_chat(
         session_manager.get_messages_for_request, request_id, after_message_id
     )
 
-    events = [session_manager.msg_to_stream_event(m) for m in messages]
+    # Exclude the user's own message from the streamed events. It is persisted
+    # under this request_id (so it appears here), but the frontend already shows
+    # it optimistically when sent. Echoing it back would render the user's own
+    # text as an instant "AI Assistant" response. Only stream assistant/tool
+    # activity generated during processing.
+    events = [
+        session_manager.msg_to_stream_event(m)
+        for m in messages
+        if m["role"] != "user"
+    ]
 
     return {
         "status": chat_request["status"],

--- a/tests/integration/test_api_routes.py
+++ b/tests/integration/test_api_routes.py
@@ -364,6 +364,58 @@ class TestChatEndpoints:
         assert "status" in data
         assert data["status"] == "completed"
 
+    def test_chat_poll_does_not_echo_user_message(self, client, mock_session_manager):
+        """Poll must not return the user's own message back as an assistant event.
+
+        Regression test: the user message is persisted under the request_id, so it is
+        returned by get_messages_for_request. Previously msg_to_stream_event mapped
+        role=='user' to event type 'assistant', which the frontend rendered as an AI
+        response — an instant echo of the user's own message. The poll should only
+        stream assistant/tool activity generated during processing.
+        """
+        from src.api.services.session_manager import SessionManager
+
+        mock_session_manager.get_chat_request.return_value = {
+            "status": "processing",
+            "result": None,
+        }
+        mock_session_manager.get_messages_for_request.return_value = [
+            {
+                "id": 1,
+                "role": "user",
+                "content": "Make the title slide blue",
+                "message_type": "user_query",
+                "created_at": "2026-01-01T00:00:00Z",
+                "metadata": None,
+            },
+            {
+                "id": 2,
+                "role": "assistant",
+                "content": "<div class=\"slide content\">updated</div>",
+                "message_type": "llm_response",
+                "created_at": "2026-01-01T00:00:01Z",
+                "metadata": None,
+            },
+        ]
+        # Use the real conversion so we exercise the actual mapping logic.
+        mock_session_manager.msg_to_stream_event.side_effect = (
+            SessionManager.msg_to_stream_event.__get__(
+                mock_session_manager, SessionManager
+            )
+        )
+
+        response = client.get("/api/chat/poll/req-123")
+        assert response.status_code == 200
+        data = response.json()
+
+        contents = [event.get("content") for event in data["events"]]
+        # The user's own message must never be echoed back as a chat event.
+        assert "Make the title slide blue" not in contents
+        # The genuine assistant message still flows through.
+        assert "<div class=\"slide content\">updated</div>" in contents
+        # last_message_id still advances past the user message so it is not refetched.
+        assert data["last_message_id"] == 2
+
 
 # ============================================
 # Slide Endpoint Tests

--- a/tests/unit/test_google_slides_converter.py
+++ b/tests/unit/test_google_slides_converter.py
@@ -329,9 +329,7 @@ class TestParallelCodegen:
             for _ in range(4)
         ]
 
-        codes = asyncio.get_event_loop().run_until_complete(
-            converter._generate_all_codes(slide_inputs)
-        )
+        codes = asyncio.run(converter._generate_all_codes(slide_inputs))
 
         assert len(codes) == 4
         assert all(c is not None for c in codes)


### PR DESCRIPTION
## Summary

Fixes two chat UI bugs found in the slide editor.

### 1. User message echoed as an instant AI response (polling mode)
The user's message is persisted under the request's `request_id`, so the poll endpoint returned it, and `msg_to_stream_event` mapped `role=="user"` to an `"assistant"` event. The frontend then rendered the user's own text as an immediate AI reply — appearing almost instantly because it isn't an LLM response at all.

This only surfaced in **polling mode** (Databricks/production); the SSE/dev path never re-emits the user message.

**Fix:** `poll_chat` now excludes user-role messages from the streamed events. The frontend already shows the user message optimistically on send, so nothing is lost; `last_message_id` still advances past it.

### 2. Revised-slide HTML leaked into the chat instead of collapsing
The chat collapses assistant HTML into a tidy "(HTML)" block. Detection matched the exact substring `` <div class="slide" ``, but:
- Initial creation works because the response starts with `<!DOCTYPE html>`.
- Revision responses contain only bare slide divs (no `<!DOCTYPE html>`), and real slides use **compound classes** like `class="slide content"` — so the exact-substring check failed and the raw markup leaked into the chat as plain text.

**Fix:** detection now matches the `slide` class token anywhere in a div's class list, mirroring the backend's BeautifulSoup `class_="slide"` parsing. The token match correctly rejects `slider` / `slide-deck` / `slideshow`.

## Testing
- **Backend:** new `test_chat_poll_does_not_echo_user_message` (red→green); full chat/session suite passes (110 passed, 2 skipped).
- **Frontend:** new E2E `collapses revised slide HTML with a compound slide class` (red→green); full `chat-ui.spec.ts` passes (28); `tsc` typecheck clean.

Both fixes were developed test-first: each regression test was confirmed failing against the bug before the fix.

This pull request and its description were written by Isaac.