### PR TITLE
ci(devops): add Test-PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,188 @@
+name: Publish to Test PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "PEP 440 dev version to publish, e.g. 0.3.9.dev3"
+        required: true
+        type: string
+
+env:
+  PYTHON_VERSION: "3.12"
+  NODE_VERSION: "20"
+
+jobs:
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Stamp version into both pyproject.toml files
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+          import tomllib
+
+          version = os.environ["INPUT_VERSION"]
+          paths = [
+              pathlib.Path("packages/databricks-tellr/pyproject.toml"),
+              pathlib.Path("packages/databricks-tellr-app/pyproject.toml"),
+          ]
+          for path in paths:
+              text = path.read_text()
+              # Replace the first `version = "..."` line (the [project] version).
+              new_text, count = re.subn(
+                  r'(?m)^version\s*=\s*".*"$',
+                  f'version = "{version}"',
+                  text,
+                  count=1,
+              )
+              if count != 1:
+                  raise SystemExit(
+                      f"ERROR: expected exactly one version line in {path}, replaced {count}"
+                  )
+              path.write_text(new_text)
+              stamped = tomllib.loads(path.read_text())["project"]["version"]
+              print(f"Stamped version = {stamped} into {path}")
+          PY
+
+      - name: Build databricks-tellr
+        run: python -m build --sdist --wheel packages/databricks-tellr
+
+      - name: Build databricks-tellr-app
+        run: |
+          cp -r src packages/databricks-tellr-app/src
+          python -m build --sdist --wheel packages/databricks-tellr-app
+          rm -rf packages/databricks-tellr-app/src
+
+      - name: Verify built artifacts (huashu tarballs present, wheel >= 25MB)
+        run: |
+          python - <<'PY'
+          import glob
+          import os
+          import sys
+          import zipfile
+
+          wheels = glob.glob("packages/databricks-tellr-app/dist/*.whl")
+          if len(wheels) != 1:
+              sys.exit(f"ERROR: expected exactly one wheel, found: {wheels}")
+          wheel = wheels[0]
+
+          size = os.path.getsize(wheel)
+          size_mb = size / (1024 * 1024)
+          print(f"Wheel: {wheel} ({size_mb:.1f} MB)")
+
+          base = "databricks_tellr_app/_assets/sidecars/pptx-emit-huashu"
+          required = [
+              f"{base}/node_modules.tar.gz",
+              f"{base}/sys-libs-bullseye.tar.gz",
+          ]
+
+          with zipfile.ZipFile(wheel) as zf:
+              names = set(zf.namelist())
+
+          missing = [name for name in required if name not in names]
+          if missing:
+              sys.exit(
+                  "ERROR: built wheel is missing required huashu sidecar tarball(s): "
+                  + ", ".join(missing)
+                  + " — this would ship a huashu-less wheel. Aborting."
+              )
+
+          if size < 25 * 1024 * 1024:
+              sys.exit(
+                  f"ERROR: built wheel is {size_mb:.1f} MB, under the 25MB floor — "
+                  "the huashu sidecar tarballs are likely missing. Aborting."
+              )
+
+          print("Verify gate passed: both huashu tarballs present and wheel >= 25MB.")
+          PY
+
+      - name: Upload tellr dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-tellr
+          path: packages/databricks-tellr/dist/
+
+      - name: Upload tellr-app dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-tellr-app
+          path: packages/databricks-tellr-app/dist/
+
+  publish-tellr:
+    name: Publish databricks-tellr to Test PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-tellr
+          path: dist/
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-tellr-app:
+    name: Publish databricks-tellr-app to Test PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-tellr-app
+          path: dist/
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Write deploy summary
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "## Published to Test PyPI"
+            echo ""
+            echo "**Package:** \`databricks-tellr-app\`"
+            echo "**Version:** \`${INPUT_VERSION}\`"
+            echo ""
+            echo "### Consume it"
+            echo ""
+            echo "Deploy the app against this version with:"
+            echo ""
+            echo '```bash'
+            echo "./scripts/deploy_local.sh update --env <env> --profile <profile> --from-test-pypi ${INPUT_VERSION}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Adds `.github/workflows/publish-testpypi.yml` — a `workflow_dispatch` workflow that builds and publishes **both** `databricks-tellr` and `databricks-tellr-app` to **test.pypi.org**.

This is the minimal piece needed on `main`: `workflow_dispatch` workflows are only dispatchable once the file exists on the default branch. The consumption side (`deploy_local.sh --from-test-pypi`) stays on the `feat/devops-test-pypi-dev-deploy` branch.

## How it works

- **Input:** a required PEP 440 dev `version` (e.g. `0.3.9.dev1`), stamped into both `pyproject.toml` files in-runner (not committed).
- **Publish:** via OIDC trusted publishing (`id-token: write`, environment `testpypi`) to `https://test.pypi.org/legacy/` — no tokens.
- **Verify gate:** asserts the huashu sidecar tarballs (`node_modules.tar.gz`, `sys-libs-bullseye.tar.gz`) are present in the app wheel and that it is ≥ 25MB, so a huashu-less wheel can never ship.

## Usage

Dispatch **against the `feat/devops-test-pypi-dev-deploy` ref** so the build uses that branch's re-included huashu tarballs (commit `4c7347c`):

```bash
gh workflow run publish-testpypi.yml --ref feat/devops-test-pypi-dev-deploy -f version=<X>
```

## Why test-PyPI

Dev deploys hit the Databricks Apps ~10MB source-bundle cap because the 31MB huashu-bearing wheel is uploaded into `source_code_path`. Publishing to test-PyPI lets the app pull the full wheel from the index at boot — same as prod — so nothing large lands in the bundle. Design: `docs/superpowers/specs/2026-06-24-test-pypi-dev-deploy-design.md`.

This pull request and its description were written by Isaac.