### PR TITLE
fix(chat): don't double-prefix uploaded image thumbnail data URL

### DIFF
--- a/frontend/src/components/ChatPanel/ChatInput.tsx
+++ b/frontend/src/components/ChatPanel/ChatInput.tsx
@@ -53,9 +53,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       setUploading(true);
       try {
         const asset = await api.uploadImage(f, { saveToLibrary: false });
-        const previewUrl = asset.thumbnail_base64
-          ? `data:${asset.mime_type};base64,${asset.thumbnail_base64}`
-          : undefined;
+        // thumbnail_base64 is already a complete data URI (data:<mime>;base64,...)
+        // from the backend — use it as-is. Prepending another scheme here yields a
+        // doubled prefix and net::ERR_INVALID_URL.
+        const previewUrl = asset.thumbnail_base64 ?? undefined;
         addUploadedImage(asset.id, previewUrl);
       } catch (err) {
         console.warn('Paste image upload failed:', err);
@@ -75,9 +76,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         for (const file of Array.from(files)) {
           if (!file.type.startsWith('image/')) continue;
           const asset = await api.uploadImage(file, { saveToLibrary: false });
-          const previewUrl = asset.thumbnail_base64
-            ? `data:${asset.mime_type};base64,${asset.thumbnail_base64}`
-            : undefined;
+          // thumbnail_base64 is already a complete data URI from the backend —
+          // use it as-is (see handlePaste).
+          const previewUrl = asset.thumbnail_base64 ?? undefined;
           addUploadedImage(asset.id, previewUrl);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #202 — uploading an image to a chat produced a broken thumbnail. The request URL was `data:image/jpeg;base64,data:image/jpeg;base64,...` and the browser rejected it with `net::ERR_INVALID_URL`.

## Root cause

The backend already returns a complete data URI: `image_service._generate_thumbnail` builds `f"data:{mime};base64,{b64}"` and the upload endpoint exposes it as `thumbnail_base64`. But `ChatInput.tsx` prepended a second `data:{mime_type};base64,` scheme on top, at both upload paths (paste + file-select), doubling the prefix.

`ImageLibrary.tsx` already consumes the field correctly (`src={image.thumbnail_base64}`), so `ChatInput` was the lone offender.

## Changes

- **`frontend/src/components/ChatPanel/ChatInput.tsx`** — use `asset.thumbnail_base64 ?? undefined` directly at both upload sites instead of re-prepending the data-URL scheme.

This also fixes a latent mime mismatch: the old prefix used the original upload `mime_type`, while the thumbnail's mime can differ (PNG for RGBA images, JPEG otherwise). Using the backend's own URI keeps the mime correct.

## Testing

- Verified by code inspection that the change is type-safe (`string | null` → `?? undefined` → `string | undefined`, matching the prior `previewUrl` type) and that `mime_type` is no longer referenced in the file.
- SVG uploads (where the backend returns `thumbnail_base64 = null`) behave as before — no thumbnail, no regression.
- Could not run `tsc`/frontend build in this environment (`node_modules` not installed, no network).

This pull request and its description were written by Isaac.