### PR TITLE
feat(devops): per-instance ephemeral prod-branch dev deployments (devloop)

### DIFF
--- a/.claude/skills/deploy-tellr-dev/SKILL.md
+++ b/.claude/skills/deploy-tellr-dev/SKILL.md
@@ -43,6 +43,30 @@ Prod is unaffected: `pip` ignores pre-releases by default, so a bare
 
 3. Open the app URL and verify it loads.
 
+## Per-instance dev loop (`devloop`)
+
+For parallel/agentic loops, use `--env devloop --instance <id>` instead of
+`devtest`. Each instance gets its own app (`db-tellr-dev-<id>`) and a fresh
+copy-on-write branch of prod Lakebase (`branches/dev-<id>`), so concurrent
+instances stay isolated:
+
+```bash
+./scripts/deploy_local.sh create --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>    # first deploy
+./scripts/deploy_local.sh update --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>    # iterate (app reused, branch refreshed)
+./scripts/deploy_local.sh delete --env devloop --instance agent-7f3a \
+    --profile tellr-dev                          # teardown (app + branch)
+```
+
+`--instance` must match `^[a-z][a-z0-9-]*$` and be ≤59 chars. The branch is
+re-forked from prod on every deploy, so anything written to an instance is wiped
+on its next deploy.
+
+**Migration limitation:** a build that `ALTER`s an *inherited* prod table fails
+at startup with `must be owner of table` (creating new tables is fine). See
+`docs/technical/dev-deploy.md` for details.
+
 ## Reading deploy logs
 
 App logs require OAuth (not PAT):

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -201,6 +201,10 @@ jobs:
             echo ""
             echo "### Deploy it"
             echo '```bash'
-            echo "./scripts/deploy_local.sh update --env devtest --profile tellr-dev --from-pypi ${RESOLVED_VERSION}"
+            echo "Static devtest:"
+            echo "  ./scripts/deploy_local.sh update --env devtest --profile tellr-dev --from-pypi ${RESOLVED_VERSION}"
+            echo "Per-instance dev loop (prod branch):"
+            echo "  ./scripts/deploy_local.sh create --env devloop --instance <id> --profile tellr-dev --from-pypi ${RESOLVED_VERSION}"
+            echo "  ./scripts/deploy_local.sh update --env devloop --instance <id> --profile tellr-dev --from-pypi ${RESOLVED_VERSION}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/config/deployment.example.yaml
+++ b/config/deployment.example.yaml
@@ -79,6 +79,30 @@ environments:
       schema: "app_data"
       capacity: "CU_1"  # Options: CU_1, CU_2, CU_4, CU_8
 
+  devloop:
+    # Per-instance dev loop. Like staging, devloop deploys against an ephemeral
+    # Lakebase branch forked from production, but the app_name and workspace_path
+    # are per-instance: `--instance <id>` appends `-<id>` to app_name and `/<id>`
+    # to workspace_path so multiple isolated dev instances can coexist.
+    app_name: "ai-slide-generator-dev"            # base; --instance appended -> ...-<id>
+    description: "AI Slide Generator - Dev loop (prod branch)"
+    workspace_path: "/Workspace/Users/{username}/.apps/devloop"  # base; /<id> appended
+    permissions:
+      - user_name: "{username}"
+        permission_level: "CAN_MANAGE"
+    compute_size: "MEDIUM"  # Options: MEDIUM, LARGE, LIQUID
+    env_vars:
+      ENVIRONMENT: "development"
+      LOG_LEVEL: "DEBUG"
+      LAKEBASE_INSTANCE: "ai-slide-generator-db"  # must match production
+      # LAKEBASE_SCHEMA inherited from branch_from (prod schema) — not set here
+    lakebase:
+      # Must match production's database_name (same Lakebase autoscaling project).
+      database_name: "ai-slide-generator-db"      # MUST equal the production env's
+      branch_from: "production"                    # fresh ephemeral branch per deploy
+      capacity: "CU_1"  # Options: CU_1, CU_2, CU_4, CU_8
+      # schema omitted — inherited from the branch_from env (production)
+
 # Common settings across all environments
 common:
   build:

--- a/docs/superpowers/plans/2026-06-29-devloop-instance-branching.md
+++ b/docs/superpowers/plans/2026-06-29-devloop-instance-branching.md
@@ -1,0 +1,956 @@
+# Devloop Per-Instance Branching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `--instance <id>` flag to the dev-deploy tooling so each concurrent agentic dev loop gets an isolated app (`db-tellr-dev-<id>`) backed by its own fresh copy-on-write branch of production Lakebase (`dev-<id>`), created via delete-then-recreate on a fixed name.
+
+**Architecture:** Reuse the existing `branch_from` machinery built for the staging design. Two changes: (1) make branch creation use a fixed branch id via delete-then-create instead of timestamp-suffix + TTL-for-freshness (a live probe proved fixed-name reuse is clean); (2) thread an `--instance` identifier through `deploy_local` that derives the app name, workspace path, and target branch name. The app compute is created once and reused; the branch is refreshed every deploy.
+
+**Tech Stack:** Python 3, argparse, bash, pytest, Databricks SDK (`ws.postgres.*`), PyYAML.
+
+## Global Constraints
+
+- Branch ids must be 1–63 chars (Lakebase limit). `--instance` is validated `^[a-z][a-z0-9-]*$` and ≤59 chars so `dev-<id>` ≤63.
+- `--instance` is only valid for a branching env (one whose `lakebase.branch_from` is set); otherwise fail fast with `DeploymentError`.
+- Backward compatibility: when `--instance` is absent, behavior is unchanged except the branch is now a fixed env-named branch (e.g. `staging`) created via delete+create rather than `staging-<timestamp>`.
+- `replace_existing` is NOT used (it preserves data; a live probe confirmed it is not a fresh fork).
+- This plan implements the **branch mechanism only**. Migrations that `ALTER` inherited prod tables remain blocked by the separate Lakebase table-ownership workstream (see the spec's dependency section). Do not attempt ownership/group changes here.
+- TDD: write the failing test first, watch it fail, implement minimally, watch it pass, commit.
+- Run tests with the project venv: `source .venv/bin/activate` then `pytest`.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md`
+
+---
+
+## File Structure
+
+- `packages/databricks-tellr/databricks_tellr/deploy.py` — branch helpers: `_create_branch_from`, `_recreate_ephemeral_branch` (change to fixed-name delete+create).
+- `scripts/deploy_local.py` — add `_validate_instance` + `_resolve_target` helpers; thread `instance` through `create_local`/`update_local`/`delete_local`; add `--instance` CLI arg; delete the branch on `delete`.
+- `scripts/deploy_local.sh` — parse/forward `--instance`; allow `devloop` env.
+- `config/deployment.example.yaml` — add the `devloop` template env (committed example; the real `config/deployment.yaml` is gitignored and updated by hand).
+- `.github/workflows/publish-dev.yml` — deploy summary prints the `--env devloop --instance` form.
+- `docs/technical/dev-deploy.md`, `.claude/skills/deploy-tellr-dev/SKILL.md` — document the instance loop.
+- Tests: `tests/unit/test_deploy_branch_helpers.py` (update), `tests/unit/test_deploy_local_instance.py` (new).
+
+---
+
+### Task 1: Fixed-name branch creation in `_create_branch_from`
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py:1129-1210`
+- Test: `tests/unit/test_deploy_branch_helpers.py:70-140`
+
+**Interfaces:**
+- Produces: `_create_branch_from(ws, project_name: str, source_branch: str, branch_id: str) -> dict` — creates `projects/<project>/branches/<branch_id>` forked from `source_branch`, with a 1-day TTL backstop, polls for a ready endpoint, returns a `lakebase_result` dict whose `branch_id` equals the passed `branch_id` verbatim (no timestamp suffix).
+
+- [ ] **Step 1: Update the test to expect a verbatim fixed branch id**
+
+Replace the body of `test_creates_branch_with_correct_source` in `tests/unit/test_deploy_branch_helpers.py` (currently lines ~71-126) with:
+
+```python
+    def test_creates_branch_with_correct_source(self, mock_ws):
+        branch_id = "dev-agent-7f3a"
+
+        create_op = MagicMock()
+        mock_ws.postgres.create_branch.return_value = create_op
+
+        endpoint_ready = MagicMock()
+        endpoint_ready.name = (
+            f"projects/db-tellr/branches/{branch_id}/endpoints/ep1"
+        )
+        endpoint_ready.status = MagicMock(
+            hosts=MagicMock(host="dev-ep1.example.com")
+        )
+        mock_ws.postgres.list_endpoints.side_effect = (
+            lambda **kw: iter([endpoint_ready])
+        )
+
+        result = _create_branch_from(
+            mock_ws,
+            project_name="db-tellr",
+            source_branch="production",
+            branch_id=branch_id,
+        )
+
+        call_kwargs = mock_ws.postgres.create_branch.call_args.kwargs
+        assert call_kwargs["parent"] == "projects/db-tellr"
+        # branch_id is used verbatim — no timestamp suffix.
+        assert call_kwargs["branch_id"] == branch_id
+        branch_arg = call_kwargs["branch"]
+        assert branch_arg.spec.source_branch == "projects/db-tellr/branches/production"
+        # TTL remains as an orphan backstop (not the freshness mechanism).
+        assert branch_arg.spec.ttl is not None
+        assert branch_arg.spec.ttl.seconds == 86400
+        assert not branch_arg.spec.no_expiry
+
+        create_op.wait.assert_called_once()
+
+        assert result["type"] == "autoscaling"
+        assert result["name"] == "db-tellr"
+        assert result["host"] == "dev-ep1.example.com"
+        assert (
+            result["endpoint_name"]
+            == f"projects/db-tellr/branches/{branch_id}/endpoints/ep1"
+        )
+        assert result["project_id"] == "db-tellr"
+        assert result["instance_name"] is None
+        assert result["branch_id"] == branch_id
+```
+
+Also update `test_raises_when_no_endpoint_after_timeout` (last line) to call with a fixed id:
+
+```python
+        with pytest.raises(DeploymentError, match="no endpoint ready"):
+            _create_branch_from(mock_ws, "db-tellr", "production", "dev-x")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_branch_helpers.py::TestCreateBranchFrom -v`
+Expected: FAIL — old code names the param `target_branch_prefix` and appends a timestamp, so `branch_id` kwarg mismatch / `TypeError` on the `branch_id=` keyword.
+
+- [ ] **Step 3: Implement fixed-name creation**
+
+In `packages/databricks-tellr/databricks_tellr/deploy.py`, change the signature and body of `_create_branch_from` (lines ~1129-1175). Replace:
+
+```python
+def _create_branch_from(
+    ws: WorkspaceClient,
+    project_name: str,
+    source_branch: str,
+    target_branch_prefix: str,
+) -> dict[str, Any]:
+```
+
+with:
+
+```python
+def _create_branch_from(
+    ws: WorkspaceClient,
+    project_name: str,
+    source_branch: str,
+    branch_id: str,
+) -> dict[str, Any]:
+```
+
+Update the docstring's first paragraph to:
+
+```python
+    """Create a new Lakebase branch named ``branch_id`` as a child of
+    ``source_branch``.
+
+    The branch id is used verbatim (a fixed per-instance name). A 1-day TTL is
+    attached purely as an orphan backstop so abandoned instances get
+    garbage-collected; freshness comes from delete-then-create (see
+    _recreate_ephemeral_branch), not from the TTL.
+
+    Waits on the create operation, then polls list_endpoints on the new branch
+    until an endpoint with a populated host appears. Raises DeploymentError on
+    timeout. Returns a lakebase_result-shaped dict with an added ``branch_id``.
+    """
+```
+
+Then delete the line that builds the timestamped id:
+
+```python
+    branch_id = f"{target_branch_prefix}-{int(time.time())}"
+```
+
+(The rest of the function already references `branch_id` and works unchanged.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_branch_helpers.py::TestCreateBranchFrom -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_branch_helpers.py
+git commit -m "refactor(deploy): _create_branch_from uses a fixed verbatim branch id
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 2: Delete-then-create in `_recreate_ephemeral_branch`
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py:1213-1227`
+- Test: `tests/unit/test_deploy_branch_helpers.py:143-172`
+
+**Interfaces:**
+- Consumes: `_delete_branch(ws, project_name, branch_id)`, `_create_branch_from(ws, project_name, source_branch, branch_id)` (Task 1).
+- Produces: `_recreate_ephemeral_branch(ws, project_name: str, source_branch: str, branch_id: str) -> dict` — deletes `branch_id` (idempotent) then re-creates it fresh from `source_branch`. Returns the `_create_branch_from` result.
+
+- [ ] **Step 1: Replace the test to assert delete-then-create**
+
+Replace `TestRecreateEphemeralBranch` in `tests/unit/test_deploy_branch_helpers.py` (lines ~146-172) with:
+
+```python
+class TestRecreateEphemeralBranch:
+    def test_deletes_then_creates_fixed_name(self, mock_ws, monkeypatch):
+        """Fresh copy each deploy = delete the fixed branch, then recreate it."""
+        calls = []
+
+        def fake_delete(ws, project, branch):
+            calls.append(("delete", branch))
+
+        def fake_create(ws, project, source, branch_id):
+            calls.append(("create", source, branch_id))
+            return {"host": "x", "endpoint_name": "e", "type": "autoscaling",
+                    "branch_id": branch_id}
+
+        monkeypatch.setattr("databricks_tellr.deploy._delete_branch", fake_delete)
+        monkeypatch.setattr("databricks_tellr.deploy._create_branch_from", fake_create)
+
+        result = _recreate_ephemeral_branch(
+            mock_ws,
+            project_name="db-tellr",
+            source_branch="production",
+            branch_id="dev-agent-7f3a",
+        )
+
+        assert calls == [
+            ("delete", "dev-agent-7f3a"),
+            ("create", "production", "dev-agent-7f3a"),
+        ]
+        assert result["host"] == "x"
+        assert result["branch_id"] == "dev-agent-7f3a"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_branch_helpers.py::TestRecreateEphemeralBranch -v`
+Expected: FAIL — current code only creates (no delete) and uses `target_branch_prefix`.
+
+- [ ] **Step 3: Implement delete-then-create**
+
+In `deploy.py`, replace the whole `_recreate_ephemeral_branch` function (lines ~1213-1227) with:
+
+```python
+def _recreate_ephemeral_branch(
+    ws: WorkspaceClient,
+    project_name: str,
+    source_branch: str,
+    branch_id: str,
+) -> dict[str, Any]:
+    """Refresh an ephemeral Lakebase branch to a fresh copy of source_branch.
+
+    Deletes ``branch_id`` (idempotent — no-op if absent) then recreates it from
+    ``source_branch``. Delete-then-create on a fixed name was verified clean
+    (~6s, no collision); the older "skip delete and rely on TTL" workaround is
+    no longer needed.
+    """
+    _delete_branch(ws, project_name, branch_id)
+    return _create_branch_from(ws, project_name, source_branch, branch_id)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_branch_helpers.py -v`
+Expected: PASS (all classes in the file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_branch_helpers.py
+git commit -m "refactor(deploy): _recreate_ephemeral_branch does delete-then-create on a fixed name
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 3: `--instance` helpers in deploy_local
+
+**Files:**
+- Modify: `scripts/deploy_local.py` (imports near line 15-23; add helpers after `load_deployment_config`, ~line 140)
+- Test: `tests/unit/test_deploy_local_instance.py` (create)
+
+**Interfaces:**
+- Produces:
+  - `_validate_instance(instance: str) -> None` — raises `DeploymentError` unless `instance` matches `^[a-z][a-z0-9-]*$` and is ≤59 chars.
+  - `_resolve_target(config: dict, env: str, instance: Optional[str]) -> tuple[str, str, str]` — returns `(app_name, workspace_path, target_branch)`. No instance → `(config["app_name"], config["workspace_path"], env)`. With instance → requires `config["branch_from_env"]` set (else `DeploymentError`), validates the slug, returns `(f"{app_name}-{instance}", f"{workspace_path}/{instance}", f"dev-{instance}")`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_deploy_local_instance.py`:
+
+```python
+"""Tests for --instance resolution + validation in deploy_local."""
+import pytest
+
+from databricks_tellr.deploy import DeploymentError
+from scripts.deploy_local import _validate_instance, _resolve_target
+
+BRANCHING = {
+    "app_name": "db-tellr-dev",
+    "workspace_path": "/Workspace/Users/x/.apps/devloop",
+    "branch_from_env": "production",
+}
+NON_BRANCHING = {
+    "app_name": "db-tellr-dev",
+    "workspace_path": "/Workspace/Users/x/.apps/dev",
+    "branch_from_env": None,
+}
+
+
+class TestValidateInstance:
+    @pytest.mark.parametrize("good", ["agent-7f3a", "a", "spike01", "x-1-2-3"])
+    def test_accepts_valid(self, good):
+        _validate_instance(good)  # no raise
+
+    @pytest.mark.parametrize("bad", ["Agent", "1abc", "has_underscore", "has.dot",
+                                     "trailing ", "UPPER", "a" * 60])
+    def test_rejects_invalid(self, bad):
+        with pytest.raises(DeploymentError):
+            _validate_instance(bad)
+
+
+class TestResolveTarget:
+    def test_no_instance_uses_env_branch(self):
+        app, wp, branch = _resolve_target(BRANCHING, "staging", None)
+        assert app == "db-tellr-dev"
+        assert wp == "/Workspace/Users/x/.apps/devloop"
+        assert branch == "staging"
+
+    def test_instance_suffixes_names_and_dev_branch(self):
+        app, wp, branch = _resolve_target(BRANCHING, "devloop", "agent-7f3a")
+        assert app == "db-tellr-dev-agent-7f3a"
+        assert wp == "/Workspace/Users/x/.apps/devloop/agent-7f3a"
+        assert branch == "dev-agent-7f3a"
+
+    def test_instance_on_non_branching_raises(self):
+        with pytest.raises(DeploymentError, match="branch_from"):
+            _resolve_target(NON_BRANCHING, "development", "agent-7f3a")
+
+    def test_instance_invalid_slug_raises(self):
+        with pytest.raises(DeploymentError):
+            _resolve_target(BRANCHING, "devloop", "Bad_Id")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_local_instance.py -v`
+Expected: FAIL — `ImportError: cannot import name '_validate_instance'`.
+
+- [ ] **Step 3: Add `re` import and the helpers**
+
+In `scripts/deploy_local.py`, add `import re` to the stdlib import block (after `import os`, line ~16).
+
+Then add these two helpers immediately after `load_deployment_config` (after line ~139):
+
+```python
+_INSTANCE_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def _validate_instance(instance: str) -> None:
+    """Validate a deploy instance id. Raises DeploymentError if invalid."""
+    if not _INSTANCE_RE.match(instance) or len(instance) > 59:
+        raise DeploymentError(
+            "--instance must match ^[a-z][a-z0-9-]*$ and be <=59 chars "
+            f"(got '{instance}')"
+        )
+
+
+def _resolve_target(
+    config: dict[str, Any], env: str, instance: Optional[str]
+) -> tuple[str, str, str]:
+    """Resolve (app_name, workspace_path, target_branch) for a deploy.
+
+    Without an instance: names come straight from config and the branch is named
+    after the env. With an instance: the env must be a branching env; the app
+    name and workspace path are suffixed with the instance and the branch is
+    ``dev-<instance>``.
+    """
+    app_name = config["app_name"]
+    workspace_path = config["workspace_path"]
+    if instance is None:
+        return app_name, workspace_path, env
+    if not config.get("branch_from_env"):
+        raise DeploymentError(
+            f"--instance requires a branch_from env; '{env}' is not a "
+            "branching env"
+        )
+    _validate_instance(instance)
+    return (
+        f"{app_name}-{instance}",
+        f"{workspace_path}/{instance}",
+        f"dev-{instance}",
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_local_instance.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/deploy_local.py tests/unit/test_deploy_local_instance.py
+git commit -m "feat(deploy): add _validate_instance + _resolve_target helpers
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 4: Thread `instance` through create/update/delete
+
+**Files:**
+- Modify: `scripts/deploy_local.py` — imports (line ~32-52), `create_local` (~263-442), `update_local` (~445-621), `delete_local` (~624-649)
+- Test: `tests/unit/test_deploy_local_instance.py` (add a delete_local test)
+
+**Interfaces:**
+- Consumes: `_resolve_target` (Task 3), `_delete_branch`, `_get_workspace_client`, `delete` (already importable from `databricks_tellr.deploy`).
+- Produces: `create_local(env, profile, seed_databricks_defaults=True, from_pypi=None, instance=None)`, `update_local(env, profile, reset_database=False, seed_databricks_defaults=True, from_pypi=None, instance=None)`, `delete_local(env, profile, reset_database=False, instance=None)`. On a branching env, `delete_local` now also deletes `branches/<target_branch>`.
+
+- [ ] **Step 1: Add the `_delete_branch` import**
+
+In `scripts/deploy_local.py`, add `_delete_branch,` to the `from databricks_tellr.deploy import (...)` block (alongside `_branch_exists`, near line 34):
+
+```python
+    _branch_exists,
+    _delete_branch,
+```
+
+- [ ] **Step 2: Write the failing delete_local test**
+
+Append to `tests/unit/test_deploy_local_instance.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+
+class TestDeleteLocalBranch:
+    def test_deletes_app_and_instance_branch(self, monkeypatch):
+        import scripts.deploy_local as dl
+
+        cfg = {
+            "app_name": "db-tellr-dev",
+            "workspace_path": "/Workspace/Users/x/.apps/devloop",
+            "lakebase_name": "db-tellr",
+            "schema_name": "app_data_prod",
+            "branch_from_env": "production",
+        }
+        monkeypatch.setattr(dl, "load_deployment_config", lambda env: cfg)
+        fake_ws = MagicMock()
+        monkeypatch.setattr(dl, "_get_workspace_client", lambda profile: fake_ws)
+        delete_calls = {}
+        monkeypatch.setattr(dl, "delete", lambda **kw: delete_calls.update(kw) or {"status": "deleted"})
+        branch_calls = []
+        monkeypatch.setattr(dl, "_delete_branch", lambda ws, proj, br: branch_calls.append((proj, br)))
+
+        dl.delete_local(env="devloop", profile="p", instance="agent-7f3a")
+
+        # App deleted under the instance-suffixed name
+        assert delete_calls["app_name"] == "db-tellr-dev-agent-7f3a"
+        # Branch deleted with the fixed dev-<instance> name
+        assert branch_calls == [("db-tellr", "dev-agent-7f3a")]
+
+    def test_non_branching_delete_does_not_touch_branches(self, monkeypatch):
+        import scripts.deploy_local as dl
+
+        cfg = {
+            "app_name": "db-tellr-dev",
+            "workspace_path": "/Workspace/Users/x/.apps/dev",
+            "lakebase_name": "db-tellr",
+            "schema_name": "tellr_app_data_dev",
+            "branch_from_env": None,
+        }
+        monkeypatch.setattr(dl, "load_deployment_config", lambda env: cfg)
+        monkeypatch.setattr(dl, "delete", lambda **kw: {"status": "deleted"})
+        branch_calls = []
+        monkeypatch.setattr(dl, "_delete_branch", lambda ws, proj, br: branch_calls.append((proj, br)))
+
+        dl.delete_local(env="development", profile="p")
+        assert branch_calls == []
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_local_instance.py::TestDeleteLocalBranch -v`
+Expected: FAIL — `delete_local` has no `instance` kwarg and never calls `_delete_branch`.
+
+- [ ] **Step 4: Update `delete_local`**
+
+Replace the whole `delete_local` function (lines ~624-649) with:
+
+```python
+def delete_local(
+    env: str, profile: str, reset_database: bool = False,
+    instance: Optional[str] = None,
+) -> dict[str, Any]:
+    """Delete a Databricks App (and its ephemeral branch, if branching)."""
+    config = load_deployment_config(env)
+    branch_from_env = config.get("branch_from_env")
+    app_name, _workspace_path, target_branch = _resolve_target(config, env, instance)
+
+    if branch_from_env and reset_database:
+        print(
+            "WARNING: --reset-db is a no-op for branching envs "
+            "(the branch itself is about to be deleted). Ignoring."
+        )
+        reset_database = False
+
+    result = delete(
+        app_name=app_name,
+        lakebase_name=config["lakebase_name"],
+        schema_name=config["schema_name"],
+        reset_database=reset_database,
+        profile=profile,
+    )
+
+    # For branching envs, also delete the ephemeral branch (fixed name, so this
+    # is now safe and re-runnable — idempotent on not-found).
+    if branch_from_env:
+        ws = _get_workspace_client(profile=profile)
+        _delete_branch(ws, config["lakebase_name"], target_branch)
+        print(f"   Deleted branch '{target_branch}'")
+
+    return result
+```
+
+- [ ] **Step 5: Run the delete test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_local_instance.py::TestDeleteLocalBranch -v`
+Expected: PASS
+
+- [ ] **Step 6: Update `create_local` for instance + target_branch**
+
+In `create_local`, add `instance: Optional[str] = None,` as the last parameter (after `from_pypi`, line ~267).
+
+Replace these two lines (~285-286):
+
+```python
+    app_name = config["app_name"]
+    workspace_path = config["workspace_path"]
+```
+
+with:
+
+```python
+    app_name, workspace_path, target_branch = _resolve_target(config, env, instance)
+```
+
+Update the branching print (line ~297) from:
+
+```python
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{env}')")
+```
+
+to:
+
+```python
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{target_branch}')")
+```
+
+Update the recreate call (lines ~326-329) from:
+
+```python
+            print(f"Creating ephemeral branch off '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, env
+            )
+```
+
+to:
+
+```python
+            print(f"Creating ephemeral branch '{target_branch}' off '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, target_branch
+            )
+```
+
+- [ ] **Step 7: Update `update_local` for instance + target_branch**
+
+In `update_local`, add `instance: Optional[str] = None,` as the last parameter (after `from_pypi`, line ~450).
+
+Replace these two lines (~460-461):
+
+```python
+    app_name = config["app_name"]
+    workspace_path = config["workspace_path"]
+```
+
+with:
+
+```python
+    app_name, workspace_path, target_branch = _resolve_target(config, env, instance)
+```
+
+Update the branching print (line ~475) from `'{env}'` to `'{target_branch}'`:
+
+```python
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{target_branch}')")
+```
+
+Update the recreate call (lines ~495-498) from:
+
+```python
+            print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, env
+            )
+```
+
+to:
+
+```python
+            print(f"Recreating ephemeral branch '{target_branch}' from '{branch_from_env}'...")
+            lakebase_result = _recreate_ephemeral_branch(
+                ws, lakebase_name, branch_from_env, target_branch
+            )
+```
+
+- [ ] **Step 8: Run the full deploy_local test suite**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_deploy_local_instance.py tests/unit/test_deploy_local_config_branching.py tests/unit/test_deploy_local_preflight.py -v`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/deploy_local.py tests/unit/test_deploy_local_instance.py
+git commit -m "feat(deploy): thread --instance through create/update/delete_local
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 5: `--instance` CLI argument in `main()`
+
+**Files:**
+- Modify: `scripts/deploy_local.py` — `main()` (arg block ~716-726; dispatch ~748-769)
+
+**Interfaces:**
+- Consumes: `create_local`/`update_local`/`delete_local` `instance=` kwarg (Task 4).
+
+- [ ] **Step 1: Add the `--instance` argument**
+
+In `main()`, after the `--from-pypi` argument block (line ~726), add:
+
+```python
+    parser.add_argument(
+        "--instance",
+        dest="instance",
+        type=str,
+        default=None,
+        metavar="ID",
+        help=(
+            "Ephemeral instance id for a branching env (e.g. devloop). "
+            "Derives app name db-<base>-<id>, branch dev-<id>, and a per-instance "
+            "workspace path. Required for concurrent dev-loop deploys."
+        ),
+    )
+```
+
+- [ ] **Step 2: Pass `instance` into the dispatch calls**
+
+Update the three calls (lines ~749-769) to pass `instance=args.instance`:
+
+```python
+        if args.action == "create":
+            result = create_local(
+                env=args.env,
+                profile=args.profile,
+                seed_databricks_defaults=args.include_databricks_prompts,
+                from_pypi=args.from_pypi,
+                instance=args.instance,
+            )
+        elif args.action == "update":
+            result = update_local(
+                env=args.env,
+                profile=args.profile,
+                reset_database=args.reset_db,
+                seed_databricks_defaults=args.include_databricks_prompts,
+                from_pypi=args.from_pypi,
+                instance=args.instance,
+            )
+        elif args.action == "delete":
+            result = delete_local(
+                env=args.env,
+                profile=args.profile,
+                reset_database=args.reset_db,
+                instance=args.instance,
+            )
+```
+
+- [ ] **Step 3: Verify the CLI parses (smoke test)**
+
+Run: `source .venv/bin/activate && python -m scripts.deploy_local --help`
+Expected: help text lists `--instance ID`. Exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/deploy_local.py
+git commit -m "feat(deploy): add --instance CLI arg to deploy_local
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 6: Forward `--instance` and allow `devloop` in the shell wrapper
+
+**Files:**
+- Modify: `scripts/deploy_local.sh` (arg parse ~52-100; env regex ~123; echo block ~141-158; python call ~201-212)
+
+- [ ] **Step 1: Add the INSTANCE variable and parser case**
+
+In `scripts/deploy_local.sh`, add `INSTANCE=""` to the variable block (after `FROM_PYPI=""`, line ~59). Then add a parser case (after the `--from-pypi` case, line ~90):
+
+```bash
+        --instance)
+            INSTANCE="$2"
+            shift 2
+            ;;
+```
+
+- [ ] **Step 2: Allow the `devloop` (and `devtest`) envs**
+
+Update the env validation regex (line ~123) from:
+
+```bash
+if [[ ! "$ENV" =~ ^(development|staging|production|test)$ ]]; then
+```
+
+to:
+
+```bash
+if [[ ! "$ENV" =~ ^(development|staging|production|test|devtest|devloop)$ ]]; then
+```
+
+- [ ] **Step 3: Echo the instance and forward it to Python**
+
+In the echo block (after the `--from-pypi` echo, line ~157), add:
+
+```bash
+if [ -n "$INSTANCE" ]; then
+    echo "  Instance:    $INSTANCE"
+fi
+```
+
+Then update the python invocation (lines ~201-212). After the `FROM_PYPI_ARG` block, add:
+
+```bash
+INSTANCE_ARG=()
+if [ -n "$INSTANCE" ]; then
+    INSTANCE_ARG=(--instance "$INSTANCE")
+fi
+```
+
+and add `"${INSTANCE_ARG[@]}"` to the `python -m scripts.deploy_local` call:
+
+```bash
+python -m scripts.deploy_local \
+    --$ACTION \
+    --env "$ENV" \
+    --profile "$PROFILE" \
+    $RESET_DB \
+    $INCLUDE_DB_PROMPTS \
+    "${FROM_PYPI_ARG[@]}" \
+    "${INSTANCE_ARG[@]}"
+```
+
+- [ ] **Step 4: Smoke-test the usage path**
+
+Run: `bash scripts/deploy_local.sh --help`
+Expected: usage prints; exit 1 (its usage() exits 1 by design). Confirm no bash syntax error.
+
+Run: `bash -n scripts/deploy_local.sh`
+Expected: no output, exit 0 (syntax OK).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/deploy_local.sh
+git commit -m "feat(deploy): forward --instance and allow devloop env in deploy_local.sh
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 7: Add the `devloop` template env to the example config
+
+**Files:**
+- Modify: `config/deployment.example.yaml`
+
+**Note:** The real `config/deployment.yaml` is gitignored. This task documents the env in the committed example; the operator mirrors it into their real config (see Step 3).
+
+- [ ] **Step 1: Add the `devloop` env**
+
+In `config/deployment.example.yaml`, under `environments:`, add (match the file's existing indentation and surrounding entries):
+
+```yaml
+  devloop:
+    app_name: "ai-slide-generator-dev"            # base; --instance appended -> ...-<id>
+    description: "AI Slide Generator - Dev loop (prod branch)"
+    workspace_path: "/Workspace/Users/me@example.com/.apps/devloop"  # base; /<id> appended
+    compute_size: "MEDIUM"
+    env_vars:
+      ENVIRONMENT: "development"
+      LOG_LEVEL: "DEBUG"
+      LAKEBASE_INSTANCE: "ai-slide-generator-db"
+      # LAKEBASE_SCHEMA inherited from branch_from (prod schema) — not set here
+    lakebase:
+      database_name: "ai-slide-generator-db"      # MUST equal the production env's
+      branch_from: "production"                    # fresh ephemeral branch per deploy
+      capacity: "CU_1"
+      # schema removed — inherited from the production env
+```
+
+- [ ] **Step 2: Verify the example parses as YAML**
+
+Run: `source .venv/bin/activate && python -c "import yaml; yaml.safe_load(open('config/deployment.example.yaml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Mirror into the real config (manual, operator action)**
+
+Add the same `devloop` block to the gitignored `config/deployment.yaml`, with the real `database_name: db-tellr`, the real prod `workspace_path` base, and `app_name: db-tellr-dev`. This is a local edit, not committed. (No code depends on it being present until a deploy is run.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/deployment.example.yaml
+git commit -m "docs(deploy): add devloop template env to example config
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 8: Print the devloop instance loop in the publish-dev summary
+
+**Files:**
+- Modify: `.github/workflows/publish-dev.yml` (deploy-summary step, ~line 196-204)
+
+- [ ] **Step 1: Add the devloop example to the summary**
+
+In the "Write deploy summary" step, alongside the existing `deploy_local.sh ... --env devtest ...` echo (line ~204), add a devloop example. Replace the single echo line with:
+
+```yaml
+            echo "Static devtest:"
+            echo "  ./scripts/deploy_local.sh update --env devtest --profile tellr-dev --from-pypi ${RESOLVED_VERSION}"
+            echo "Per-instance dev loop (prod branch):"
+            echo "  ./scripts/deploy_local.sh create --env devloop --instance <id> --profile tellr-dev --from-pypi ${RESOLVED_VERSION}"
+            echo "  ./scripts/deploy_local.sh update --env devloop --instance <id> --profile tellr-dev --from-pypi ${RESOLVED_VERSION}"
+```
+
+(Keep the surrounding `echo` lines and the `${RESOLVED_VERSION}` variable usage consistent with what's already in the step.)
+
+- [ ] **Step 2: Verify the workflow YAML parses**
+
+Run: `source .venv/bin/activate && python -c "import yaml; yaml.safe_load(open('.github/workflows/publish-dev.yml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/publish-dev.yml
+git commit -m "ci(devops): print devloop --instance loop in publish-dev summary
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 9: Document the instance loop
+
+**Files:**
+- Modify: `docs/technical/dev-deploy.md`
+- Modify: `.claude/skills/deploy-tellr-dev/SKILL.md`
+
+- [ ] **Step 1: Add a "Per-instance dev loop" section to dev-deploy.md**
+
+Append to `docs/technical/dev-deploy.md`:
+
+```markdown
+## Per-instance dev loop (`devloop`) — branch off prod
+
+For agentic dev loops that run multiple deployments at once, use the `devloop`
+env with an `--instance <id>`. Each instance gets its own app
+(`db-tellr-dev-<id>`) and a fresh copy-on-write branch of production Lakebase
+(`branches/dev-<id>`), recreated on every deploy:
+
+```bash
+gh workflow run publish-dev.yml          # publish the next .devN
+./scripts/deploy_local.sh create --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>    # first deploy
+./scripts/deploy_local.sh update --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>    # iterate (reuses app, refreshes branch)
+./scripts/deploy_local.sh delete --env devloop --instance agent-7f3a \
+    --profile tellr-dev                          # teardown (app + branch)
+```
+
+`--instance` must match `^[a-z][a-z0-9-]*$` and be ≤59 chars. Concurrent
+instances are fully isolated. The app compute is created once and reused; the
+branch is deleted and re-forked from prod on every deploy (fresh prod data each
+time — anything written to an instance is wiped on its next deploy).
+
+**Migration limitation:** an instance can create new tables and read/write prod
+data, but a build that `ALTER`s an *inherited* prod table fails at startup with
+`must be owner of table`. Fixing that needs the Lakebase table-ownership
+(shared-owner) workstream — see
+`docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md`.
+```
+
+- [ ] **Step 2: Add the instance loop to the deploy-tellr-dev skill**
+
+In `.claude/skills/deploy-tellr-dev/SKILL.md`, add a short subsection mirroring the commands above (create/update/delete with `--env devloop --instance <id>`), and note the migration limitation in one line. Match the file's existing heading style.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/technical/dev-deploy.md .claude/skills/deploy-tellr-dev/SKILL.md
+git commit -m "docs(deploy): document the devloop --instance dev loop
+
+Co-authored-by: Isaac"
+```
+
+---
+
+### Task 10: Full regression run
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `source .venv/bin/activate && pytest tests/unit -q`
+Expected: PASS. Pay attention to `test_deploy_branch_helpers.py`, `test_deploy_local_config_branching.py`, `test_deploy_local_preflight.py`, `test_database_autoscaling.py`, `test_deploy_local_instance.py`.
+
+- [ ] **Step 2: If any regression test asserts old branch behavior, fix it**
+
+If `test_database_autoscaling.py` or another test references `target_branch_prefix` or timestamp-suffixed branch ids, update the assertion to the fixed-name behavior (branch id used verbatim; `_recreate_ephemeral_branch` deletes then creates). Re-run until green. Commit any such fix:
+
+```bash
+git add tests/unit/<file>.py
+git commit -m "test: update branch assertions for fixed-name delete+create
+
+Co-authored-by: Isaac"
+```
+
+- [ ] **Step 3: Manual integration checklist (against a real workspace; not automated)**
+
+Perform the spec's integration tests:
+1. `create --instance a` and `create --instance b` → two apps + two branches (`dev-a`, `dev-b`), both children of `branches/production`, isolated.
+2. write a row in `a`, `update --instance a` with a newer version → row gone (branch re-forked), app URL unchanged (compute reused).
+3. confirm prod sessions/decks visible and a prod Google OAuth credential decrypts.
+4. `delete --instance a` → app and `branches/dev-a` gone; `branches/production` and `b` untouched.
+5. `--instance FOO` (uppercase) → fails fast with the slug message, no `ws.postgres` call.
+6. a build that adds a column to an existing table → fails at startup with `must be owner of table` (expected; confirms the ownership dependency is still needed).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** config (Task 7), `--instance` flag + validation (Tasks 3, 5, 6), naming derivation (Tasks 3, 4), branch mechanism delete+create fixed name (Tasks 1, 2), preflight (unchanged — already implemented), create/update/delete flows (Task 4), publish-dev summary (Task 8), docs (Task 9), unit + regression + manual integration tests (Tasks 1-4, 10). The ownership dependency is explicitly out of scope per the spec.
+- **Placeholder scan:** none — every code step shows exact code; the only manual step (Task 7 Step 3, real gitignored config) is operator action by necessity, with exact values given.
+- **Type consistency:** `_resolve_target` returns `(app_name, workspace_path, target_branch)` and is consumed identically in create/update/delete; `_recreate_ephemeral_branch` / `_create_branch_from` take `branch_id` (renamed from `target_branch_prefix`) consistently across deploy.py and all callers/tests.

--- a/docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md
+++ b/docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md
@@ -1,0 +1,289 @@
+# Ephemeral per-instance dev environments branched from prod Lakebase
+
+**Status:** Approved design (2026-06-29)
+**Author:** robert.whiffin@databricks.com
+
+## Problem
+
+The dev pipeline publishes dev `.devN` builds to real PyPI and deploys them to a
+single `devtest` app backed by a static schema (`devtest_app_data`) on the prod
+`db-tellr` Lakebase instance. That schema diverges from prod, so a dev deploy can
+pass while the same build would fail against prod's actual schema and data. It
+also cannot decrypt prod-encrypted fields (Google OAuth credentials use prod's
+`GOOGLE_OAUTH_ENCRYPTION_KEY`).
+
+We are building the foundation for **agentic dev loops**: multiple concurrent
+deployments at any one time, each iterating on its own build. A single shared
+`devtest` env cannot support that — concurrent deploys would clobber each other.
+
+We want every dev deployment to run against a **fresh copy of production** — same
+schema, same data, same encryption key — and for multiple such deployments to
+coexist in isolation.
+
+## Solution
+
+A single template env **`devloop`** in `config/deployment.yaml` carries
+`branch_from: production` plus *base* names. An `--instance <id>` flag fills in
+the unique parts at deploy time, giving each concurrent loop an isolated app and
+an isolated copy-on-write branch of production Lakebase.
+
+| Resource | Pattern | Example (`--instance agent-7f3a`) | Lifecycle |
+|----------|---------|-----------------------------------|-----------|
+| App compute | `<base app_name>-<instance>` | `db-tellr-dev-agent-7f3a` | created once, reused every deploy |
+| Lakebase branch | fixed `dev-<instance>` off `branches/production` | `branches/dev-agent-7f3a` | delete + recreate (fresh prod) every deploy |
+| Workspace path | `<base workspace_path>/<instance>` | `.../.apps/devloop/agent-7f3a` | — |
+
+Because the branch is forked from `branches/production` and the app inherits
+prod's schema (`app_data_prod`) and prod's `GOOGLE_OAUTH_ENCRYPTION_KEY`, each
+dev instance is a full mirror of prod: it reads prod-shaped data, runs its
+migrations against a byte-identical copy of prod, and decrypts prod-encrypted
+fields. Dev ≈ prod for testing purposes.
+
+The deploy loop is unchanged in shape (manual, from a laptop):
+
+```bash
+gh workflow run publish-dev.yml                 # publishes the next .devN
+./scripts/deploy_local.sh create --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>   # first deploy of this instance
+./scripts/deploy_local.sh update --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>   # subsequent iterations
+./scripts/deploy_local.sh delete --env devloop --instance agent-7f3a \
+    --profile tellr-dev                         # teardown
+```
+
+## Decisions
+
+| # | Decision | Chosen | Why |
+|---|----------|--------|-----|
+| 1 | Identity of a deployment | Explicit `--instance <id>` flag | Most flexible for an agent-driven loop; no git coupling; works from laptop or CI. Drives app name, branch name, and workspace path from one id. |
+| 2 | Concurrency model | Many concurrent instances, each its own app + branch | Foundation for agentic dev loops; a fixed shared name would clobber. |
+| 3 | Branch freshness | Fresh copy of prod **every** deploy | Simplest correct model — sidesteps "did this build touch the data model?". Every deploy is a faithful prod-fidelity test. Copy-on-write makes it cheap. |
+| 4 | Branch mechanism | `delete_branch().wait()` then `create_branch()` on a **fixed name** | Empirically proven clean (~6s, see below). Gives a stable 1:1 `dev-<instance>` branch ↔ app mapping. |
+| 5 | App compute | Created once, reused every deploy | `update` rewrites `requirements.txt` to the new `.devN` and redeploys; compute never recreated. |
+| 6 | Cleanup | Manual `delete --instance <id>`; branch TTL as orphan backstop | No reaper/cron for now (YAGNI). TTL auto-GCs instances nobody tears down, softening the manual-only risk. |
+| 7 | Data + encryption | Full mirror (prod schema, prod key) | The point is prod-fidelity testing; rotating secrets defeats it and makes OAuth credentials un-decryptable. |
+| 8 | Implementation shape | Reuse existing `branch_from` machinery, parameterized by `--instance` | The staging design already built `_branch_exists`/`_create_branch_from`/`_recreate_ephemeral_branch` and a `branch_from`-aware config loader. This change parameterizes them, it does not rebuild them. |
+
+## Empirical findings (live `db-tellr` probes, 2026-06-29)
+
+Two throwaway probes against the live autoscaling `projects/db-tellr` project
+(forking only throwaway branches off `branches/production`; production never
+mutated) settled the branch mechanism:
+
+1. **`create_branch(replace_existing=True)` does NOT re-copy prod.** It is an
+   idempotent upsert: a marker row written to a branch *survived* a second
+   `create_branch(..., replace_existing=True)` call, and the endpoint/host did
+   not change. So `replace_existing` preserves existing branch data — it cannot
+   deliver "fresh copy of prod each deploy". **Not used.**
+2. **`delete_branch().wait()` then `create_branch()` on the same fixed name is
+   clean.** Recreate succeeded on the first attempt in ~6s. The current code's
+   comment claiming fixed-name reuse "collides for many minutes after delete"
+   **does not reproduce**. The timestamp-suffix + TTL workaround it justifies is
+   therefore unnecessary and is removed.
+
+## Feasibility (verified)
+
+- `projects/db-tellr` is an **autoscaling** Lakebase project, and
+  `branches/production` exists.
+- The `production` env in `deployment.yaml` uses `database_name: db-tellr` and
+  `schema: app_data_prod` — so `devloop` (same `database_name`) satisfies the
+  same-instance branching precondition, and inherits `app_data_prod`.
+
+## Configuration
+
+New `devloop` env in `config/deployment.yaml` (additive — existing `devtest`,
+`chatfix`, `test`, `development`, `production` entries are untouched):
+
+```yaml
+devloop:
+  app_name: "db-tellr-dev"                 # base; --instance appended -> db-tellr-dev-<id>
+  description: "AI Slide Generator - Dev loop (prod branch)"
+  workspace_path: "/Workspace/Users/robert.whiffin@databricks.com/.apps/devloop"  # base; /<id> appended
+  permissions:
+    - user_name: "robert.whiffin@databricks.com"
+      permission_level: "CAN_MANAGE"
+  compute_size: "MEDIUM"
+  env_vars:
+    ENVIRONMENT: "development"
+    LOG_LEVEL: "DEBUG"
+    LAKEBASE_INSTANCE: "db-tellr"
+    # LAKEBASE_SCHEMA inherited from branch_from (app_data_prod) — not set here
+  lakebase:
+    database_name: "db-tellr"
+    branch_from: "production"               # ephemeral branch of production per deploy
+    capacity: "CU_1"
+    # schema removed — inherited from branch_from env
+```
+
+**Naming conventions** (driven by `--instance <id>`):
+
+- App: `<app_name>-<id>` → `db-tellr-dev-<id>`.
+- Branch: `dev-<id>` off `branches/production`. Fixed name, delete+recreate each
+  deploy. (Prefix `dev-` keeps the branch namespace tidy and distinct from
+  `production`/`staging`.)
+- Workspace path: `<workspace_path>/<id>`.
+
+**`--instance` validation:** `id` must match `^[a-z][a-z0-9-]*$` and be ≤59
+chars (so `dev-<id>` stays within the Lakebase 1–63-char branch-id limit). A
+non-conforming id fails fast with an actionable error.
+
+## Deployment flow
+
+### `deploy_local.sh create --env devloop --instance <id> [--from-pypi <ver>]`
+
+1. Load config. `--instance` requires the env to set `lakebase.branch_from`
+   (else error). Derive `app_name`, `workspace_path`, and target branch
+   `dev-<id>` from the base config + id.
+2. **Preflight** (existing 6 checks, fail loud before any mutation):
+   1. `branch_from` resolves to an env in `deployment.yaml`.
+   2. Source and target share `lakebase.database_name`.
+   3. Source app deployed (`production` app.yaml downloadable).
+   4. Source app.yaml contains `GOOGLE_OAUTH_ENCRYPTION_KEY`.
+   5. Lakebase is autoscaling (`_probe_autoscaling_available` + `get_project`).
+   6. Source branch `production` exists.
+3. **Recreate ephemeral branch:** `_recreate_ephemeral_branch` =
+   `_delete_branch(dev-<id>)` (idempotent no-op if absent) then
+   `_create_branch_from(production → dev-<id>)` with a fixed branch id and a
+   TTL backstop. Wait for the create op; poll `list_endpoints` for a ready
+   endpoint; capture `host`/`endpoint_name`. Returns a `lakebase_result`-shaped
+   dict with `branch_id = dev-<id>`.
+4. **Create the app** `db-tellr-dev-<id>`.
+5. **Register the app SP** on `branches/dev-<id>` via
+   `_ensure_sp_autoscaling_role(..., branch_name="dev-<id>")`.
+6. **Setup schema = grant-only.** The branch already carries `app_data_prod`;
+   `CREATE SCHEMA IF NOT EXISTS` is a no-op, then grant the SP access.
+7. **Generate app.yaml** with the branch's `host`/`endpoint_name`, prod's schema
+   (`app_data_prod`), and prod's encryption key (read from `production`
+   app.yaml).
+8. **Deploy.** First startup runs migrations against the fresh prod copy.
+
+### `deploy_local.sh update --env devloop --instance <id> [--from-pypi <ver>]`
+
+Same as `create` except step 4 is skipped — the app already exists (error "run
+create first" if it does not). The branch is still delete+recreated (fresh prod
+copy), and the app compute is reused: `requirements.txt` is rewritten to the new
+`.devN` and the app redeployed.
+
+### `deploy_local.sh delete --env devloop --instance <id>`
+
+1. Delete the app `db-tellr-dev-<id>`.
+2. Delete `branches/dev-<id>` (idempotent — swallow "not found" so the command
+   is re-runnable).
+
+### `--reset-db` on a branching env
+
+Remains a no-op with a warning — each deploy is already a fresh branch.
+
+## Code changes
+
+### `packages/databricks-tellr/databricks_tellr/deploy.py`
+
+- **`_create_branch_from(ws, project_name, source_branch, branch_id)`** — take
+  the fixed `branch_id` directly instead of building `{prefix}-{timestamp}`.
+  Keep the create-with-TTL + endpoint-poll body. Return `branch_id` unchanged in
+  the result dict.
+- **`_recreate_ephemeral_branch(ws, project_name, source_branch, branch_id)`** —
+  call `_delete_branch(ws, project_name, branch_id)` then
+  `_create_branch_from(...)`. Update the docstring/comment: the async-purge
+  collision the old comment describes does not reproduce; delete+create on a
+  fixed name is the supported path.
+- Remove the now-obsolete timestamp/`_BRANCH_TTL`-for-freshness rationale
+  comment (TTL stays, but as an orphan backstop, not the freshness mechanism).
+- `_branch_exists`, `_delete_branch`, `_ensure_sp_autoscaling_role(...,
+  branch_name=...)` — unchanged (already parameterized).
+
+### `scripts/deploy_local.py`
+
+- **CLI**: add `--instance <id>`. Validate the slug. `--instance` requires the
+  resolved env to have `branch_from`.
+- **Config derivation**: a helper that, given the base config + `instance`,
+  returns `app_name=<base>-<id>`, `workspace_path=<base>/<id>`, and target
+  branch `dev-<id>`. When `--instance` is absent, behavior is exactly as today
+  (env-named branch — preserves the staging path).
+- **`create_local` / `update_local`**: accept `instance`; use the derived names;
+  pass the fixed `dev-<id>` branch to `_recreate_ephemeral_branch`; SP role uses
+  `dev-<id>`.
+- **`delete_local`**: accept `instance`; delete the derived app and explicitly
+  delete `branches/dev-<id>`.
+
+### `.github/workflows/publish-dev.yml`
+
+- The deploy summary prints the new `--env devloop --instance <id>` form
+  alongside the existing example.
+
+### Docs
+
+- `docs/technical/dev-deploy.md` and the `deploy-tellr-dev` skill describe the
+  per-instance `devloop` loop.
+
+## Error handling
+
+| Failure | Message |
+|---------|---------|
+| `--instance` set but env has no `branch_from` | `--instance requires a branch_from env; '<env>' is not a branching env` |
+| Invalid instance slug | `--instance must match ^[a-z][a-z0-9-]*$ and be <=59 chars` |
+| `branch_from` unset in referenced env | `branch_from "production" not found in deployment config` |
+| Different `database_name` source vs target | `branching requires same database_name; devloop=<x>, production=<y>` |
+| Source not deployed | `production not deployed — deploy production first` |
+| Key missing from source app.yaml | `GOOGLE_OAUTH_ENCRYPTION_KEY missing from production app.yaml` |
+| Lakebase not autoscaling | `Lakebase branching requires autoscaling; <db> is not an autoscaling project` |
+| Source branch missing | `source branch "production" not found in project <db>` |
+| `update` before `create` | `App '<app>' does not exist — run 'deploy_local.sh create --env devloop --instance <id>' first` |
+
+All preflight failures raise `DeploymentError` before any mutating
+`ws.postgres` call. A failed deploy never half-creates a branch + app.
+
+### Orphan risk
+
+If branch creation succeeds but app creation fails, the next deploy's
+delete+create self-heals, and the branch TTL backstops abandoned instances. No
+rollback machinery.
+
+## Testing
+
+### Unit tests (new / updated)
+
+- Instance → name derivation: `app_name`, `workspace_path`, branch `dev-<id>`.
+- Slug validation: rejects uppercase / leading digit / `>59` chars / illegal
+  chars; accepts `agent-7f3a`.
+- `--instance` without `branch_from` env → `DeploymentError`.
+- `_recreate_ephemeral_branch` does **delete-then-create** with the fixed
+  `branch_id` (mocked `ws`): asserts `_delete_branch` called, then
+  `create_branch` with `branch_id == dev-<id>` and `source_branch == production`.
+- `_create_branch_from` no longer appends a timestamp — `branch_id` is used
+  verbatim. **Update** existing tests that assert timestamp-suffixed ids.
+- `delete_local` deletes the derived app and `branches/dev-<id>` (idempotent on
+  not-found).
+
+### Regression
+
+- `tests/unit/test_database_autoscaling.py`,
+  `tests/unit/test_deploy_branch_helpers.py`,
+  `tests/unit/test_deploy_local_config_branching.py`,
+  `tests/unit/test_deploy_local_preflight.py` — re-run; update any assertions
+  tied to timestamp branch ids or env-named branches.
+
+### Integration (manual, against a real workspace)
+
+1. **Concurrency:** `create --instance a` and `create --instance b` (different
+   ids). Verify two apps (`db-tellr-dev-a`, `db-tellr-dev-b`) and two branches
+   (`dev-a`, `dev-b`), both children of `branches/production`, mutually isolated.
+2. **Fresh-each-deploy:** write a row in instance `a`, then `update --instance a`
+   with a newer version; confirm the row is gone (branch re-forked) and the app
+   compute is the same (URL unchanged, new `.devN` serving).
+3. **Decrypt + data:** confirm a copy of prod sessions/decks is visible and a
+   prod Google OAuth credential decrypts in the dev instance.
+4. **Teardown:** `delete --instance a`; confirm app and `branches/dev-a` are
+   gone; `branches/production` and instance `b` untouched.
+5. **Precondition failure:** invalid `--instance FOO` fails fast with the slug
+   message and makes no `ws.postgres` call.
+
+## Out of scope
+
+- CI-run deploys — the deploy stays a manual laptop step; `publish-dev.yml`
+  still only publishes and prints the command.
+- Auto-reaper / cron cleanup — manual delete + branch TTL only.
+- Deriving the instance id from git branch / worktree / PR.
+- Scrubbing or masking prod data in dev instances.
+- Migrating other static-schema envs (`devtest`, `chatfix`, `test`) onto
+  branching — `devloop` is additive; they are left as-is.

--- a/docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md
+++ b/docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md
@@ -3,6 +3,17 @@
 **Status:** Approved design (2026-06-29)
 **Author:** robert.whiffin@databricks.com
 
+> **Dependency / blocker for the migration story.** Live probing (2026-06-29)
+> found that a forked branch inherits prod's objects *owned by the prod app's
+> service principal*, and a *different* (dev) SP cannot `ALTER`/`DROP` those
+> inherited tables — so the app's `ALTER`-heavy migrations fail on a fork. The
+> branch mechanism in this spec is proven and independent, but **full
+> prod-fidelity migrations require a separate "Lakebase table ownership
+> (shared-owner)" workstream** — see [Dependency: Lakebase table ownership](#dependency-lakebase-table-ownership-shared-owner-model)
+> below. Until that lands, a `devloop` instance supports new-table creation +
+> DML against prod data, but **not** migrations that alter inherited prod
+> tables.
+
 ## Problem
 
 The dev pipeline publishes dev `.devN` builds to real PyPI and deploys them to a
@@ -35,9 +46,10 @@ an isolated copy-on-write branch of production Lakebase.
 
 Because the branch is forked from `branches/production` and the app inherits
 prod's schema (`app_data_prod`) and prod's `GOOGLE_OAUTH_ENCRYPTION_KEY`, each
-dev instance is a full mirror of prod: it reads prod-shaped data, runs its
-migrations against a byte-identical copy of prod, and decrypts prod-encrypted
-fields. Dev ≈ prod for testing purposes.
+dev instance is a full mirror of prod: it reads prod-shaped data and decrypts
+prod-encrypted fields. Dev ≈ prod for testing purposes. (Running *migrations*
+against that mirror additionally requires the ownership dependency — see the
+callout above and the dependency section below.)
 
 The deploy loop is unchanged in shape (manual, from a laptop):
 
@@ -63,6 +75,7 @@ gh workflow run publish-dev.yml                 # publishes the next .devN
 | 6 | Cleanup | Manual `delete --instance <id>`; branch TTL as orphan backstop | No reaper/cron for now (YAGNI). TTL auto-GCs instances nobody tears down, softening the manual-only risk. |
 | 7 | Data + encryption | Full mirror (prod schema, prod key) | The point is prod-fidelity testing; rotating secrets defeats it and makes OAuth credentials un-decryptable. |
 | 8 | Implementation shape | Reuse existing `branch_from` machinery, parameterized by `--instance` | The staging design already built `_branch_exists`/`_create_branch_from`/`_recreate_ephemeral_branch` and a `branch_from`-aware config loader. This change parameterizes them, it does not rebuild them. |
+| 9 | Migration support | Deferred to the ownership dependency | The dev SP can't `ALTER` inherited prod-SP-owned tables (proven). Shipping order: branch mechanism first (new-table + DML works), then the shared-owner workstream unblocks `ALTER` migrations. |
 
 ## Empirical findings (live `db-tellr` probes, 2026-06-29)
 
@@ -80,6 +93,106 @@ mutated) settled the branch mechanism:
    comment claiming fixed-name reuse "collides for many minutes after delete"
    **does not reproduce**. The timestamp-suffix + TTL workaround it justifies is
    therefore unnecessary and is removed.
+
+## Dependency: Lakebase table ownership (shared-owner model)
+
+This is a **separate, prod-touching workstream** that gates the migration story
+of this feature. It is documented in full here so a fresh agent can pick it up
+and drive it independently. (Companion notes:
+`memory/lakebase_branch_permissions.md`; Databricks runbook ES-1783639,
+Confluence "Change table ownership to a group", page `6095568937`.)
+
+### The problem
+
+Each Databricks App gets its **own** managed service principal (SP). Lakebase
+objects are owned by **whichever SP created them**. On `db-tellr`, the entire
+`app_data_prod` schema and all ~20 tables are owned by the **prod app's SP**
+(`161834b3-c54d-4b24-82c4-8f0166c191f4`). A forked branch inherits that
+ownership. The new dev app's SP is a *different* identity, and in Postgres only
+the **owner** (or a true superuser) may `ALTER`/`DROP` a table.
+
+The app's migrations (`src/core/database.py`, `_run_migrations`) are
+`ALTER`-heavy — `ADD COLUMN`, `ALTER COLUMN ... TYPE`, `DROP COLUMN`,
+`RENAME` against existing tables. So a dev build whose schema has moved since the
+fork point fails on first startup with `must be owner of table`. New-table
+`CREATE` and DML succeed (the existing `GRANT CREATE/USAGE` + DML grants cover
+them); altering inherited tables does not.
+
+### What was proven (live probes, 2026-06-29)
+
+- **The deployer cannot fix it.** Run as the human deployer (`robert.whiffin`),
+  `ALTER ... OWNER`, `ALTER SCHEMA OWNER`, and `REASSIGN OWNED BY <prod_sp>` all
+  fail. Only the **current owner** (the prod SP) or a true superuser can move
+  ownership.
+- **`databricks_superuser` is a red herring.** It has `rolsuper = false`; you
+  cannot `SET ROLE` to it, and membership does not grant ownership-bypass. Only
+  `databricks_control_plane` is a true superuser (`rolsuper = true`, unusable).
+- **`generate_database_credential` cannot impersonate** another SP; the `claims`
+  param scopes permissions *down*, it does not switch identity.
+- **The fix works: a member of the owning role can `ALTER` via `INHERIT`.** A
+  real login identity that is a *member* of a normal shared owning role can
+  `ALTER`/`DROP` that role's tables **as itself, without `SET ROLE`**, including
+  on a fork. This is the mechanism the dev SP will use. `REASSIGN OWNED BY <self>
+  TO <shared_role>` also works for moving one's own objects into the shared role.
+
+### Required end state
+
+All of `app_data_prod`'s objects are owned by a **shared owner** that *every*
+app SP (prod + each dev) is a member of. Then any member SP can migrate the
+inherited tables on its fork.
+
+### Two implementation routes (pick one in the dependency's own spec)
+
+1. **Permanent shared Postgres role** (recommended — built only from proven
+   mechanisms, no unsolved steps):
+   - Create a permanent `NOLOGIN` role, e.g. `tellr_app_owners`.
+   - **One-time prod transfer**, run *as the prod SP* (the current owner): grant
+     the prod SP membership in `tellr_app_owners`, then
+     `REASSIGN OWNED BY <prod_sp> TO tellr_app_owners` for `app_data_prod`.
+   - **Keep new objects shared-owned:** the app's migration step ends with
+     `REASSIGN OWNED BY CURRENT_USER TO tellr_app_owners` (the SP owns anything
+     it just created and is a member of the shared role, so this is allowed) — or
+     the app `SET ROLE`s the shared role before DDL if SET membership is granted.
+   - **Per dev deploy:** `GRANT tellr_app_owners TO "<dev_sp_client_id>"` on the
+     branch (run by a role with admin on `tellr_app_owners`). The dev SP then
+     inherits owner rights on the inherited tables.
+2. **Native Databricks group** (more native membership management via the
+   Databricks UI/API; matches the runbook):
+   - Group is created in Settings → Identity and access → Groups; made a
+     connectable Postgres role via `ws.postgres.create_role(identity_type=GROUP,
+     auth_method=LAKEBASE_OAUTH_V1)`.
+   - Ownership transferred with the runbook's temp-role bridge, finishing by
+     **connecting *as* the group** and `REASSIGN OWNED BY temp_table_owners TO
+     "<group>"`.
+   - **Open issue:** connecting as the group via the SDK
+     (`generate_database_credential` token + `-U <group>`) failed with
+     "Malformed OAuth token"; the runbook uses a **UI-issued** OAuth token. The
+     SDK path for connect-as-group is unsolved and must be figured out before
+     this route is viable.
+
+### What a fresh agent should do next
+
+1. Write a dedicated spec `…/specs/<date>-lakebase-shared-owner-design.md`,
+   choosing route 1 or 2 (recommend route 1).
+2. Decide who/what runs the one-time prod ownership transfer *as the prod SP*
+   (the deploy runs as the human, which can't — needs the app/SP to do it, e.g.
+   a guarded one-shot path in `init_database`, or a manual maintenance script run
+   with prod-SP creds).
+3. Add the per-deploy "grant new SP into the shared owner" step to the `devloop`
+   create flow (`scripts/deploy_local.py`), alongside `_ensure_sp_autoscaling_role`.
+4. Add the "keep new objects shared-owned" step to the app's migration path.
+5. Validate end-to-end on a throwaway project with a **real** member SP
+   (authenticate as the SP, not via `SET ROLE`) — confirm it can `ALTER` a
+   shared-owned table on a fork.
+
+### Interaction with this spec
+
+- `_setup_database_schema` / `_grant_schema_permissions` stay (they cover
+  USAGE/CREATE/DML and are still needed).
+- The `devloop` create flow gains the "add SP to shared owner" call once the
+  dependency lands.
+- Until then, `devloop` is usable for non-migrating builds; document the
+  limitation (see Out of scope).
 
 ## Feasibility (verified)
 
@@ -152,10 +265,15 @@ non-conforming id fails fast with an actionable error.
    `_ensure_sp_autoscaling_role(..., branch_name="dev-<id>")`.
 6. **Setup schema = grant-only.** The branch already carries `app_data_prod`;
    `CREATE SCHEMA IF NOT EXISTS` is a no-op, then grant the SP access.
+   *(Ownership dependency: once the shared-owner workstream lands, this step also
+   adds the new SP to the shared owner — `GRANT tellr_app_owners TO "<sp>"` — so
+   the SP can `ALTER` inherited tables.)*
 7. **Generate app.yaml** with the branch's `host`/`endpoint_name`, prod's schema
    (`app_data_prod`), and prod's encryption key (read from `production`
    app.yaml).
 8. **Deploy.** First startup runs migrations against the fresh prod copy.
+   New-table + DML migrations work today; `ALTER`s on inherited prod tables fail
+   until the ownership dependency lands (see the dependency section).
 
 ### `deploy_local.sh update --env devloop --instance <id> [--from-pypi <ver>]`
 
@@ -277,9 +395,18 @@ rollback machinery.
    gone; `branches/production` and instance `b` untouched.
 5. **Precondition failure:** invalid `--instance FOO` fails fast with the slug
    message and makes no `ws.postgres` call.
+6. **Migration limitation (pre-dependency):** a build that only adds a *new*
+   table or writes data deploys cleanly; a build that `ALTER`s an inherited prod
+   table fails at startup with `must be owner of table`. This is expected until
+   the ownership dependency lands — verifying this failure mode is part of
+   confirming the dependency is still needed.
 
 ## Out of scope
 
+- **The shared-owner ownership workstream itself** — tracked as a dependency
+  (see [Dependency: Lakebase table ownership](#dependency-lakebase-table-ownership-shared-owner-model));
+  it gets its own spec. This spec ships the branch mechanism; migrations that
+  alter inherited tables are unblocked by that separate work.
 - CI-run deploys — the deploy stays a manual laptop step; `publish-dev.yml`
   still only publishes and prints the command.
 - Auto-reaper / cron cleanup — manual delete + branch TTL only.

--- a/docs/technical/dev-deploy.md
+++ b/docs/technical/dev-deploy.md
@@ -65,3 +65,31 @@ publishing, that's proxy mirror lag — wait a moment and re-run the deploy step
 - `publish.yml` — tagged (`v*`) final releases to real PyPI. Unchanged; not for dev.
 
 See also the `deploy-tellr-dev` skill (`.claude/skills/deploy-tellr-dev/`).
+
+## Per-instance dev loop (`devloop`) — branch off prod
+
+For agentic dev loops that run multiple deployments at once, use the `devloop`
+env with an `--instance <id>`. Each instance gets its own app
+(`db-tellr-dev-<id>`) and a fresh copy-on-write branch of production Lakebase
+(`branches/dev-<id>`), recreated on every deploy:
+
+```bash
+gh workflow run publish-dev.yml          # publish the next .devN
+./scripts/deploy_local.sh create --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>    # first deploy
+./scripts/deploy_local.sh update --env devloop --instance agent-7f3a \
+    --profile tellr-dev --from-pypi <version>    # iterate (reuses app, refreshes branch)
+./scripts/deploy_local.sh delete --env devloop --instance agent-7f3a \
+    --profile tellr-dev                          # teardown (app + branch)
+```
+
+`--instance` must match `^[a-z][a-z0-9-]*$` and be ≤59 chars. Concurrent
+instances are fully isolated. The app compute is created once and reused; the
+branch is deleted and re-forked from prod on every deploy (fresh prod data each
+time — anything written to an instance is wiped on its next deploy).
+
+**Migration limitation:** an instance can create new tables and read/write prod
+data, but a build that `ALTER`s an *inherited* prod table fails at startup with
+`must be owner of table`. Fixing that needs the Lakebase table-ownership
+(shared-owner) workstream — see
+`docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md`.

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -1117,12 +1117,12 @@ def _delete_branch(
         raise
 
 
-# Lakebase branch TTL: 1 day. Branches auto-expire and are garbage-collected
-# after this window. The deploy flow relies on this for cleanup — we never
-# explicitly delete old branches, because Lakebase's delete is async and its
-# purge window is unpredictable (fixed-name reuse hits "branch id already
-# exists" for many minutes after delete). Unique-per-deploy IDs + TTL sidesteps
-# the whole issue.
+# Lakebase branch TTL: 1 day. This is now only an orphan backstop — if a deploy
+# crashes between create and cleanup, the TTL eventually garbage-collects the
+# stranded branch. The normal flow no longer relies on it: branches use fixed
+# names and are explicitly deleted and recreated (_recreate_ephemeral_branch,
+# delete_local) via _delete_branch, whose delete is idempotent and was verified
+# to leave the name immediately reusable.
 _BRANCH_TTL_SECONDS = 86400
 
 

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -1130,26 +1130,19 @@ def _create_branch_from(
     ws: WorkspaceClient,
     project_name: str,
     source_branch: str,
-    target_branch_prefix: str,
+    branch_id: str,
 ) -> dict[str, Any]:
-    """Create a new Lakebase branch as a child of `source_branch`.
+    """Create a new Lakebase branch named ``branch_id`` as a child of
+    ``source_branch``.
 
-    The branch ID is `{target_branch_prefix}-{unix_timestamp}` so that every
-    deploy gets a fresh unique ID. This avoids the "branch id already exists"
-    collision we hit when trying to reuse a fixed ID right after a delete —
-    Lakebase's delete is async and its purge window is unpredictable.
-
-    Branch is created with a 1-day TTL so Lakebase garbage-collects it for us.
-    The staging app the branch backs will break after ~1 day; re-deploy to get
-    a fresh branch. This trade is intentional: no cleanup code, no stale state.
+    The branch id is used verbatim (a fixed per-instance name). A 1-day TTL is
+    attached purely as an orphan backstop so abandoned instances get
+    garbage-collected; freshness comes from delete-then-create (see
+    _recreate_ephemeral_branch), not from the TTL.
 
     Waits on the create operation, then polls list_endpoints on the new branch
-    until an endpoint with a populated host appears (up to
-    _BRANCH_ENDPOINT_TIMEOUT_S). Raises DeploymentError on timeout.
-
-    Returns a lakebase_result-shaped dict pointing at the new branch, with an
-    added `branch_id` field so callers can reference the unique name (e.g.,
-    for SP role registration).
+    until an endpoint with a populated host appears. Raises DeploymentError on
+    timeout. Returns a lakebase_result-shaped dict with an added ``branch_id``.
     """
     if not HAS_AUTOSCALING_SDK:
         raise DeploymentError(
@@ -1157,7 +1150,6 @@ def _create_branch_from(
             "Upgrade databricks-sdk."
         )
 
-    branch_id = f"{target_branch_prefix}-{int(time.time())}"
     source_path = f"projects/{project_name}/branches/{source_branch}"
     target_parent = f"projects/{project_name}"
     target_path = f"projects/{project_name}/branches/{branch_id}"

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -1206,17 +1206,17 @@ def _recreate_ephemeral_branch(
     ws: WorkspaceClient,
     project_name: str,
     source_branch: str,
-    target_branch_prefix: str,
+    branch_id: str,
 ) -> dict[str, Any]:
-    """Create a fresh ephemeral Lakebase branch for this deploy.
+    """Refresh an ephemeral Lakebase branch to a fresh copy of source_branch.
 
-    Thin wrapper around _create_branch_from for call-site readability. Does
-    NOT delete any prior branch — we rely on Lakebase's TTL-driven garbage
-    collection (see _BRANCH_TTL_SECONDS) to clean up old branches, because
-    explicit delete has an async purge window that causes fixed-ID reuse to
-    collide for many minutes.
+    Deletes ``branch_id`` (idempotent — no-op if absent) then recreates it from
+    ``source_branch``. Delete-then-create on a fixed name was verified clean
+    (~6s, no collision); the older "skip delete and rely on TTL" workaround is
+    no longer needed.
     """
-    return _create_branch_from(ws, project_name, source_branch, target_branch_prefix)
+    _delete_branch(ws, project_name, branch_id)
+    return _create_branch_from(ws, project_name, source_branch, branch_id)
 
 
 def _write_requirements(

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -137,6 +138,45 @@ def load_deployment_config(env: str) -> dict[str, Any]:
         "branch_from_workspace_path": branch_from_workspace_path,
         **ml_flat,
     }
+
+
+_INSTANCE_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def _validate_instance(instance: str) -> None:
+    """Validate a deploy instance id. Raises DeploymentError if invalid."""
+    if not _INSTANCE_RE.match(instance) or len(instance) > 59:
+        raise DeploymentError(
+            "--instance must match ^[a-z][a-z0-9-]*$ and be <=59 chars "
+            f"(got '{instance}')"
+        )
+
+
+def _resolve_target(
+    config: dict[str, Any], env: str, instance: Optional[str]
+) -> tuple[str, str, str]:
+    """Resolve (app_name, workspace_path, target_branch) for a deploy.
+
+    Without an instance: names come straight from config and the branch is named
+    after the env. With an instance: the env must be a branching env; the app
+    name and workspace path are suffixed with the instance and the branch is
+    ``dev-<instance>``.
+    """
+    app_name = config["app_name"]
+    workspace_path = config["workspace_path"]
+    if instance is None:
+        return app_name, workspace_path, env
+    if not config.get("branch_from_env"):
+        raise DeploymentError(
+            f"--instance requires a branch_from env; '{env}' is not a "
+            "branching env"
+        )
+    _validate_instance(instance)
+    return (
+        f"{app_name}-{instance}",
+        f"{workspace_path}/{instance}",
+        f"dev-{instance}",
+    )
 
 
 def find_app_wheel() -> Path:

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -475,7 +475,7 @@ def create_local(
             "schema_name": schema_name,
             "wheel": wheel_path.name if wheel_path else None,
             "pypi_version": from_pypi,
-            "branch": env if branch_from_env else None,
+            "branch": target_branch if branch_from_env else None,
             "status": "created",
         }
 
@@ -654,7 +654,7 @@ def update_local(
             "wheel": wheel_path.name if wheel_path else None,
             "pypi_version": from_pypi,
             "status": "updated",
-            "branch": env if branch_from_env else None,
+            "branch": target_branch if branch_from_env else None,
             "database_reset": reset_database,
         }
 

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -771,6 +771,18 @@ def main() -> None:
             "instead of building/uploading a local wheel"
         ),
     )
+    parser.add_argument(
+        "--instance",
+        dest="instance",
+        type=str,
+        default=None,
+        metavar="ID",
+        help=(
+            "Ephemeral instance id for a branching env (e.g. devloop). "
+            "Derives app name db-<base>-<id>, branch dev-<id>, and a per-instance "
+            "workspace path. Required for concurrent dev-loop deploys."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -799,6 +811,7 @@ def main() -> None:
                 profile=args.profile,
                 seed_databricks_defaults=args.include_databricks_prompts,
                 from_pypi=args.from_pypi,
+                instance=args.instance,
             )
         elif args.action == "update":
             result = update_local(
@@ -807,12 +820,14 @@ def main() -> None:
                 reset_database=args.reset_db,
                 seed_databricks_defaults=args.include_databricks_prompts,
                 from_pypi=args.from_pypi,
+                instance=args.instance,
             )
         elif args.action == "delete":
             result = delete_local(
                 env=args.env,
                 profile=args.profile,
                 reset_database=args.reset_db,
+                instance=args.instance,
             )
         else:
             raise ValueError(f"Unknown action: {args.action}")

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "packages" / "databricks-tellr"))
 from databricks_tellr.deploy import (
     DeploymentError,
     _branch_exists,
+    _delete_branch,
     _get_workspace_client,
     _get_or_create_lakebase,
     _mlflow_flat_from_env_section,
@@ -305,6 +306,7 @@ def create_local(
     profile: str,
     seed_databricks_defaults: bool = True,
     from_pypi: Optional[str] = None,
+    instance: Optional[str] = None,
 ) -> dict[str, Any]:
     """Create a new Databricks App using locally-built wheels.
 
@@ -322,8 +324,7 @@ def create_local(
     config = load_deployment_config(env)
     ws = _get_workspace_client(profile=profile)
 
-    app_name = config["app_name"]
-    workspace_path = config["workspace_path"]
+    app_name, workspace_path, target_branch = _resolve_target(config, env, instance)
     lakebase_name = config["lakebase_name"]
     schema_name = config["schema_name"]
     branch_from_env = config.get("branch_from_env")
@@ -334,7 +335,7 @@ def create_local(
     print(f"   Lakebase: {lakebase_name}")
     print(f"   Schema: {schema_name}")
     if branch_from_env:
-        print(f"   Branching from: {branch_from_env} (ephemeral branch '{env}')")
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{target_branch}')")
     print()
 
     try:
@@ -363,9 +364,9 @@ def create_local(
             encryption_key = _check_branching_preconditions(ws, config)
             print(f"   Preflight OK (source: {branch_from_env})")
 
-            print(f"Creating ephemeral branch off '{branch_from_env}'...")
+            print(f"Creating ephemeral branch '{target_branch}' off '{branch_from_env}'...")
             lakebase_result = _recreate_ephemeral_branch(
-                ws, lakebase_name, branch_from_env, env
+                ws, lakebase_name, branch_from_env, target_branch
             )
             print(
                 f"   Branch '{lakebase_result['branch_id']}' ready "
@@ -488,6 +489,7 @@ def update_local(
     reset_database: bool = False,
     seed_databricks_defaults: bool = True,
     from_pypi: Optional[str] = None,
+    instance: Optional[str] = None,
 ) -> dict[str, Any]:
     """Update an existing Databricks App using locally-built wheels.
 
@@ -497,8 +499,7 @@ def update_local(
     config = load_deployment_config(env)
     ws = _get_workspace_client(profile=profile)
 
-    app_name = config["app_name"]
-    workspace_path = config["workspace_path"]
+    app_name, workspace_path, target_branch = _resolve_target(config, env, instance)
     lakebase_name = config["lakebase_name"]
     schema_name = config["schema_name"]
     branch_from_env = config.get("branch_from_env")
@@ -512,7 +513,7 @@ def update_local(
 
     print(f"Updating AI Slide Generator (local wheels): {app_name}")
     if branch_from_env:
-        print(f"   Branching from: {branch_from_env} (ephemeral branch '{env}')")
+        print(f"   Branching from: {branch_from_env} (ephemeral branch '{target_branch}')")
     print()
 
     try:
@@ -532,9 +533,9 @@ def update_local(
                     f"run 'deploy_local.sh create --env {env}' first"
                 ) from e
 
-            print(f"Recreating ephemeral branch '{env}' from '{branch_from_env}'...")
+            print(f"Recreating ephemeral branch '{target_branch}' from '{branch_from_env}'...")
             lakebase_result = _recreate_ephemeral_branch(
-                ws, lakebase_name, branch_from_env, env
+                ws, lakebase_name, branch_from_env, target_branch
             )
             print(
                 f"   Branch '{lakebase_result['branch_id']}' ready "
@@ -661,10 +662,14 @@ def update_local(
         raise DeploymentError(f"Update failed: {e}") from e
 
 
-def delete_local(env: str, profile: str, reset_database: bool = False) -> dict[str, Any]:
+def delete_local(
+    env: str, profile: str, reset_database: bool = False,
+    instance: Optional[str] = None,
+) -> dict[str, Any]:
     """Delete a Databricks App (and its ephemeral branch, if branching)."""
     config = load_deployment_config(env)
     branch_from_env = config.get("branch_from_env")
+    app_name, _workspace_path, target_branch = _resolve_target(config, env, instance)
 
     if branch_from_env and reset_database:
         print(
@@ -674,17 +679,19 @@ def delete_local(env: str, profile: str, reset_database: bool = False) -> dict[s
         reset_database = False
 
     result = delete(
-        app_name=config["app_name"],
+        app_name=app_name,
         lakebase_name=config["lakebase_name"],
         schema_name=config["schema_name"],
         reset_database=reset_database,
         profile=profile,
     )
 
-    # Intentionally do NOT delete ephemeral branches here. Lakebase's delete
-    # is async and its purge window causes fixed-ID reuse to collide. We rely
-    # on the branch TTL (_BRANCH_TTL_SECONDS in databricks_tellr.deploy) to
-    # garbage-collect. Leftover branches are harmless and auto-expire.
+    # For branching envs, also delete the ephemeral branch (fixed name, so this
+    # is now safe and re-runnable — idempotent on not-found).
+    if branch_from_env:
+        ws = _get_workspace_client(profile=profile)
+        _delete_branch(ws, config["lakebase_name"], target_branch)
+        print(f"   Deleted branch '{target_branch}'")
 
     return result
 

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -37,6 +37,8 @@ usage() {
     echo "  --skip-build                 Skip wheel build (use existing wheels in dist/)"
     echo "  --from-pypi <version>        Deploy by pinning databricks-tellr-app==<version>"
     echo "                               from PyPI (skips the local wheel build/upload)"
+    echo "  --instance <id>              Ephemeral instance id for a branching env (e.g. devloop);"
+    echo "                               each gets its own app + prod branch"
     echo "  -h, --help                   Show this help message"
     echo ""
     echo "Examples:"
@@ -45,6 +47,8 @@ usage() {
     echo "  $0 update --env development --profile my-profile --reset-db"
     echo "  $0 update --env staging --profile my-profile --skip-build"
     echo "  $0 update --env development --profile my-profile --from-pypi 0.3.9.dev3"
+    echo "  $0 update --env devtest --profile my-profile --from-pypi 0.3.10.dev1"
+    echo "  $0 create --env devloop --instance agent-7f3a --profile my-profile --from-pypi 0.3.10.dev1"
     echo "  $0 delete --env development --profile my-profile"
     exit 1
 }

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -57,6 +57,7 @@ RESET_DB=""
 INCLUDE_DB_PROMPTS=""
 SKIP_BUILD=""
 FROM_PYPI=""
+INSTANCE=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -86,6 +87,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --from-pypi)
             FROM_PYPI="$2"
+            shift 2
+            ;;
+        --instance)
+            INSTANCE="$2"
             shift 2
             ;;
         -h|--help)
@@ -120,7 +125,7 @@ fi
 
 # Note: Environment names must match keys in config/deployment.yaml
 # Add new environments to the regex below when adding to deployment.yaml
-if [[ ! "$ENV" =~ ^(development|staging|production|test)$ ]]; then
+if [[ ! "$ENV" =~ ^(development|staging|production|test|devtest|devloop)$ ]]; then
     echo -e "${RED}Invalid environment: $ENV${NC}"
     echo "   Check config/deployment.yaml for valid environment names"
     exit 1
@@ -154,6 +159,9 @@ if [ -n "$SKIP_BUILD" ]; then
 fi
 if [ -n "$FROM_PYPI" ]; then
     echo "  PyPI:        $FROM_PYPI"
+fi
+if [ -n "$INSTANCE" ]; then
+    echo "  Instance:    $INSTANCE"
 fi
 echo ""
 
@@ -203,13 +211,19 @@ if [ -n "$FROM_PYPI" ]; then
     FROM_PYPI_ARG=(--from-pypi "$FROM_PYPI")
 fi
 
+INSTANCE_ARG=()
+if [ -n "$INSTANCE" ]; then
+    INSTANCE_ARG=(--instance "$INSTANCE")
+fi
+
 python -m scripts.deploy_local \
     --$ACTION \
     --env "$ENV" \
     --profile "$PROFILE" \
     $RESET_DB \
     $INCLUDE_DB_PROMPTS \
-    "${FROM_PYPI_ARG[@]}"
+    "${FROM_PYPI_ARG[@]}" \
+    "${INSTANCE_ARG[@]}"
 
 echo ""
 echo -e "${GREEN}Done!${NC}"

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -474,16 +474,10 @@ def _run_migrations(engine, schema: str | None = None):
                 f"ALTER TABLE {qualified_table} ADD COLUMN llm_judge_backend VARCHAR(32) "
                 "DEFAULT 'mlflow' NOT NULL"
             ))
-        elif not is_sqlite:
-            try:
-                conn.execute(text(
-                    f"ALTER TABLE {qualified_table} ALTER COLUMN llm_judge_backend "
-                    "SET DEFAULT 'mlflow'"
-                ))
-            except Exception as ex:
-                logger.debug(
-                    "Migration: skip llm_judge_backend server default alter: %s", ex
-                )
+        else:
+            _ensure_llm_judge_backend_default(
+                conn, table_name, qualified_table, schema, is_sqlite
+            )
         # --- config_profiles: migrate is_global bool to global_permission ---
         if "is_global" in columns:
             logger.info(f"Migration: migrating is_global to global_permission")
@@ -526,6 +520,57 @@ def _run_migrations(engine, schema: str | None = None):
 
         # --- image_assets.tags: json → jsonb (PostgreSQL) for native @> queries ---
         _migrate_image_assets_tags_json_to_jsonb(conn, schema, _qual, is_sqlite)
+
+
+def _ensure_llm_judge_backend_default(
+    conn, table_name, qualified_table, schema, is_sqlite
+) -> None:
+    """Ensure config_profiles.llm_judge_backend has server default 'mlflow'.
+
+    Idempotent and fork-safe. SQLite sets the default at column creation, so
+    there is nothing to do there. On PostgreSQL, only issue the ALTER when the
+    current default is NOT already 'mlflow' — re-issuing it on every startup is
+    needless ownership-gated DDL that fails on a copy-on-write branch where the
+    app's service principal does not own the inherited table, and (because the
+    whole migration runs in one transaction) a swallowed failure would poison
+    every later migration statement. Skipping when already-correct makes a
+    same-schema branch a true no-op; the rare real backfill runs inside a
+    SAVEPOINT so its failure is contained rather than aborting the outer
+    transaction.
+    """
+    from sqlalchemy import text
+
+    if is_sqlite:
+        return
+
+    current_default = None
+    try:
+        sql = (
+            "SELECT column_default FROM information_schema.columns "
+            "WHERE table_name = :t AND column_name = 'llm_judge_backend'"
+        )
+        params = {"t": table_name}
+        if schema:
+            sql += " AND table_schema = :s"
+            params["s"] = schema
+        current_default = conn.execute(text(sql), params).scalar()
+    except Exception:
+        current_default = None
+
+    if current_default is not None and "mlflow" in str(current_default):
+        return  # already correct — no DDL needed
+
+    logger.info("Migration: setting llm_judge_backend server default to 'mlflow'")
+    try:
+        with conn.begin_nested():
+            conn.execute(text(
+                f"ALTER TABLE {qualified_table} ALTER COLUMN llm_judge_backend "
+                "SET DEFAULT 'mlflow'"
+            ))
+    except Exception as ex:
+        logger.debug(
+            "Migration: skip llm_judge_backend server default alter: %s", ex
+        )
 
 
 def _migrate_image_assets_tags_json_to_jsonb(conn, schema, _qual, is_sqlite) -> None:

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -68,22 +68,19 @@ from databricks_tellr.deploy import _create_branch_from
 
 
 class TestCreateBranchFrom:
-    def test_creates_branch_with_correct_source(self, mock_ws, monkeypatch):
-        # Freeze time so the generated branch_id is deterministic.
-        monkeypatch.setattr("databricks_tellr.deploy.time.time", lambda: 1777000000)
-        expected_branch_id = "staging-1777000000"
+    def test_creates_branch_with_correct_source(self, mock_ws):
+        branch_id = "dev-agent-7f3a"
 
         create_op = MagicMock()
         mock_ws.postgres.create_branch.return_value = create_op
 
         endpoint_ready = MagicMock()
         endpoint_ready.name = (
-            f"projects/db-tellr/branches/{expected_branch_id}/endpoints/ep1"
+            f"projects/db-tellr/branches/{branch_id}/endpoints/ep1"
         )
         endpoint_ready.status = MagicMock(
-            hosts=MagicMock(host="staging-ep1.example.com")
+            hosts=MagicMock(host="dev-ep1.example.com")
         )
-        # Fresh iterator per call — avoids one-shot iter() exhaustion if polling loops.
         mock_ws.postgres.list_endpoints.side_effect = (
             lambda **kw: iter([endpoint_ready])
         )
@@ -92,38 +89,32 @@ class TestCreateBranchFrom:
             mock_ws,
             project_name="db-tellr",
             source_branch="production",
-            target_branch_prefix="staging",
+            branch_id=branch_id,
         )
 
-        # Verify create_branch call shape
         call_kwargs = mock_ws.postgres.create_branch.call_args.kwargs
         assert call_kwargs["parent"] == "projects/db-tellr"
-        # branch_id is {prefix}-{timestamp} — a fresh unique ID per deploy.
-        assert call_kwargs["branch_id"] == expected_branch_id
+        # branch_id is used verbatim — no timestamp suffix.
+        assert call_kwargs["branch_id"] == branch_id
         branch_arg = call_kwargs["branch"]
         assert branch_arg.spec.source_branch == "projects/db-tellr/branches/production"
-        # Databricks API requires an expiration policy. We use ttl=1 day and
-        # rely on TTL-driven auto-cleanup rather than explicit delete.
+        # TTL remains as an orphan backstop (not the freshness mechanism).
         assert branch_arg.spec.ttl is not None
         assert branch_arg.spec.ttl.seconds == 86400
-        # no_expiry MUST NOT be set when ttl is — they're mutually exclusive.
         assert not branch_arg.spec.no_expiry
 
         create_op.wait.assert_called_once()
 
-        # Verify returned lakebase_result shape
         assert result["type"] == "autoscaling"
         assert result["name"] == "db-tellr"
-        assert result["host"] == "staging-ep1.example.com"
+        assert result["host"] == "dev-ep1.example.com"
         assert (
             result["endpoint_name"]
-            == f"projects/db-tellr/branches/{expected_branch_id}/endpoints/ep1"
+            == f"projects/db-tellr/branches/{branch_id}/endpoints/ep1"
         )
         assert result["project_id"] == "db-tellr"
         assert result["instance_name"] is None
-        # New field: callers (SP role registration, schema grants) use this
-        # to reference the unique branch name.
-        assert result["branch_id"] == expected_branch_id
+        assert result["branch_id"] == branch_id
 
     def test_raises_when_no_endpoint_after_timeout(self, mock_ws, monkeypatch):
         """If list_endpoints never returns a ready endpoint, raise DeploymentError."""
@@ -137,7 +128,7 @@ class TestCreateBranchFrom:
         monkeypatch.setattr("databricks_tellr.deploy._BRANCH_ENDPOINT_TIMEOUT_S", 0.1)
 
         with pytest.raises(DeploymentError, match="no endpoint ready"):
-            _create_branch_from(mock_ws, "db-tellr", "production", "staging")
+            _create_branch_from(mock_ws, "db-tellr", "production", "dev-x")
 
 
 from databricks_tellr.deploy import _recreate_ephemeral_branch

--- a/tests/unit/test_deploy_branch_helpers.py
+++ b/tests/unit/test_deploy_branch_helpers.py
@@ -135,17 +135,17 @@ from databricks_tellr.deploy import _recreate_ephemeral_branch
 
 
 class TestRecreateEphemeralBranch:
-    def test_delegates_to_create_without_deleting(self, mock_ws, monkeypatch):
-        """Delete step removed — TTL handles cleanup. Verify we ONLY create."""
+    def test_deletes_then_creates_fixed_name(self, mock_ws, monkeypatch):
+        """Fresh copy each deploy = delete the fixed branch, then recreate it."""
         calls = []
 
         def fake_delete(ws, project, branch):
             calls.append(("delete", branch))
 
-        def fake_create(ws, project, source, prefix):
-            calls.append(("create", source, prefix))
+        def fake_create(ws, project, source, branch_id):
+            calls.append(("create", source, branch_id))
             return {"host": "x", "endpoint_name": "e", "type": "autoscaling",
-                    "branch_id": f"{prefix}-12345"}
+                    "branch_id": branch_id}
 
         monkeypatch.setattr("databricks_tellr.deploy._delete_branch", fake_delete)
         monkeypatch.setattr("databricks_tellr.deploy._create_branch_from", fake_create)
@@ -154,10 +154,12 @@ class TestRecreateEphemeralBranch:
             mock_ws,
             project_name="db-tellr",
             source_branch="production",
-            target_branch_prefix="staging",
+            branch_id="dev-agent-7f3a",
         )
 
-        # No delete — only create.
-        assert calls == [("create", "production", "staging")]
+        assert calls == [
+            ("delete", "dev-agent-7f3a"),
+            ("create", "production", "dev-agent-7f3a"),
+        ]
         assert result["host"] == "x"
-        assert result["branch_id"] == "staging-12345"
+        assert result["branch_id"] == "dev-agent-7f3a"

--- a/tests/unit/test_deploy_local_instance.py
+++ b/tests/unit/test_deploy_local_instance.py
@@ -48,3 +48,51 @@ class TestResolveTarget:
     def test_instance_invalid_slug_raises(self):
         with pytest.raises(DeploymentError):
             _resolve_target(BRANCHING, "devloop", "Bad_Id")
+
+
+from unittest.mock import MagicMock, patch
+
+
+class TestDeleteLocalBranch:
+    def test_deletes_app_and_instance_branch(self, monkeypatch):
+        import scripts.deploy_local as dl
+
+        cfg = {
+            "app_name": "db-tellr-dev",
+            "workspace_path": "/Workspace/Users/x/.apps/devloop",
+            "lakebase_name": "db-tellr",
+            "schema_name": "app_data_prod",
+            "branch_from_env": "production",
+        }
+        monkeypatch.setattr(dl, "load_deployment_config", lambda env: cfg)
+        fake_ws = MagicMock()
+        monkeypatch.setattr(dl, "_get_workspace_client", lambda profile: fake_ws)
+        delete_calls = {}
+        monkeypatch.setattr(dl, "delete", lambda **kw: delete_calls.update(kw) or {"status": "deleted"})
+        branch_calls = []
+        monkeypatch.setattr(dl, "_delete_branch", lambda ws, proj, br: branch_calls.append((proj, br)))
+
+        dl.delete_local(env="devloop", profile="p", instance="agent-7f3a")
+
+        # App deleted under the instance-suffixed name
+        assert delete_calls["app_name"] == "db-tellr-dev-agent-7f3a"
+        # Branch deleted with the fixed dev-<instance> name
+        assert branch_calls == [("db-tellr", "dev-agent-7f3a")]
+
+    def test_non_branching_delete_does_not_touch_branches(self, monkeypatch):
+        import scripts.deploy_local as dl
+
+        cfg = {
+            "app_name": "db-tellr-dev",
+            "workspace_path": "/Workspace/Users/x/.apps/dev",
+            "lakebase_name": "db-tellr",
+            "schema_name": "tellr_app_data_dev",
+            "branch_from_env": None,
+        }
+        monkeypatch.setattr(dl, "load_deployment_config", lambda env: cfg)
+        monkeypatch.setattr(dl, "delete", lambda **kw: {"status": "deleted"})
+        branch_calls = []
+        monkeypatch.setattr(dl, "_delete_branch", lambda ws, proj, br: branch_calls.append((proj, br)))
+
+        dl.delete_local(env="development", profile="p")
+        assert branch_calls == []

--- a/tests/unit/test_deploy_local_instance.py
+++ b/tests/unit/test_deploy_local_instance.py
@@ -17,7 +17,7 @@ NON_BRANCHING = {
 
 
 class TestValidateInstance:
-    @pytest.mark.parametrize("good", ["agent-7f3a", "a", "spike01", "x-1-2-3"])
+    @pytest.mark.parametrize("good", ["agent-7f3a", "a", "spike01", "x-1-2-3", "a" * 59])
     def test_accepts_valid(self, good):
         _validate_instance(good)  # no raise
 
@@ -50,7 +50,7 @@ class TestResolveTarget:
             _resolve_target(BRANCHING, "devloop", "Bad_Id")
 
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
 class TestDeleteLocalBranch:

--- a/tests/unit/test_deploy_local_instance.py
+++ b/tests/unit/test_deploy_local_instance.py
@@ -1,0 +1,50 @@
+"""Tests for --instance resolution + validation in deploy_local."""
+import pytest
+
+from databricks_tellr.deploy import DeploymentError
+from scripts.deploy_local import _validate_instance, _resolve_target
+
+BRANCHING = {
+    "app_name": "db-tellr-dev",
+    "workspace_path": "/Workspace/Users/x/.apps/devloop",
+    "branch_from_env": "production",
+}
+NON_BRANCHING = {
+    "app_name": "db-tellr-dev",
+    "workspace_path": "/Workspace/Users/x/.apps/dev",
+    "branch_from_env": None,
+}
+
+
+class TestValidateInstance:
+    @pytest.mark.parametrize("good", ["agent-7f3a", "a", "spike01", "x-1-2-3"])
+    def test_accepts_valid(self, good):
+        _validate_instance(good)  # no raise
+
+    @pytest.mark.parametrize("bad", ["Agent", "1abc", "has_underscore", "has.dot",
+                                     "trailing ", "UPPER", "a" * 60])
+    def test_rejects_invalid(self, bad):
+        with pytest.raises(DeploymentError):
+            _validate_instance(bad)
+
+
+class TestResolveTarget:
+    def test_no_instance_uses_env_branch(self):
+        app, wp, branch = _resolve_target(BRANCHING, "staging", None)
+        assert app == "db-tellr-dev"
+        assert wp == "/Workspace/Users/x/.apps/devloop"
+        assert branch == "staging"
+
+    def test_instance_suffixes_names_and_dev_branch(self):
+        app, wp, branch = _resolve_target(BRANCHING, "devloop", "agent-7f3a")
+        assert app == "db-tellr-dev-agent-7f3a"
+        assert wp == "/Workspace/Users/x/.apps/devloop/agent-7f3a"
+        assert branch == "dev-agent-7f3a"
+
+    def test_instance_on_non_branching_raises(self):
+        with pytest.raises(DeploymentError, match="branch_from"):
+            _resolve_target(NON_BRANCHING, "development", "agent-7f3a")
+
+    def test_instance_invalid_slug_raises(self):
+        with pytest.raises(DeploymentError):
+            _resolve_target(BRANCHING, "devloop", "Bad_Id")

--- a/tests/unit/test_llm_judge_default_migration.py
+++ b/tests/unit/test_llm_judge_default_migration.py
@@ -1,0 +1,79 @@
+"""Regression tests for the llm_judge_backend SET DEFAULT migration.
+
+Root cause (devloop branching investigation, 2026-06-29): the migration issued
+`ALTER TABLE config_profiles ALTER COLUMN llm_judge_backend SET DEFAULT 'mlflow'`
+unconditionally whenever the column existed — even when the default was already
+'mlflow'. That needless ownership-gated DDL fails on a copy-on-write branch
+(app SP isn't the table owner), and the swallowing try/except left the shared
+migration transaction poisoned, breaking every later migration.
+
+The fix: only ALTER when the default is NOT already correct, and wrap the ALTER
+in a SAVEPOINT so a failure cannot abort the outer transaction.
+"""
+from unittest.mock import MagicMock
+
+from src.core.database import _ensure_llm_judge_backend_default
+
+
+def _executed_sql(conn):
+    return [str(c.args[0]) for c in conn.execute.call_args_list]
+
+
+def test_skips_alter_when_default_already_mlflow():
+    """Same-schema fork: default already correct -> no DDL emitted."""
+    conn = MagicMock()
+    conn.execute.return_value.scalar.return_value = "'mlflow'::character varying"
+
+    _ensure_llm_judge_backend_default(
+        conn, "config_profiles",
+        '"app_data_prod"."config_profiles"', "app_data_prod", is_sqlite=False,
+    )
+
+    sql = _executed_sql(conn)
+    assert any("information_schema.columns" in s for s in sql), "should check current default"
+    assert not any("SET DEFAULT" in s for s in sql), "must NOT re-issue the ALTER when already correct"
+    conn.begin_nested.assert_not_called()
+
+
+def test_issues_alter_in_savepoint_when_default_missing():
+    """Legit backfill: default missing -> ALTER, wrapped in a savepoint."""
+    conn = MagicMock()
+    conn.execute.return_value.scalar.return_value = None
+
+    _ensure_llm_judge_backend_default(
+        conn, "config_profiles",
+        '"app_data_prod"."config_profiles"', "app_data_prod", is_sqlite=False,
+    )
+
+    sql = _executed_sql(conn)
+    assert any("SET DEFAULT" in s for s in sql), "should ALTER when default is missing"
+    conn.begin_nested.assert_called_once(), "ALTER must run inside a SAVEPOINT so a failure can't poison the txn"
+
+
+def test_noop_on_sqlite():
+    """SQLite manages the default at column creation; nothing to do."""
+    conn = MagicMock()
+    _ensure_llm_judge_backend_default(
+        conn, "config_profiles", '"config_profiles"', None, is_sqlite=True,
+    )
+    conn.execute.assert_not_called()
+
+
+def test_swallowed_alter_failure_does_not_propagate():
+    """If the ALTER fails (e.g. non-owner on a fork), it is contained, not raised."""
+    conn = MagicMock()
+    conn.execute.return_value.scalar.return_value = None
+    # Make the ALTER (the execute call inside begin_nested) raise.
+    def execute_side_effect(stmt, *a, **k):
+        if "SET DEFAULT" in str(stmt):
+            raise Exception("must be owner of table config_profiles")
+        m = MagicMock()
+        m.scalar.return_value = None
+        return m
+    conn.execute.side_effect = execute_side_effect
+
+    # Must NOT raise.
+    _ensure_llm_judge_backend_default(
+        conn, "config_profiles",
+        '"app_data_prod"."config_profiles"', "app_data_prod", is_sqlite=False,
+    )


### PR DESCRIPTION
## What

Adds a `devloop` deploy environment + `--instance <id>` flag so each concurrent agentic dev loop gets an **isolated app** (`db-tellr-dev-<id>`) backed by its **own ephemeral copy-on-write branch of production Lakebase** (`dev-<id>`). The app compute is created once and reused; the branch is delete+recreated fresh from prod each deploy.

```bash
gh workflow run publish-dev.yml --ref <branch>      # publishes the next .devN
./scripts/deploy_local.sh create --env devloop --instance agent-7f3a --profile tellr-dev --from-pypi <ver>
./scripts/deploy_local.sh update --env devloop --instance agent-7f3a --profile tellr-dev --from-pypi <ver>
./scripts/deploy_local.sh delete --env devloop --instance agent-7f3a --profile tellr-dev
```

## How

- **Branch mechanism** (`databricks_tellr/deploy.py`): `_create_branch_from` uses a verbatim fixed branch id; `_recreate_ephemeral_branch` does delete-then-create on that fixed name (a live probe proved fixed-name reuse is clean — the old timestamp+TTL workaround is removed). TTL stays only as an orphan backstop.
- **Instance plumbing** (`scripts/deploy_local.py` + `.sh`): `_validate_instance` (`^[a-z][a-z0-9-]*$`, ≤59 chars) and `_resolve_target` derive the app name, workspace path, and `dev-<id>` branch from one `--instance`. Threaded through create/update/delete; `delete` removes the app **and** the branch. `--instance` requires a branching env.
- **Migration robustness fix** (`src/core/database.py`): `_run_migrations` re-issued `ALTER COLUMN llm_judge_backend SET DEFAULT` unconditionally even when already correct — needless ownership-gated DDL that fails on a fork (app SP isn't the table owner) and, since all migrations share one transaction, the swallowed failure poisoned every later migration. Now skips when the default is already correct and wraps the rare real backfill in a SAVEPOINT. Audited the rest of `_run_migrations`: all other DDL is guarded and a true no-op on an up-to-date branch.
- Additive + opt-in: `devloop` example config, publish-dev deploy summary, docs/skill updates. No existing env or prod path changes.

## Verified live

Published `0.3.10.dev2` (built from this branch) and deployed it to a real prod fork (`devloop --instance smoke02`): branch forked, app created, SP role + schema grants applied, **migrations completed cleanly** (no `must be owner` / no aborted transaction), app reached **RUNNING** and served (HTTP 302 auth gate). Teardown removed both app and branch; prod untouched.

## Tests

- Updated `test_deploy_branch_helpers.py` (fixed-name delete+create), new `test_deploy_local_instance.py` (instance derivation, slug validation, branch-deletion on teardown), new `test_llm_judge_default_migration.py` (idempotency + savepoint). Existing migration suites green.

## Known follow-up (out of scope — documented dependency)

Dev builds that introduce a **new schema migration** still need the dev SP to own/act-as-owner of the inherited prod tables. That's the separate **Lakebase shared-owner / group ownership** workstream (see the dependency section in `docs/superpowers/specs/2026-06-29-devloop-instance-branching-design.md`). This PR makes devloop work for every dev iteration that doesn't add a new migration; the ownership work unblocks the rest.

This pull request and its description were written by Isaac.