### PR TITLE
fix(publish-dev): bundle huashu sidecar in dev wheel (parity with prod)

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -111,10 +111,16 @@ jobs:
       - name: Build databricks-tellr
         run: python -m build --sdist --wheel packages/databricks-tellr
 
+      - name: Build huashu bootstrap artifacts
+        # Produces services/pptx-emit-huashu/{node_modules,sys-libs-bullseye}.tar.gz
+        # which setup.py copies into the wheel's _assets/sidecars/pptx-emit-huashu/
+        # when TELLR_INCLUDE_HUASHU_SIDECAR=1. Mirrors publish.yml (prod).
+        run: bash services/pptx-emit-huashu/build-artifacts.sh
+
       - name: Build databricks-tellr-app
         run: |
           cp -r src packages/databricks-tellr-app/src
-          python -m build --sdist --wheel packages/databricks-tellr-app
+          TELLR_INCLUDE_HUASHU_SIDECAR=1 python -m build --sdist --wheel packages/databricks-tellr-app
           rm -rf packages/databricks-tellr-app/src
 
       - name: Verify built artifacts (huashu tarballs present, wheel >= 25MB)


### PR DESCRIPTION
## What

`publish-dev.yml` built the `databricks-tellr-app` wheel **without** `TELLR_INCLUDE_HUASHU_SIDECAR=1`, so `setup.py` skipped bundling the huashu sidecar tarballs (`node_modules.tar.gz`, `sys-libs-bullseye.tar.gz`). The resulting wheel was ~1.0 MB and failed the workflow's own verify gate:

```
ERROR: wheel missing huashu tarball(s): .../node_modules.tar.gz, .../sys-libs-bullseye.tar.gz
```

This makes the dev-build workflow match prod (`publish.yml`):
- Add the `build-artifacts.sh` verify step (confirms the committed tarballs are present/uncorrupt).
- Set `TELLR_INCLUDE_HUASHU_SIDECAR=1` on the app build so `setup.py` bundles them.

## Why it wasn't caught before

The bug dates to PR #200, which introduced `publish-dev.yml` with the verify gate (tarballs present + wheel ≥ 25 MB) but never added the env var the gate depends on — so the gate was unsatisfiable from the start. Prod's `publish.yml` was unaffected, so prod deploys kept working. This surfaced the first time `publish-dev.yml` was actually run since #200.

## Verification

With this change, `publish-dev.yml` produced a 30.6 MB wheel, passed the verify gate, and published `0.3.10.dev4` to PyPI; a devloop app deployed from it came up `RUNNING`.

This pull request and its description were written by Isaac.