### PR TITLE
docs(skill): fix stale migration limitation in deploy-tellr-dev skill

### DIFF
--- a/.claude/skills/deploy-tellr-dev/SKILL.md
+++ b/.claude/skills/deploy-tellr-dev/SKILL.md
@@ -63,9 +63,13 @@ instances stay isolated:
 re-forked from prod on every deploy, so anything written to an instance is wiped
 on its next deploy.
 
-**Migration limitation:** a build that `ALTER`s an *inherited* prod table fails
-at startup with `must be owner of table` (creating new tables is fine). See
-`docs/technical/dev-deploy.md` for details.
+**Migrations run as code on the fork.** A build can `ALTER`/`DROP` inherited prod
+tables *and* create new ones — `app_data_prod` is owned by the shared
+`tellr_app_owners` role, and `devloop create` grants each instance's SP into that
+role (via a serverless granter job) so its migrations run as owner through
+`INHERIT`. New objects a migration creates are reassigned back to the shared role
+so the next fork inherits them too. See
+`docs/technical/lakebase-table-ownership.md` for the ownership model.
 
 ## Reading deploy logs
 


### PR DESCRIPTION
## What

The `deploy-tellr-dev` skill still carried a **Migration limitation** note saying a build that `ALTER`s an inherited prod table fails at startup with `must be owner of table`. That was fixed by the Lakebase shared-owner model (#208): `app_data_prod` is owned by the shared `tellr_app_owners` role, `devloop create` grants each instance's SP into that role, and migrations run as owner through `INHERIT`.

Updates the skill to reflect that migrations (both `ALTER`/`DROP` on inherited tables and new-table creation) now run as code on any fork, and points at `docs/technical/lakebase-table-ownership.md`.

## Notes

- `docs/technical/dev-deploy.md` and `docs/technical/lakebase-table-ownership.md` were checked and are already current — no change needed.
- Docs-only change to a skill file.

This pull request and its description were written by Isaac.