### PR TITLE
chore(release): bump version to 0.3.10

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.3.9"
+version = "0.3.10"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.3.9"
+version = "0.3.10"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `databricks-tellr` and `databricks-tellr-app` from `0.3.9` → `0.3.10` to cut the next release.

## Verification
The `0.3.x` delta migrations (workspace-wide deck sharing / share-all, #205) were verified upgrading cleanly **in place** from the published `0.3.9` to `0.3.10.dev5` on a `devloop` fork of prod Lakebase — deploy SUCCEEDED, migrations (`global_permission` column, `deck workspace sharing columns`, `reassign-to-shared-owner`) applied against the live 0.3.9 schema, 0 errors, app reached startup-complete.

## Release
Once merged, tag `main` with `v0.3.10` to trigger `publish.yml` (validate checks the tag matches both pyproject versions).

This pull request and its description were written by Isaac.