### PR TITLE
fix(deploy): SP-only devloop — skip human schema-setup connection on the fork path

### DIFF
--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -324,6 +324,41 @@ def _trigger_owner_grant_job(ws, job_id, new_sp_id, host, endpoint_name) -> None
     print("   SP granted into shared owning role")
 
 
+def _assert_fork_schema_setup_skippable(
+    sp_owner_grant_ran: bool, schema_name: Optional[str]
+) -> None:
+    """Guard the fork-path skip of `_setup_database_schema`; raise if unsafe.
+
+    Skipping deploy-time schema setup on a fork is only safe when the app SP
+    actually owns the inherited schema. That holds only if BOTH:
+      * the owner-grant job ran and succeeded — `_trigger_owner_grant_job`
+        raises on failure, so a True flag here means the app SP is a member of
+        `tellr_app_owners` WITH INHERIT (owner rights on the inherited schema);
+      * the fork inherited a schema at all (copy-on-write from `branch_from_env`).
+
+    The `tellr_app_owners` *ownership* of the inherited schema/tables cannot be
+    re-checked here without a human Postgres connection — the very thing the
+    skip removes — so it is guaranteed by construction: the branching preflight
+    (`_check_branching_preconditions`) requires the source env to be deployed,
+    and the fork is a copy-on-write branch of it. This guard enforces the parts
+    that ARE checkable SP-only, and fails loudly rather than shipping an app
+    that would lack schema ownership (or a schema) at runtime.
+    """
+    if not sp_owner_grant_ran:
+        raise DeploymentError(
+            "cannot skip deploy-time schema setup on the fork: the app SP was "
+            "not granted into tellr_app_owners (missing app SP client id or "
+            "owner_grant_job_id). Refusing to deploy an app that would lack "
+            "schema ownership at runtime."
+        )
+    if not schema_name:
+        raise DeploymentError(
+            "cannot skip deploy-time schema setup on the fork: no schema was "
+            "inherited from the source env (empty schema_name) — check the "
+            "branch_from env's lakebase.schema."
+        )
+
+
 def create_local(
     env: str,
     profile: str,
@@ -457,6 +492,7 @@ def create_local(
         print()
 
         # Register SP role on the target branch (staging branch or production branch)
+        sp_owner_grant_ran = False
         if lakebase_type == "autoscaling":
             client_id = _get_app_client_id(app)
             if client_id:
@@ -476,6 +512,9 @@ def create_local(
                         ws, grant_job_id, client_id,
                         lakebase_result["host"], lakebase_result["endpoint_name"],
                     )
+                    # Grant job raises unless it succeeds, so reaching here means
+                    # the app SP now owns the inherited schema via tellr_app_owners.
+                    sp_owner_grant_ran = True
             else:
                 print("   Warning: Could not get SP client ID — role setup skipped")
 
@@ -499,7 +538,11 @@ def create_local(
         # "password authentication failed". The non-fork (local/prod) path
         # still needs it — the schema may not exist yet and the SP's grants
         # come from AppResourceDatabase — so only the fork path is skipped.
+        # The skip is gated on the owner-grant having actually run (see
+        # `_assert_fork_schema_setup_skippable`): if the SP was never granted
+        # into tellr_app_owners we fail loudly rather than ship a broken app.
         if branch_from_env:
+            _assert_fork_schema_setup_skippable(sp_owner_grant_ran, schema_name)
             print(
                 "Skipping deploy-time schema setup on fork "
                 "(SP owns inherited schema; app migrates on startup)"
@@ -599,6 +642,7 @@ def update_local(
             # Register SP role on the new staging branch.
             # (`app` was fetched above — reuse it; no need to re-GET.)
             client_id = _get_app_client_id(app)
+            sp_owner_grant_ran = False
             if client_id:
                 print("Configuring SP role on new branch...")
                 _ensure_sp_autoscaling_role(
@@ -614,6 +658,9 @@ def update_local(
                         ws, grant_job_id, client_id,
                         lakebase_result["host"], lakebase_result["endpoint_name"],
                     )
+                    # Grant job raises unless it succeeds — reaching here means
+                    # the app SP owns the inherited schema via tellr_app_owners.
+                    sp_owner_grant_ran = True
             else:
                 print(
                     "   Warning: Could not get SP client ID — role setup skipped"
@@ -625,6 +672,8 @@ def update_local(
             # inherited schema/tables, and the app migrates them at startup AS
             # the SP. Running it here would connect as the deploying human via
             # `_get_lakebase_connection`, breaking SP-only dev-loop deploys.
+            # Gated on the grant having run, same as create_local.
+            _assert_fork_schema_setup_skippable(sp_owner_grant_ran, schema_name)
             print(
                 "Skipping deploy-time schema setup on fork "
                 "(SP owns inherited schema; app migrates on startup)"

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -479,13 +479,38 @@ def create_local(
             else:
                 print("   Warning: Could not get SP client ID — role setup skipped")
 
-        # Set up database schema
-        print("Setting up database schema...")
-        _setup_database_schema(
-            ws, app, lakebase_name, schema_name,
-            lakebase_result=lakebase_result,
-        )
-        print(f"   Schema '{schema_name}' configured")
+        # Set up database schema.
+        #
+        # On the branching/fork path this step is skipped: it is redundant and
+        # is the ONLY step that requires the deploying human to hold a Postgres
+        # login role on the project, so skipping it keeps dev-loop deploys
+        # SP-only.
+        #   * The fork inherits the schema and tables copy-on-write from the
+        #     source env, owned by the shared `tellr_app_owners` role. The new
+        #     app SP was just granted into that role WITH INHERIT (see
+        #     `_trigger_owner_grant_job` above), so it already owns the
+        #     inherited schema/tables — the GRANTs here would be no-ops.
+        #   * The app (re)creates and migrates its own tables at startup AS the
+        #     app SP (`init_db()` in the FastAPI lifespan), so table setup does
+        #     not need to happen at deploy time.
+        # `_setup_database_schema` connects via `_get_lakebase_connection`,
+        # which authenticates as `ws.current_user.me()` (the deploying human);
+        # a deployer with no login role on the project would fail there with
+        # "password authentication failed". The non-fork (local/prod) path
+        # still needs it — the schema may not exist yet and the SP's grants
+        # come from AppResourceDatabase — so only the fork path is skipped.
+        if branch_from_env:
+            print(
+                "Skipping deploy-time schema setup on fork "
+                "(SP owns inherited schema; app migrates on startup)"
+            )
+        else:
+            print("Setting up database schema...")
+            _setup_database_schema(
+                ws, app, lakebase_name, schema_name,
+                lakebase_result=lakebase_result,
+            )
+            print(f"   Schema '{schema_name}' configured")
         print()
 
         # Deploy the app
@@ -594,13 +619,16 @@ def update_local(
                     "   Warning: Could not get SP client ID — role setup skipped"
                 )
 
-            # Grant schema perms on the new branch
-            print("Granting schema permissions on new branch...")
-            _setup_database_schema(
-                ws, app, lakebase_name, schema_name,
-                lakebase_result=lakebase_result,
+            # Schema setup is intentionally NOT run on the branch (see the
+            # detailed note in `create_local`): the SP was just granted into
+            # `tellr_app_owners` WITH INHERIT above, so it already owns the
+            # inherited schema/tables, and the app migrates them at startup AS
+            # the SP. Running it here would connect as the deploying human via
+            # `_get_lakebase_connection`, breaking SP-only dev-loop deploys.
+            print(
+                "Skipping deploy-time schema setup on fork "
+                "(SP owns inherited schema; app migrates on startup)"
             )
-            print(f"   Schema '{schema_name}' permissions configured")
         else:
             # Standard path (prod/dev): get current Lakebase state
             print("Checking Lakebase database...")

--- a/tests/unit/test_deploy_local_schema_setup_sp_only.py
+++ b/tests/unit/test_deploy_local_schema_setup_sp_only.py
@@ -1,0 +1,135 @@
+"""Regression tests: dev-loop (fork) deploys must be SP-only.
+
+`_setup_database_schema` / `_reset_schema` connect via `_get_lakebase_connection`,
+which authenticates as `ws.current_user.me()` (the deploying human). On the
+branching/fork path that step is redundant (the SP is granted into
+`tellr_app_owners` WITH INHERIT and the app migrates its own tables at startup),
+so it is skipped — otherwise a deployer without a personal Postgres login role
+fails with "password authentication failed". These tests pin that behaviour:
+the fork path must NOT call `_setup_database_schema`, while the non-fork
+(local/prod) path still must.
+"""
+from unittest.mock import MagicMock
+
+from scripts import deploy_local
+
+_BRANCH_CFG = {
+    "app_name": "db-tellr",
+    "description": "AI Slide Generator",
+    "workspace_path": "/Workspace/Users/x/.apps/devloop/tellr",
+    "compute_size": "MEDIUM",
+    "lakebase_name": "db-tellr",
+    "lakebase_capacity": "CU_1",
+    "schema_name": "app_data_prod",
+    "branch_from_env": "production",
+    "branch_from_workspace_path": "/Workspace/Users/x/.apps/prod/tellr",
+    "owner_grant_job_id": 724278545842460,
+}
+
+_NONBRANCH_CFG = {
+    "app_name": "db-tellr-prod",
+    "description": "AI Slide Generator",
+    "workspace_path": "/Workspace/Users/x/.apps/prod/tellr",
+    "compute_size": "LARGE",
+    "lakebase_name": "db-tellr",
+    "lakebase_capacity": "CU_1",
+    "schema_name": "app_data_prod",
+    "branch_from_env": None,
+    "branch_from_workspace_path": None,
+    "owner_grant_job_id": None,
+}
+
+_BRANCH_RESULT = {
+    "type": "autoscaling",
+    "name": "db-tellr",
+    "status": "READY",
+    "host": "h.example",
+    "endpoint_name": "ep",
+    "branch_id": "dev-spfix",
+}
+
+_NONBRANCH_RESULT = {
+    "type": "provisioned",
+    "name": "db-tellr",
+    "status": "READY",
+}
+
+
+def _patch_common(monkeypatch, cfg):
+    """Patch every side-effecting helper create_local/update_local call, and
+    return a spy standing in for `_setup_database_schema`."""
+    schema_spy = MagicMock(name="_setup_database_schema")
+
+    monkeypatch.setattr(deploy_local, "load_deployment_config", lambda env: dict(cfg))
+    monkeypatch.setattr(
+        deploy_local, "_get_workspace_client", lambda profile=None: MagicMock()
+    )
+    monkeypatch.setattr(
+        deploy_local, "_check_branching_preconditions", lambda ws, config: "enc-key"
+    )
+    monkeypatch.setattr(
+        deploy_local, "_recreate_ephemeral_branch",
+        lambda *a, **k: dict(_BRANCH_RESULT),
+    )
+    monkeypatch.setattr(
+        deploy_local, "_get_or_create_lakebase",
+        lambda *a, **k: dict(_NONBRANCH_RESULT),
+    )
+    monkeypatch.setattr(deploy_local, "_write_requirements", lambda *a, **k: None)
+    monkeypatch.setattr(
+        deploy_local, "_mlflow_substitutions_for_app_yaml", lambda **k: {}
+    )
+    monkeypatch.setattr(deploy_local, "_write_app_yaml", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_local, "_upload_files", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_local, "_create_app", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(deploy_local, "_get_app_client_id", lambda app: "sp-client-id")
+    monkeypatch.setattr(deploy_local, "_ensure_sp_autoscaling_role", lambda *a, **k: None)
+    # Defined in deploy_local itself; no-op so it doesn't touch ws.jobs.
+    monkeypatch.setattr(deploy_local, "_trigger_owner_grant_job", lambda *a, **k: None)
+    monkeypatch.setattr(
+        deploy_local, "_deploy_app", lambda *a, **k: MagicMock(url="https://app")
+    )
+    monkeypatch.setattr(deploy_local, "_setup_database_schema", schema_spy)
+    return schema_spy
+
+
+class TestCreateLocalSchemaSetup:
+    def test_fork_path_skips_schema_setup(self, monkeypatch):
+        """create_local on a branching env must NOT open the human-identity
+        schema-setup connection (SP-only)."""
+        schema_spy = _patch_common(monkeypatch, _BRANCH_CFG)
+
+        deploy_local.create_local(
+            env="devloop", profile="p", from_pypi="0.3.11.dev4", instance="spfix"
+        )
+
+        schema_spy.assert_not_called()
+
+    def test_nonfork_path_still_sets_up_schema(self, monkeypatch):
+        """The non-fork (local/prod) path must be unchanged — schema setup
+        still runs there."""
+        schema_spy = _patch_common(monkeypatch, _NONBRANCH_CFG)
+
+        deploy_local.create_local(
+            env="production", profile="p", from_pypi="0.3.11.dev4"
+        )
+
+        schema_spy.assert_called_once()
+
+
+class TestUpdateLocalSchemaSetup:
+    def test_fork_path_skips_schema_setup(self, monkeypatch):
+        """update_local on a branching env must NOT open the human-identity
+        schema-setup connection either."""
+        schema_spy = _patch_common(monkeypatch, _BRANCH_CFG)
+        # update_local's branching path GETs the app before re-forking.
+        mock_ws = MagicMock()
+        monkeypatch.setattr(
+            deploy_local, "_get_workspace_client", lambda profile=None: mock_ws
+        )
+
+        deploy_local.update_local(
+            env="devloop", profile="p", from_pypi="0.3.11.dev4", instance="spfix"
+        )
+
+        schema_spy.assert_not_called()

--- a/tests/unit/test_deploy_local_schema_setup_sp_only.py
+++ b/tests/unit/test_deploy_local_schema_setup_sp_only.py
@@ -6,10 +6,17 @@ branching/fork path that step is redundant (the SP is granted into
 `tellr_app_owners` WITH INHERIT and the app migrates its own tables at startup),
 so it is skipped — otherwise a deployer without a personal Postgres login role
 fails with "password authentication failed". These tests pin that behaviour:
-the fork path must NOT call `_setup_database_schema`, while the non-fork
-(local/prod) path still must.
+
+  * the fork path must NOT open a human-identity schema connection — neither
+    `_setup_database_schema` nor `_reset_schema`;
+  * the skip is gated on the owner-grant prerequisite: if the app SP was never
+    granted into `tellr_app_owners` (no client id / no owner_grant_job_id) the
+    deploy fails loudly instead of shipping an app that can't own its schema;
+  * the non-fork (local/prod) path is unchanged.
 """
 from unittest.mock import MagicMock
+
+import pytest
 
 from scripts import deploy_local
 
@@ -25,6 +32,10 @@ _BRANCH_CFG = {
     "branch_from_workspace_path": "/Workspace/Users/x/.apps/prod/tellr",
     "owner_grant_job_id": 724278545842460,
 }
+
+# Branching env whose config omits owner_grant_job_id — the owner-grant job
+# never runs, so skipping schema setup would be unsafe.
+_BRANCH_CFG_NO_GRANT_JOB = {**_BRANCH_CFG, "owner_grant_job_id": None}
 
 _NONBRANCH_CFG = {
     "app_name": "db-tellr-prod",
@@ -57,8 +68,10 @@ _NONBRANCH_RESULT = {
 
 def _patch_common(monkeypatch, cfg):
     """Patch every side-effecting helper create_local/update_local call, and
-    return a spy standing in for `_setup_database_schema`."""
-    schema_spy = MagicMock(name="_setup_database_schema")
+    return spies for the two functions that open a human-identity Postgres
+    connection (`_setup_database_schema`, `_reset_schema`)."""
+    setup_spy = MagicMock(name="_setup_database_schema")
+    reset_spy = MagicMock(name="_reset_schema")
 
     monkeypatch.setattr(deploy_local, "load_deployment_config", lambda env: dict(cfg))
     monkeypatch.setattr(
@@ -66,6 +79,9 @@ def _patch_common(monkeypatch, cfg):
     )
     monkeypatch.setattr(
         deploy_local, "_check_branching_preconditions", lambda ws, config: "enc-key"
+    )
+    monkeypatch.setattr(
+        deploy_local, "_read_existing_encryption_key", lambda *a, **k: "enc-key"
     )
     monkeypatch.setattr(
         deploy_local, "_recreate_ephemeral_branch",
@@ -84,44 +100,73 @@ def _patch_common(monkeypatch, cfg):
     monkeypatch.setattr(deploy_local, "_create_app", lambda *a, **k: MagicMock())
     monkeypatch.setattr(deploy_local, "_get_app_client_id", lambda app: "sp-client-id")
     monkeypatch.setattr(deploy_local, "_ensure_sp_autoscaling_role", lambda *a, **k: None)
-    # Defined in deploy_local itself; no-op so it doesn't touch ws.jobs.
+    # Defined in deploy_local itself; no-op so it doesn't touch ws.jobs. It
+    # raises on real failure, so a clean return models a successful grant.
     monkeypatch.setattr(deploy_local, "_trigger_owner_grant_job", lambda *a, **k: None)
     monkeypatch.setattr(
         deploy_local, "_deploy_app", lambda *a, **k: MagicMock(url="https://app")
     )
-    monkeypatch.setattr(deploy_local, "_setup_database_schema", schema_spy)
-    return schema_spy
+    monkeypatch.setattr(deploy_local, "_setup_database_schema", setup_spy)
+    monkeypatch.setattr(deploy_local, "_reset_schema", reset_spy)
+    return {"setup": setup_spy, "reset": reset_spy}
 
 
 class TestCreateLocalSchemaSetup:
     def test_fork_path_skips_schema_setup(self, monkeypatch):
         """create_local on a branching env must NOT open the human-identity
-        schema-setup connection (SP-only)."""
-        schema_spy = _patch_common(monkeypatch, _BRANCH_CFG)
+        schema connection — neither _setup_database_schema nor _reset_schema."""
+        spies = _patch_common(monkeypatch, _BRANCH_CFG)
 
         deploy_local.create_local(
             env="devloop", profile="p", from_pypi="0.3.11.dev4", instance="spfix"
         )
 
-        schema_spy.assert_not_called()
+        spies["setup"].assert_not_called()
+        spies["reset"].assert_not_called()
 
     def test_nonfork_path_still_sets_up_schema(self, monkeypatch):
         """The non-fork (local/prod) path must be unchanged — schema setup
         still runs there."""
-        schema_spy = _patch_common(monkeypatch, _NONBRANCH_CFG)
+        spies = _patch_common(monkeypatch, _NONBRANCH_CFG)
 
         deploy_local.create_local(
             env="production", profile="p", from_pypi="0.3.11.dev4"
         )
 
-        schema_spy.assert_called_once()
+        spies["setup"].assert_called_once()
+
+    def test_fork_fails_loudly_when_sp_client_id_missing(self, monkeypatch):
+        """If the app SP can't be resolved the owner-grant never runs, so the
+        SP does not own the inherited schema — the deploy must fail loudly, not
+        silently skip schema setup."""
+        spies = _patch_common(monkeypatch, _BRANCH_CFG)
+        monkeypatch.setattr(deploy_local, "_get_app_client_id", lambda app: None)
+
+        with pytest.raises(deploy_local.DeploymentError, match="tellr_app_owners"):
+            deploy_local.create_local(
+                env="devloop", profile="p", from_pypi="0.3.11.dev4", instance="spfix"
+            )
+
+        spies["setup"].assert_not_called()
+
+    def test_fork_fails_loudly_when_owner_grant_job_id_missing(self, monkeypatch):
+        """If owner_grant_job_id is unset the grant job never runs, so the skip
+        is unsafe and the deploy must fail loudly."""
+        spies = _patch_common(monkeypatch, _BRANCH_CFG_NO_GRANT_JOB)
+
+        with pytest.raises(deploy_local.DeploymentError, match="tellr_app_owners"):
+            deploy_local.create_local(
+                env="devloop", profile="p", from_pypi="0.3.11.dev4", instance="spfix"
+            )
+
+        spies["setup"].assert_not_called()
 
 
 class TestUpdateLocalSchemaSetup:
     def test_fork_path_skips_schema_setup(self, monkeypatch):
         """update_local on a branching env must NOT open the human-identity
-        schema-setup connection either."""
-        schema_spy = _patch_common(monkeypatch, _BRANCH_CFG)
+        schema connection either."""
+        spies = _patch_common(monkeypatch, _BRANCH_CFG)
         # update_local's branching path GETs the app before re-forking.
         mock_ws = MagicMock()
         monkeypatch.setattr(
@@ -132,4 +177,39 @@ class TestUpdateLocalSchemaSetup:
             env="devloop", profile="p", from_pypi="0.3.11.dev4", instance="spfix"
         )
 
-        schema_spy.assert_not_called()
+        spies["setup"].assert_not_called()
+        spies["reset"].assert_not_called()
+
+    def test_fork_fails_loudly_when_sp_client_id_missing(self, monkeypatch):
+        """Same fail-loud guard as create_local, on the update fork path."""
+        spies = _patch_common(monkeypatch, _BRANCH_CFG)
+        mock_ws = MagicMock()
+        monkeypatch.setattr(
+            deploy_local, "_get_workspace_client", lambda profile=None: mock_ws
+        )
+        monkeypatch.setattr(deploy_local, "_get_app_client_id", lambda app: None)
+
+        with pytest.raises(deploy_local.DeploymentError, match="tellr_app_owners"):
+            deploy_local.update_local(
+                env="devloop", profile="p", from_pypi="0.3.11.dev4", instance="spfix"
+            )
+
+        spies["setup"].assert_not_called()
+
+    def test_nonfork_path_does_not_call_schema_setup(self, monkeypatch):
+        """update_local's non-fork path never calls _setup_database_schema:
+        update assumes create already set the schema up and only re-deploys the
+        wheel (_reset_schema runs only under --reset-db). This pins that
+        pre-existing behaviour so the fork-path fix didn't shift it."""
+        spies = _patch_common(monkeypatch, _NONBRANCH_CFG)
+        mock_ws = MagicMock()
+        monkeypatch.setattr(
+            deploy_local, "_get_workspace_client", lambda profile=None: mock_ws
+        )
+
+        deploy_local.update_local(
+            env="production", profile="p", from_pypi="0.3.11.dev4"
+        )
+
+        spies["setup"].assert_not_called()
+        spies["reset"].assert_not_called()  # reset_database defaults False


### PR DESCRIPTION
## Summary

Makes the devloop (branching) deploy tooling **truly SP-only**: a user with **no personal Postgres login role** on the target Lakebase project can now run `./scripts/deploy_local.sh create --env devloop` end-to-end. Previously this failed at schema-setup with `password authentication failed`, even though every other step is already SP-only.

## Root cause

`create_local` runs: recreate ephemeral branch → create app → `_ensure_sp_autoscaling_role` → `_trigger_owner_grant_job` (grants the app SP into `tellr_app_owners` **WITH INHERIT** — succeeds) → **`_setup_database_schema`**. That last step connects via `_get_lakebase_connection`, which authenticates as the deploying **human** (`ws.current_user.me()`, `deploy.py:1525` → `psycopg2.connect(user=user, ...)`). The SP / group membership is never used for this connection, so a deployer without a personal login role fails here — the only non-SP-only step on the fork path. (Evidence pattern: the owner-grant job **succeeds**, then the human connect **fails**.)

## The fix

Skip `_setup_database_schema` on the fork/branching path in both `create_local` and `update_local`. On a fork this step is redundant:
- schema + tables are inherited **copy-on-write** from the source env, owned by `tellr_app_owners`;
- the app SP was just granted into `tellr_app_owners` **WITH INHERIT**, so it already owns them (the `GRANT`s are no-ops);
- the app **migrates its own tables at startup as the SP** (`init_db()` in the FastAPI lifespan: `SET search_path` + `create_all()` + `_run_migrations()`; it does **not** `CREATE SCHEMA` — the schema already exists on a fork).

**The skip is guarded (fail-loud), not blind.** A new `_assert_fork_schema_setup_skippable(sp_owner_grant_ran, schema_name)` raises `DeploymentError` unless the owner-grant job actually ran **and succeeded** (`sp_owner_grant_ran` is set true only after `_trigger_owner_grant_job` returns) **and** a schema name is present. So if the SP grant didn't happen, the deploy aborts loudly at deploy time rather than shipping an app that fails at runtime. The **non-fork (local/prod) path is unchanged** — it still runs `_setup_database_schema`.

**Why skip, not route-through-SP.** Routing this connection through the app SP was considered and rejected as infeasible here: `deploy.py` cannot mint the SP's token (`generate_database_credential` is caller-scoped, deploy runs as the human, and there is no app-SP client_secret/OBO in the codebase), so it would require building a whole new `run_as=SP` job to do work that is redundant on a fork anyway. Skipping the redundant step is simpler and safer.

## Validation (real deploy on `db-tellr`, as a deployer with **no** login role)

`deploy_local.sh create --env devloop --instance <id> --from-pypi 0.3.11.dev4` on the default `db-tellr` prod fork, as a user with no Postgres login role:
- cleared schema-setup **SP-only** — `SP granted into shared owning role` → `Skipping deploy-time schema setup on fork (...)` → `Deploying app...`, with **no `password authentication failed`**;
- the **app booted** (`Application startup complete`) and the app's own startup migration ran successfully (`Migration: design_system tables` → `reassigning new objects to shared owner tellr_app_owners`);
- teardown confirmed clean; the `production` branch + `app_data_prod` are untouched (copy-on-write fork, never written via a human connection).

**Cross-vendor review:** independently reviewed by a second vendor (GPT/codex) — **APPROVE**, no blocking issues, after the hardening below.

## Tests

`tests/unit/test_deploy_local_schema_setup_sp_only.py`:
- fork path (create **and** update) asserts **neither** `_setup_database_schema` **nor** `_reset_schema` is called (proves no human-identity connection on the fork path);
- fail-loud guard tests: the fork path raises when the app SP client id is missing, and when `owner_grant_job_id` is missing (both `create_local` and `update_local`);
- non-fork `create_local` still calls `_setup_database_schema`; `update_local`'s non-fork path is pinned as **not** calling it (it never did — `update` assumes `create` already set the schema up).

Full `tests/unit/test_deploy_local_*` suite passes; changed files are ruff-clean (no net-new violations).
