### PR TITLE
chore: bump version to 0.3.12

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.3.11"
+version = "0.3.12"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.3.11"
+version = "0.3.12"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `databricks-tellr` and `databricks-tellr-app` from 0.3.11 to 0.3.12 so the next release picks up the chat-input length cap removal (#216).

This pull request and its description were written by Isaac.