### PR TITLE
SDR-4437 PR-1a: App-origin security headers + CSP (CRITICAL-1)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -417,6 +417,21 @@ from src.api.middleware.request_logging import RequestLoggingMiddleware
 
 app.add_middleware(RequestLoggingMiddleware)
 
+# === SDR-4437 Track A security middleware (PR-1a/PR-1b) ==================
+# Keep ALL security-middleware registration inside this delimited block
+# (PR-2 adds an exception handler below the middleware block — do not edit
+# outside these markers). Starlette wraps later-added middleware outermost;
+# ordering here is deliberate:
+#   SecurityHeaders (outermost, added last) -> CSRF -> RequestLogging ->
+#   user_auth -> CORS(dev) -> normalize_mcp_path -> routes
+# Headers must stamp EVERY response (including CSRF 403s); CSRF must reject
+# forged cross-site requests before OBO auth work and before request_logs
+# DB writes.
+from src.api.middleware.security_headers import SecurityHeadersMiddleware  # noqa: E402
+
+app.add_middleware(SecurityHeadersMiddleware)
+# === end SDR-4437 Track A security middleware =============================
+
 # Include API routers
 app.include_router(admin.router)
 app.include_router(admin_usage.router)

--- a/src/api/middleware/security_headers.py
+++ b/src/api/middleware/security_headers.py
@@ -1,0 +1,97 @@
+"""App-origin security headers (SDR-4437 CRITICAL-1, PR-1a).
+
+Sets browser hardening headers on every response that flows back through
+the middleware stack (known limit: raw 500s from genuinely unhandled
+exceptions are synthesized by Starlette's ``ServerErrorMiddleware``
+outside all user middleware and are NOT stamped; those bodies are
+``text/plain`` and non-executable), plus a
+Content-Security-Policy differentiated by response type:
+
+- HTML documents (the SPA index/catch-all AND the Google OAuth callback
+  popup, which carries inline <script>) get ``DOCUMENT_CSP``. Two
+  constraints rule out a strict policy here:
+
+  1. srcdoc inheritance: slides render in ``srcdoc`` iframes, and srcdoc
+     documents inherit the embedding document's CSP in addition to their
+     own SLIDE_CSP meta tag (both policies enforce; most restrictive
+     wins). A ``default-src 'self'`` header on the SPA would block every
+     slide's inline <script>, Chart.js/Tailwind CDN loads, and Google
+     Fonts — breaking slide rendering app-wide. The document policy must
+     therefore be a superset of SLIDE_CSP's allowances
+     (``src/utils/html_safety.py``; sync-tested in
+     ``tests/unit/test_export_csp.py``).
+  2. Inline styles: the React app uses ``style={{...}}`` attributes and
+     Radix UI injects inline styles at runtime; CSP hashes apply to
+     <style>/<script> *elements*, not style *attributes*, so
+     ``style-src`` needs 'unsafe-inline'.
+
+  ``script-src 'unsafe-inline'`` + CDNs is a deliberate, documented
+  trade-off forced by srcdoc inheritance: slides remain confined by the
+  stricter SLIDE_CSP meta policy (connect-src 'none', form-action
+  'none', no eval) plus the html_safety.py scanner, and any header at
+  all is a strict improvement over the previous no-CSP state.
+
+- Everything else (JSON APIs, assets, SSE) gets the deny-all
+  ``API_CSP`` — nothing executes in a JSON response.
+
+``frame-ancestors 'none'`` / ``X-Frame-Options: DENY`` is safe: all
+in-app slide iframes use ``srcdoc`` (never a backend-served ``src``), and
+the only other HTML endpoint, the Google OAuth callback, opens as a
+popup, not an iframe.
+
+``frame-src 'self'`` does not affect the srcdoc slide iframes: a srcdoc
+document loads no URL (its address is the local scheme ``about:srcdoc``,
+no fetch occurs), and per CSP3 local-scheme handling plus current
+Chrome/Firefox/Safari behavior it is NOT subject to frame-src source
+matching — even ``frame-src 'none'`` pages can create srcdoc iframes.
+Instead it inherits this document policy, which is exactly the
+srcdoc-inheritance constraint handled above. Pre-decided fallback if a
+browser ever refuses the slide iframe with a frame-src violation
+("Refused to frame ..."): ``frame-src 'self' about:`` — the ``about:``
+scheme-source matches ``about:srcdoc`` (the historical workaround for
+old-Chrome behavior that did URL-match about: frames).
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# CSP for HTML document responses: union of SPA needs and SLIDE_CSP
+# allowances (kept a superset of SLIDE_CSP by test_export_csp.py).
+DOCUMENT_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "img-src 'self' data:; "
+    "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; "
+    "connect-src 'self'; "
+    "frame-src 'self'; "
+    "frame-ancestors 'none'; "
+    "object-src 'none'; "
+    "base-uri 'none'"
+)
+
+# CSP for everything else.
+API_CSP = "default-src 'none'; frame-ancestors 'none'"
+
+_STATIC_HEADERS = {
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "same-origin",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+}
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Stamp security headers on every response (registered outermost)."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        for name, value in _STATIC_HEADERS.items():
+            response.headers[name] = value
+        content_type = response.headers.get("content-type", "")
+        if content_type.startswith("text/html"):
+            response.headers["Content-Security-Policy"] = DOCUMENT_CSP
+        else:
+            response.headers["Content-Security-Policy"] = API_CSP
+        return response

--- a/tests/unit/test_export_csp.py
+++ b/tests/unit/test_export_csp.py
@@ -83,3 +83,28 @@ def test_allowlisted_external_script_is_not_flagged(caplog):
     with caplog.at_level(logging.WARNING):
         build_slide_html(slide, deck)
     assert not any("Unsafe patterns" in r.message for r in caplog.records)
+
+
+def _csp_directives(policy: str) -> dict[str, set[str]]:
+    out = {}
+    for directive in policy.split(";"):
+        directive = directive.strip()
+        if not directive:
+            continue
+        name, *sources = directive.split()
+        out[name] = set(sources)
+    return out
+
+
+def test_document_csp_header_is_superset_of_slide_csp():
+    # SDR-4437 PR-1a: srcdoc iframes inherit the embedding document's CSP in
+    # addition to the SLIDE_CSP meta tag (both enforce; most restrictive
+    # wins). Every fetch source SLIDE_CSP grants must therefore also be
+    # granted by the document CSP header, or slide rendering breaks app-wide.
+    from src.api.middleware.security_headers import DOCUMENT_CSP
+
+    slide = _csp_directives(SLIDE_CSP)
+    doc = _csp_directives(DOCUMENT_CSP)
+    for directive in ("script-src", "style-src", "img-src", "font-src"):
+        missing = slide[directive] - doc[directive]
+        assert not missing, f"{directive}: document CSP header missing {missing}"

--- a/tests/unit/test_security_headers.py
+++ b/tests/unit/test_security_headers.py
@@ -69,3 +69,13 @@ def test_document_csp_hardening_directives():
 
 def test_api_csp_is_deny_all():
     assert API_CSP == "default-src 'none'; frame-ancestors 'none'"
+
+
+def test_main_app_registers_security_headers():
+    # Registration check against the real app (ENVIRONMENT=test via conftest;
+    # the SPA is only mounted in production's lifespan, so use an API route).
+    from src.api.main import app as main_app
+
+    r = TestClient(main_app).get("/api/health")
+    assert r.headers["Content-Security-Policy"] == API_CSP
+    assert r.headers["X-Frame-Options"] == "DENY"

--- a/tests/unit/test_security_headers.py
+++ b/tests/unit/test_security_headers.py
@@ -1,0 +1,71 @@
+"""SDR-4437 CRITICAL-1: every response carries app-origin security headers,
+with the document CSP on HTML responses and the strict CSP on everything else.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.responses import HTMLResponse
+
+from src.api.middleware.security_headers import (
+    API_CSP,
+    DOCUMENT_CSP,
+    SecurityHeadersMiddleware,
+)
+
+EXPECTED_STATIC = {
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "same-origin",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+}
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/api/thing")
+    async def api_thing():
+        return {"ok": True}
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index():
+        return "<html><body>spa</body></html>"
+
+    return TestClient(app)
+
+
+def test_api_response_carries_headers_and_strict_csp(client):
+    r = client.get("/api/thing")
+    for name, value in EXPECTED_STATIC.items():
+        assert r.headers[name] == value
+    assert r.headers["Content-Security-Policy"] == API_CSP
+
+
+def test_html_response_carries_document_csp(client):
+    r = client.get("/")
+    for name, value in EXPECTED_STATIC.items():
+        assert r.headers[name] == value
+    assert r.headers["Content-Security-Policy"] == DOCUMENT_CSP
+
+
+def test_error_response_carries_headers(client):
+    r = client.get("/does-not-exist")
+    assert r.status_code == 404
+    assert r.headers["Content-Security-Policy"] == API_CSP
+    assert r.headers["X-Frame-Options"] == "DENY"
+
+
+def test_document_csp_hardening_directives():
+    # The document policy must still deny framing, plugins, and <base> rewrites,
+    # and must not grant eval.
+    assert "frame-ancestors 'none'" in DOCUMENT_CSP
+    assert "object-src 'none'" in DOCUMENT_CSP
+    assert "base-uri 'none'" in DOCUMENT_CSP
+    assert "unsafe-eval" not in DOCUMENT_CSP
+
+
+def test_api_csp_is_deny_all():
+    assert API_CSP == "default-src 'none'; frame-ancestors 'none'"


### PR DESCRIPTION
## SDR-4437 CRITICAL-1 — Security headers / CSP

Adds `SecurityHeadersMiddleware`: every response now carries security headers, with a content-type-aware CSP (strict `default-src 'none'` for API/JSON, a document CSP for HTML that permits the slide-render and OAuth-callback inline scripts). A regression test asserts DOCUMENT_CSP is a superset of the existing `SLIDE_CSP`.

Split from PR-1b (CSRF) so the CSP change — the one piece with rendering blast radius — can be reverted independently.

**Tests:** full backend suite green (1314 passed); TDD red-steps verified per task.
**Deployed & verified:** devloop instance `sdr4437-pr1` (`0.3.13.dev2`) — headers present on SPA + API, slides render under the new CSP, OAuth popup completes.

Baseline: `main@7c50339`.

This pull request and its description were written by Isaac.