### PR TITLE
fix: version-check the per-worker deck cache against the database

### DIFF
--- a/.claude/skills/tellr-code-review/SKILL.md
+++ b/.claude/skills/tellr-code-review/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: tellr-code-review
+description: Tellr-specific code-review checklist capturing tribal knowledge — recurring bug classes and fragile subsystems a reviewer should actively check. Load when reviewing a Tellr diff/PR, or when asked to review Tellr changes. Currently covers (1) multi-worker in-process state coherence and (2) the huashu PPTX-export bundling chain.
+---
+
+# Tellr code-review checklist (tribal knowledge)
+
+These are Tellr-specific things that generic review misses. They are not
+style rules — each one is a class of bug that has actually shipped and hurt.
+When reviewing a diff, check whether it touches any of these areas and, if
+so, apply the corresponding check. If a diff touches none of them, this skill
+adds nothing — don't force it.
+
+---
+
+## 1. Multi-worker in-process state must be coherent with the database
+
+**Why this exists.** Prod runs `uvicorn` with multiple worker *processes*
+(`UVICORN_WORKERS`, default 4 — see
+`packages/databricks-tellr-app/databricks_tellr_app/run.py`). Each worker is a
+separate OS process with **separate memory**. Anything stored in a Python
+attribute/dict/global lives in *one* worker only; the other workers never see
+it. Requests are load-balanced across workers, so successive requests in the
+same session routinely hit different workers.
+
+**The recurring bug.** State cached in process memory goes stale on every
+worker except the one that last wrote it. This has shipped repeatedly:
+- `ChatService._deck_cache` served stale decks → reorder returned
+  `400 Invalid reorder: wrong number of indices`, deleted slides reappeared
+  after an LLM edit, and inserts landed at the wrong index. Fixed by
+  version-checking the cache against the DB (`_get_or_load_deck` +
+  `SessionManager.get_slide_deck_version`).
+- Session locks — fixed earlier by moving them to the **database**
+  (`session_manager.py` acquire_session_lock is DB-backed "to work across
+  multiple uvicorn workers").
+- MCP — fixed by running **stateless** ("survive multi-worker routing").
+
+**The rule.** Any state shared *across requests* must either live somewhere
+all workers can see (the database) or be a cache that can **detect its own
+staleness**. In-process memory that is written by one request and read by a
+later request, with no freshness check, is a bug under multiple workers.
+
+**What to flag in review.** Raise a concern when a diff:
+- adds or mutates a process-lifetime container on a service/singleton
+  (`self._something = {}` / module-level dict/set/list) that holds
+  per-session or per-deck state across requests;
+- reads such a cache on a mutation path without validating it against the DB
+  (e.g. a bare cache-hit return with no version/timestamp comparison);
+- introduces a new "read cache → mutate → write back to DB" flow. Writing a
+  stale cached object back to the DB is how deleted data resurrects.
+- assumes a value written during one request will be visible to a later
+  request in the same session (it won't, unless it round-trips the DB).
+
+Cache-as-cache (rebuildable from the DB, validated on hit) is fine. Cache-as-
+source-of-truth is not. When unsure, ask: "if request A hits worker 1 and
+request B hits worker 2, do they still agree?" If the diff can't answer yes,
+flag it.
+
+**Guard pattern.** New cross-request caches should have a coherence test in
+the style of `tests/unit/test_multiworker_cache_coherence.py`: two service
+instances sharing one store, mutate via A, assert B's view matches the store.
+
+---
+
+## 2. The huashu PPTX-export bundling chain must not be silently broken
+
+**Why this exists.** The HTML→PPTX export ("huashu", from
+`alchaincyf/huashu-design`'s `html2pptx.js`) lives in
+`services/pptx-emit-huashu/` and runs Playwright/Chromium. That can't be built
+in CI (npm's "Exit handler never called!" bug) or shipped uncompressed (size
+limits), so the pipeline depends on a fragile, easy-to-break bundling chain:
+
+1. **Pre-built tarballs committed to git**:
+   `services/pptx-emit-huashu/node_modules.tar.gz` (~12 MB) and
+   `sys-libs-bullseye.tar.gz` (~18 MB). These are committed on purpose, *not*
+   built in CI. Regen instructions live in the header comment of
+   `services/pptx-emit-huashu/build-artifacts.sh`.
+2. **Verify step** (`build-artifacts.sh`) runs in `publish.yml` /
+   `publish-dev.yml` before `python -m build`: checks the tarballs exist, are
+   >1 MB (not truncated/dir-only), and contain `playwright*/cli.js`.
+3. **setup.py copies the sidecar into the wheel** at
+   `databricks_tellr_app/_assets/sidecars/pptx-emit-huashu/`, but **only when
+   `TELLR_INCLUDE_HUASHU_SIDECAR=1`** (the deployed-app path via CI; local
+   `deploy_local` deliberately omits it because the tarballs exceed Apps
+   workspace file limits).
+4. **CI post-build verify**: the publish workflows assert the built wheel is
+   ≥25 MB and contains the huashu tarballs, failing the release otherwise.
+5. **`.databricksignore`** excludes the bulky uncompressed
+   `services/pptx-emit-huashu/node_modules/` and `playwright-browsers/` from
+   `deploy_local` uploads.
+
+**What to flag in review.** Raise a concern when a diff touches any link in
+this chain in a way that could break it silently:
+- edits `services/pptx-emit-huashu/package.json` (Playwright/pptxgenjs
+  version bumps) **without** regenerating and committing fresh
+  `node_modules.tar.gz` / `sys-libs-bullseye.tar.gz`. A version bump with
+  stale tarballs ships a mismatched pipeline.
+- weakens or removes the `build-artifacts.sh` verification, the
+  `TELLR_INCLUDE_HUASHU_SIDECAR` gate, the setup.py copy step, or the CI
+  wheel-size / tarball-presence assertion (the ≥25 MB check exists to catch a
+  wheel built without the sidecar).
+- changes `.databricksignore` or setup.py `_SIDECAR_IGNORE` such that the
+  uncompressed trees start getting uploaded (blows Apps file limits) or the
+  tarballs stop being included (breaks deployed export).
+- moves/renames `services/pptx-emit-huashu/` files without updating the
+  references in `setup.py`, the publish workflows, and `.databricksignore`.
+
+**Rule of thumb.** If a change touches `services/pptx-emit-huashu/` or the
+packaging around it, confirm the whole chain still holds: committed tarballs
+match `package.json`, the verify + include gates are intact, and CI would
+still fail on a sidecar-less wheel. When in doubt, check whether the tarballs
+were regenerated alongside a dependency bump.

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -2031,23 +2031,18 @@ class ChatService:
     def _get_deck_version(self, session_id: str) -> Optional[int]:
         """Read the current deck version from the database.
 
-        Called once before the LLM runs to capture the version for
-        optimistic locking. Uses the existing get_slide_deck which
-        returns the full deck dict including the version column.
-
-        On Lakebase/PostgreSQL this is a single-row indexed lookup (~1-2ms).
+        Used on every deck-cache hit (multi-worker cache validation) and
+        before LLM calls (optimistic locking), so it must stay cheap: a
+        single-column indexed lookup, never a full deck fetch.
 
         Returns:
             Current deck version number, or None if no deck exists.
         """
         session_manager = get_session_manager()
         try:
-            deck_data = session_manager.get_slide_deck(session_id)
-            if deck_data:
-                return deck_data.get("version")
+            return session_manager.get_slide_deck_version(session_id)
         except Exception:
-            pass
-        return None
+            return None
 
     @staticmethod
     def _reindex_slide_ids(deck: "SlideDeck") -> None:

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -80,6 +80,11 @@ class ChatService:
         # This avoids re-parsing HTML on every request
         self._deck_cache: Dict[str, SlideDeck] = {}
 
+        # DB version each cached deck corresponds to. The cache is per-process
+        # while prod runs multiple uvicorn workers sharing one database, so a
+        # cache hit is only valid if the DB version hasn't moved on.
+        self._deck_cache_versions: Dict[str, int] = {}
+
         logger.info("ChatService initialized successfully")
 
     def _substitute_images_for_response(self, deck_dict, raw_html=None):
@@ -600,7 +605,7 @@ class ChatService:
                     slide_deck_dict = current_deck.to_dict()
 
                 try:
-                    session_manager.save_slide_deck(
+                    save_result = session_manager.save_slide_deck(
                         session_id=session_id,
                         title=current_deck.title,
                         html_content=current_deck.knit(),
@@ -610,6 +615,7 @@ class ChatService:
                         modified_by=_user,
                         expected_version=_deck_version_before_llm,
                     )
+                    self._record_deck_version(session_id, save_result)
                 except VersionConflictError:
                     logger.warning(
                         "Chat save rejected: deck was edited during LLM call, reloading",
@@ -1385,7 +1391,7 @@ class ChatService:
                 slide_deck_dict = current_deck.to_dict()
 
             try:
-                session_manager.save_slide_deck(
+                save_result = session_manager.save_slide_deck(
                     session_id=session_id,
                     title=current_deck.title,
                     html_content=current_deck.knit(),
@@ -1395,6 +1401,7 @@ class ChatService:
                     modified_by=_user,
                     expected_version=_deck_version_before_llm,
                 )
+                self._record_deck_version(session_id, save_result)
             except VersionConflictError:
                 logger.warning(
                     "Chat save rejected: deck was edited during LLM call, reloading",
@@ -1921,18 +1928,63 @@ class ChatService:
         context = "\n\n[Attached images]\n" + "\n".join(image_descriptions)
         return message + context
 
+    def _deck_versions(self) -> Dict[str, int]:
+        """Return the cached-deck version map, creating it if needed.
+
+        Lazy creation keeps instances built without __init__ (test harnesses
+        use ChatService.__new__) working. Callers must hold _cache_lock.
+        """
+        try:
+            return self._deck_cache_versions
+        except AttributeError:
+            self._deck_cache_versions = {}
+            return self._deck_cache_versions
+
+    def _record_deck_version(self, session_id: str, save_result: Optional[Dict[str, Any]]) -> None:
+        """Remember which DB version the cached deck now corresponds to.
+
+        Call after save_slide_deck so the next _get_or_load_deck cache hit
+        validates cleanly instead of reloading from the database.
+        """
+        version = (save_result or {}).get("version")
+        with self._cache_lock:
+            if version is not None:
+                self._deck_versions()[session_id] = version
+            else:
+                self._deck_versions().pop(session_id, None)
+
     def _get_or_load_deck(self, session_id: str) -> Optional[SlideDeck]:
         """Get deck from cache or load from database.
 
         Thread-safe access to deck cache using _cache_lock.
-        
+
+        The cache is per-process while prod runs multiple uvicorn workers
+        sharing one database, so a cached deck is only served if its recorded
+        version matches the current DB version; otherwise it is reloaded.
+
         Uses deck_dict (slides array with individual scripts) when available,
         falling back to from_html_string for legacy data.
         """
         # Check cache first (with lock)
         with self._cache_lock:
-            if session_id in self._deck_cache:
-                return self._deck_cache[session_id]
+            cached_deck = self._deck_cache.get(session_id)
+            cached_version = self._deck_versions().get(session_id)
+
+        if cached_deck is not None:
+            db_version = self._get_deck_version(session_id)
+            if db_version is None or cached_version == db_version:
+                return cached_deck
+            logger.info(
+                "Deck cache stale, reloading from database",
+                extra={
+                    "session_id": session_id,
+                    "cached_version": cached_version,
+                    "db_version": db_version,
+                },
+            )
+            with self._cache_lock:
+                self._deck_cache.pop(session_id, None)
+                self._deck_versions().pop(session_id, None)
 
         # Try to load from database (outside lock to avoid blocking)
         session_manager = get_session_manager()
@@ -1966,6 +2018,10 @@ class ChatService:
             # Store in cache (with lock)
             with self._cache_lock:
                 self._deck_cache[session_id] = deck
+                if deck_data.get("version") is not None:
+                    self._deck_versions()[session_id] = deck_data["version"]
+                else:
+                    self._deck_versions().pop(session_id, None)
             return deck
         except Exception as e:
             logger.warning(f"Failed to load deck from database: {e}")
@@ -2008,6 +2064,7 @@ class ChatService:
         """Remove the cached deck for a session so the next read hits the DB."""
         with self._cache_lock:
             self._deck_cache.pop(session_id, None)
+            self._deck_versions().pop(session_id, None)
 
     def _replace_slide_htmls_from_cache(self, session_id: str, slide_context: Dict[str, Any]) -> Dict[str, Any]:
         """Replace frontend-supplied slide_htmls with backend cache versions.
@@ -2540,7 +2597,7 @@ class ChatService:
         # Persist to database
         deck_dict = current_deck.to_dict()
         session_manager = get_session_manager()
-        session_manager.save_slide_deck(
+        save_result = session_manager.save_slide_deck(
             session_id=session_id,
             title=current_deck.title,
             html_content=current_deck.knit(),
@@ -2549,6 +2606,7 @@ class ChatService:
             deck_dict=deck_dict,
             expected_version=expected_version,
         )
+        self._record_deck_version(session_id, save_result)
 
         # Create save point
         try:
@@ -2616,7 +2674,7 @@ class ChatService:
         # Persist to database
         deck_dict = current_deck.to_dict()
         session_manager = get_session_manager()
-        session_manager.save_slide_deck(
+        save_result = session_manager.save_slide_deck(
             session_id=session_id,
             title=current_deck.title,
             html_content=current_deck.knit(),
@@ -2625,6 +2683,7 @@ class ChatService:
             deck_dict=deck_dict,
             expected_version=expected_version,
         )
+        self._record_deck_version(session_id, save_result)
 
         # Create save point immediately after persisting
         try:
@@ -2681,7 +2740,7 @@ class ChatService:
         # Persist to database
         deck_dict = current_deck.to_dict()
         session_manager = get_session_manager()
-        session_manager.save_slide_deck(
+        save_result = session_manager.save_slide_deck(
             session_id=session_id,
             title=current_deck.title,
             html_content=current_deck.knit(),
@@ -2690,6 +2749,7 @@ class ChatService:
             deck_dict=deck_dict,
             expected_version=expected_version,
         )
+        self._record_deck_version(session_id, save_result)
 
         # Create save point
         try:
@@ -2744,7 +2804,7 @@ class ChatService:
         # Persist to database
         deck_dict = current_deck.to_dict()
         session_manager = get_session_manager()
-        session_manager.save_slide_deck(
+        save_result = session_manager.save_slide_deck(
             session_id=session_id,
             title=current_deck.title,
             html_content=current_deck.knit(),
@@ -2753,6 +2813,7 @@ class ChatService:
             deck_dict=deck_dict,
             expected_version=expected_version,
         )
+        self._record_deck_version(session_id, save_result)
 
         # Create save point
         try:

--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -723,6 +723,33 @@ class SessionManager:
                 "version": deck.version,
             }
 
+    def get_slide_deck_version(self, session_id: str) -> Optional[int]:
+        """Return only the deck's current version number.
+
+        Selects a single column — no deck_json parse, verification merge, or
+        display-name resolution — so it is cheap enough to run on every
+        deck-cache hit (multi-worker cache validation) and before LLM calls
+        (optimistic locking).
+
+        Args:
+            session_id: Session to check (contributor sessions resolve to the
+                owner's deck)
+
+        Returns:
+            Current version number, or None if the session/deck doesn't exist
+        """
+        with get_db_session() as db:
+            try:
+                session = self._get_session_or_raise(db, session_id)
+            except SessionNotFoundError:
+                return None
+            deck_owner = self._get_deck_owner_session(db, session)
+            return (
+                db.query(SessionSlideDeck.version)
+                .filter(SessionSlideDeck.session_id == deck_owner.id)
+                .scalar()
+            )
+
     def get_slide_deck(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get slide deck for a session with verification merged by content hash.
 

--- a/tests/unit/test_chart_persistence.py
+++ b/tests/unit/test_chart_persistence.py
@@ -414,7 +414,7 @@ class TestDatabaseLoadPreservesScripts:
         service._deck_cache_versions = {session_id: 3}
 
         mock_sm = MagicMock()
-        mock_sm.get_slide_deck.return_value = {"version": 3}
+        mock_sm.get_slide_deck_version.return_value = 3
 
         with patch("src.api.services.chat_service.get_session_manager", return_value=mock_sm):
             deck = service._get_or_load_deck(session_id)

--- a/tests/unit/test_chart_persistence.py
+++ b/tests/unit/test_chart_persistence.py
@@ -395,8 +395,13 @@ class TestDatabaseLoadPreservesScripts:
         assert "dbChart" in deck.slides[0].scripts
         assert deck.slides[1].scripts == ""
 
-    def test_cache_hit_skips_database(self):
-        """When deck is in cache, database should not be called."""
+    def test_cache_hit_with_current_version_skips_deck_rebuild(self):
+        """When the cached deck matches the DB version, it is served as-is.
+
+        A cache hit still performs a version lookup (the cache is per-process
+        while prod runs multiple uvicorn workers sharing one database), but it
+        must not re-parse/rebuild the deck — the cached object is returned.
+        """
         service = ChatService.__new__(ChatService)
         service.agent = MagicMock()
 
@@ -406,15 +411,16 @@ class TestDatabaseLoadPreservesScripts:
         session_id = "test-session"
         cached_deck = _create_deck_with_charts(1, 0)
         service._deck_cache = {session_id: cached_deck}
+        service._deck_cache_versions = {session_id: 3}
 
         mock_sm = MagicMock()
+        mock_sm.get_slide_deck.return_value = {"version": 3}
 
         with patch("src.api.services.chat_service.get_session_manager", return_value=mock_sm):
             deck = service._get_or_load_deck(session_id)
 
-        # Should return cached deck without calling database
+        # Same object back — no reconstruction from the database payload
         assert deck is cached_deck
-        mock_sm.get_slide_deck.assert_not_called()
 
 
 class TestCanvasIdExtraction:

--- a/tests/unit/test_error_recovery.py
+++ b/tests/unit/test_error_recovery.py
@@ -988,6 +988,7 @@ class TestSavePointErrorRecovery:
 
         # Mock session manager where save works but create_version fails
         mock_sm = MagicMock()
+        mock_sm.get_slide_deck.return_value = None  # deck lives in cache only
         mock_sm.get_verification_map.return_value = {}
         mock_sm.create_version.side_effect = Exception("DB connection lost during version creation")
 

--- a/tests/unit/test_error_recovery.py
+++ b/tests/unit/test_error_recovery.py
@@ -989,6 +989,7 @@ class TestSavePointErrorRecovery:
         # Mock session manager where save works but create_version fails
         mock_sm = MagicMock()
         mock_sm.get_slide_deck.return_value = None  # deck lives in cache only
+        mock_sm.get_slide_deck_version.return_value = None
         mock_sm.get_verification_map.return_value = {}
         mock_sm.create_version.side_effect = Exception("DB connection lost during version creation")
 

--- a/tests/unit/test_image_utils.py
+++ b/tests/unit/test_image_utils.py
@@ -164,6 +164,7 @@ class TestSlideContextBase64Stripping:
             "agent_config": None,
         }
         mock_session_manager.get_slide_deck.return_value = None
+        mock_session_manager.get_slide_deck_version.return_value = None
 
         slide_context = {
             "indices": [0],

--- a/tests/unit/test_multiworker_cache_coherence.py
+++ b/tests/unit/test_multiworker_cache_coherence.py
@@ -75,6 +75,10 @@ class FakeDeckStore:
         record = self.decks.get(session_id)
         return copy.deepcopy(record) if record else None
 
+    def get_slide_deck_version(self, session_id: str) -> Optional[int]:
+        record = self.decks.get(session_id)
+        return record["version"] if record else None
+
     # -- collaborators ChatService touches during mutations ------------------
 
     def get_session(self, session_id: str) -> Dict[str, Any]:
@@ -125,6 +129,30 @@ def shared_db():
         "src.api.services.chat_service.get_session_manager", return_value=store
     ):
         yield store
+
+
+class TestVersionProbeCost:
+    """The cache-validation probe must be a lightweight version lookup."""
+
+    def test_cache_hit_probe_does_not_fetch_full_deck(self):
+        """A warm cache hit pays one version read, never a full deck fetch
+        (get_slide_deck parses the whole deck JSON and hashes every slide —
+        running it per mutation made deletes visibly slow)."""
+        worker = make_worker()
+        deck = SlideDeck.from_html_string(load_6_slide_deck())
+        worker._deck_cache[SESSION_ID] = deck
+        worker._deck_cache_versions = {SESSION_ID: 7}
+
+        sm = MagicMock()
+        sm.get_slide_deck_version.return_value = 7
+
+        with patch(
+            "src.api.services.chat_service.get_session_manager", return_value=sm
+        ):
+            result = worker._get_or_load_deck(SESSION_ID)
+
+        assert result is deck
+        sm.get_slide_deck.assert_not_called()
 
 
 class TestMultiWorkerCacheCoherence:

--- a/tests/unit/test_multiworker_cache_coherence.py
+++ b/tests/unit/test_multiworker_cache_coherence.py
@@ -1,0 +1,185 @@
+"""Multi-worker deck-cache coherence tests.
+
+Production runs uvicorn with multiple worker processes (see
+databricks_tellr_app/run.py: UVICORN_WORKERS, default 4). Each process has its
+own ChatService singleton and therefore its own in-memory ``_deck_cache``.
+The database is the only state shared between workers.
+
+The invariant these tests enforce:
+
+    A worker's view of the deck must never be staler than the database.
+
+Topology simulation: each "worker" is a separate ChatService instance; the
+shared database is a single FakeDeckStore. This is faithful to production
+(the per-process singleton is instance state; Lakebase is shared) while
+letting the test deterministically route each request to a chosen worker —
+something a real multi-process test cannot do.
+
+Regression context: in prod, worker B's stale cache caused
+- PUT /api/slides/reorder → 400 "Invalid reorder: wrong number of indices"
+- deleted slides resurrecting after a later mutation landed on a stale worker
+"""
+
+import copy
+import threading
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.api.services.chat_service import ChatService
+from src.domain.slide_deck import SlideDeck
+
+from tests.fixtures.html import load_6_slide_deck
+
+SESSION_ID = "multiworker-session"
+
+
+class FakeDeckStore:
+    """Stand-in for the shared database (session_manager persistence).
+
+    Mirrors the behaviour of SessionManager.save_slide_deck/get_slide_deck
+    that matters for coherence: version increments on every save, and reads
+    return fresh copies (like real DB rows), never shared object references.
+    """
+
+    def __init__(self):
+        self.decks: Dict[str, Dict[str, Any]] = {}
+
+    def save_slide_deck(
+        self,
+        session_id: str,
+        title: Optional[str],
+        html_content: str,
+        scripts_content: Optional[str] = None,
+        slide_count: int = 0,
+        deck_dict: Optional[Dict[str, Any]] = None,
+        modified_by: Optional[str] = None,
+        expected_version: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        existing = self.decks.get(session_id)
+        version = existing["version"] + 1 if existing else 1
+        self.decks[session_id] = {
+            "session_id": session_id,
+            "title": title,
+            "html_content": html_content,
+            "scripts_content": scripts_content,
+            "slide_count": slide_count,
+            "slides": copy.deepcopy(deck_dict.get("slides", [])) if deck_dict else [],
+            "css": deck_dict.get("css", "") if deck_dict else "",
+            "version": version,
+        }
+        return {"session_id": session_id, "slide_count": slide_count, "version": version}
+
+    def get_slide_deck(self, session_id: str) -> Optional[Dict[str, Any]]:
+        record = self.decks.get(session_id)
+        return copy.deepcopy(record) if record else None
+
+    # -- collaborators ChatService touches during mutations ------------------
+
+    def get_session(self, session_id: str) -> Dict[str, Any]:
+        return {"id": session_id}
+
+    def acquire_session_lock(self, session_id: str) -> bool:
+        return True
+
+    def release_session_lock(self, session_id: str) -> None:
+        pass
+
+    def get_verification_map(self, session_id: str) -> Dict[str, Any]:
+        return {}
+
+    def create_version(self, session_id: str, description: str, deck_dict, **kwargs):
+        return {"version_number": 1, "description": description}
+
+    def update_last_activity(self, session_id: str) -> None:
+        pass
+
+
+def make_worker() -> ChatService:
+    """One simulated uvicorn worker: a ChatService with its own deck cache."""
+    worker = ChatService.__new__(ChatService)
+    worker.agent = MagicMock()
+    worker._deck_cache = {}
+    worker._cache_lock = threading.Lock()
+    return worker
+
+
+def seed_db(store: FakeDeckStore, html: str) -> SlideDeck:
+    deck = SlideDeck.from_html_string(html)
+    store.save_slide_deck(
+        session_id=SESSION_ID,
+        title=deck.title,
+        html_content=deck.knit(),
+        slide_count=len(deck.slides),
+        deck_dict=deck.to_dict(),
+    )
+    return deck
+
+
+@pytest.fixture
+def shared_db():
+    """The shared 'database' both workers read and write."""
+    store = FakeDeckStore()
+    with patch(
+        "src.api.services.chat_service.get_session_manager", return_value=store
+    ):
+        yield store
+
+
+class TestMultiWorkerCacheCoherence:
+    """Worker-local cache must never serve state older than the database."""
+
+    def test_worker_deck_read_is_not_staler_than_db(self, shared_db):
+        """Generic invariant: after another worker mutates, a cached read
+        must reflect the database, not the process-local snapshot."""
+        seed_db(shared_db, load_6_slide_deck())
+        worker_a, worker_b = make_worker(), make_worker()
+
+        # Worker B serves a read and caches the 6-slide deck
+        assert len(worker_b._get_or_load_deck(SESSION_ID).slides) == 6
+
+        # A mutation lands on worker A: deck is now 5 slides in the DB
+        worker_a.delete_slide(SESSION_ID, 0)
+        assert len(shared_db.get_slide_deck(SESSION_ID)["slides"]) == 5
+
+        # Worker B's next read must match the database
+        deck_b = worker_b._get_or_load_deck(SESSION_ID)
+        assert len(deck_b.slides) == len(shared_db.get_slide_deck(SESSION_ID)["slides"])
+
+    def test_reorder_on_stale_worker_accepts_current_db_order(self, shared_db):
+        """Prod regression: reorder validated against a stale worker cache
+        returned 400 'wrong number of indices (got 5, expected 6)'."""
+        seed_db(shared_db, load_6_slide_deck())
+        worker_a, worker_b = make_worker(), make_worker()
+
+        worker_b._get_or_load_deck(SESSION_ID)  # warm B's cache (6 slides)
+        worker_a.delete_slide(SESSION_ID, 0)  # DB now has 5 slides
+
+        # The frontend refetched from the DB and sends a 5-index permutation
+        worker_b.reorder_slides(SESSION_ID, [4, 3, 2, 1, 0])
+
+        saved = shared_db.get_slide_deck(SESSION_ID)
+        assert len(saved["slides"]) == 5
+
+    def test_stale_worker_mutation_does_not_resurrect_deleted_slide(self, shared_db):
+        """Prod regression: a mutation landing on a stale worker wrote the
+        stale 6-slide deck back to the DB, resurrecting the deleted slide."""
+        seed_db(shared_db, load_6_slide_deck())
+        worker_a, worker_b = make_worker(), make_worker()
+
+        worker_b._get_or_load_deck(SESSION_ID)  # warm B's cache (6 slides)
+
+        deleted_html = shared_db.get_slide_deck(SESSION_ID)["slides"][0]["html"]
+        worker_a.delete_slide(SESSION_ID, 0)  # DB now has 5 slides
+
+        # An unrelated edit lands on stale worker B; index 0 is valid in both
+        # the stale and fresh deck, so no validation error fires
+        worker_b.update_slide(
+            SESSION_ID, 0, '<div class="slide"><h1>Edited on worker B</h1></div>'
+        )
+
+        saved = shared_db.get_slide_deck(SESSION_ID)
+        saved_htmls: List[str] = [s["html"] for s in saved["slides"]]
+        assert len(saved["slides"]) == 5
+        assert deleted_html not in saved_htmls

--- a/tests/unit/test_save_points.py
+++ b/tests/unit/test_save_points.py
@@ -600,6 +600,7 @@ class TestCreateSavePoint:
         service._deck_cache[self.session_id] = deck
 
         mock_sm = MagicMock()
+        mock_sm.get_slide_deck.return_value = None  # deck lives in cache only
         mock_sm.get_verification_map.return_value = {"hash1": {"status": "verified"}}
         mock_sm.create_version.return_value = {
             "version_number": 1,

--- a/tests/unit/test_save_points.py
+++ b/tests/unit/test_save_points.py
@@ -601,6 +601,7 @@ class TestCreateSavePoint:
 
         mock_sm = MagicMock()
         mock_sm.get_slide_deck.return_value = None  # deck lives in cache only
+        mock_sm.get_slide_deck_version.return_value = None
         mock_sm.get_verification_map.return_value = {"hash1": {"status": "verified"}}
         mock_sm.create_version.return_value = {
             "version_number": 1,


### PR DESCRIPTION
## Problem

Prod runs 4 uvicorn worker processes, each with its own in-memory `ChatService` deck cache. The database is the only shared state. Mutations only updated the *mutating* worker's cache, so the other workers served stale decks indefinitely. This surfaced as several long-standing prod bugs:

- **Reorder fails** with `ApiError: Failed to reorder slides` — backend returned `400 Invalid reorder: wrong number of indices` because the worker validated the new order against a stale slide list (seen in prod logs, both `got 16, expected 15` and the reverse).
- **Deleted slides reappear** — an LLM add/edit landing on a stale worker rebuilt the deck from its old cached copy and wrote it back to the DB, resurrecting a slide deleted on another worker.
- **Inserts/edits land in the wrong place** — index-based operations resolved against the stale slide list.

The root cause: `ChatService._deck_cache` is per-process, but `_get_or_load_deck` returned a cache hit with no freshness check. `get_slides` (the read path) always hit the DB, so reads and mutations disagreed. This is the same class of multi-worker state bug the codebase already fixed for session locks (DB-backed) and MCP (stateless).

## Fix

`_get_or_load_deck` now records the DB version each cached deck corresponds to and validates it on every cache hit, reloading from the database on mismatch. All six `save_slide_deck` call sites record the new version so the mutating worker's cache stays warm. `_invalidate_deck_cache` clears both maps.

The version probe is a dedicated single-column lookup (`SessionManager.get_slide_deck_version`), not the full `get_slide_deck` (which parses the whole deck JSON, hashes every slide, and resolves display names) — otherwise every mutation paid that cost and deletes got visibly slow.

## Tests

`tests/unit/test_multiworker_cache_coherence.py` simulates the prod topology (two `ChatService` instances sharing one store) and covers:
- the generic "worker state = database state" invariant at the single choke point every mutation flows through,
- both prod regressions (reorder 400, zombie slide),
- a guard that a warm cache hit performs only the lightweight version probe, never a full deck fetch.

Full unit + slide integration suites match the pre-existing baseline (no new failures).

## Verification

Deployed `0.3.13.dev11` to a `devloop` instance (`db-tellr-dev-cache-fix`, 4 workers, fresh fork of prod data). Confirmed reorder and delete work correctly and deletes are fast again.

This pull request and its description were written by Isaac.