### PR TITLE
SDR-4437 PR-2: Authorization / IDOR + admin role (HIGH-1/2/3/4/6, MEDIUM-1/6)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from src.api.routes import admin, admin_usage, agent_config, chat, export, feedback, images, profiles, sessions, slides, tools, tour, verification, version, google_slides, setup, local_version
@@ -434,6 +434,29 @@ from src.api.middleware.security_headers import SecurityHeadersMiddleware  # noq
 app.add_middleware(CSRFProtectionMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 # === end SDR-4437 Track A security middleware =============================
+
+# ---------------------------------------------------------------------------
+# Exception handlers — keep BELOW the middleware-registration block above
+# (Track A of SDR-4437 owns that block; do not reorder or interleave).
+#
+# HIGH-6: when user_auth_middleware fails to build the OBO client, the request
+# used to proceed silently as the SP; now the first user-scoped call raises
+# UserClientRequiredError, mapped here to a clean 401 instead of a 500 from
+# deep inside a tool call.
+# ---------------------------------------------------------------------------
+from src.core.databricks_client import UserClientRequiredError
+
+
+@app.exception_handler(UserClientRequiredError)
+async def user_client_required_handler(request: Request, exc: UserClientRequiredError):
+    logger.warning("User-scoped call without a bound OBO client: %s", exc)
+    return JSONResponse(
+        status_code=401,
+        content={
+            "detail": "Your Databricks identity could not be resolved for this "
+            "request. Please refresh the page to re-authenticate."
+        },
+    )
 
 # Include API routers
 app.include_router(admin.router)

--- a/src/api/routes/_authz.py
+++ b/src/api/routes/_authz.py
@@ -1,0 +1,337 @@
+"""Shared authorization helpers for API routes (SDR-4437 PR-2).
+
+Consolidates the deck-permission helpers that previously lived in
+``sessions.py`` and ``slides.py`` (names and signatures preserved), and adds:
+
+- ``_require_export_job_access`` — job-ID → session_id → deck permission
+  (closes the job-ID IDOR on export poll/download and Google Slides poll).
+- ``require_admin`` — HIGH-2 admin primitive. Admin == holds CAN_MANAGE on
+  the Databricks App itself, tested by reading the app's ACL with the
+  caller's own OBO client (reading an object's ACL requires CAN_MANAGE on
+  it, so the read succeeding *is* the admin test; group-held / inherited
+  CAN_MANAGE resolves server-side for free).
+"""
+
+import logging
+import os
+import time
+from typing import Optional, Tuple
+
+from databricks.sdk.errors import PermissionDenied
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from src.api.services.session_manager import SessionNotFoundError, get_session_manager
+from src.core.database import get_db_session
+from src.core.permission_context import get_permission_context
+from src.core.user_context import get_current_user
+from src.database.models.profile_contributor import PermissionLevel
+from src.services.permission_service import PERMISSION_PRIORITY, get_permission_service
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Deck-permission helpers (moved from sessions.py / slides.py — verbatim)
+# ---------------------------------------------------------------------------
+
+
+def _get_session_permission_for_info(
+    session_info: dict,
+    db: Session,
+) -> Tuple[bool, Optional[PermissionLevel]]:
+    """Check user's permission on a session via deck_contributors.
+
+    (Moved from sessions.py:_get_session_permission.)
+
+    Resolves to the root session (parent for contributor sessions) and checks
+    the DeckContributor table for the current user's permission level.
+
+    Args:
+        session_info: Session dict with id, created_by, parent_session_id, etc.
+        db: Database session
+
+    Returns:
+        Tuple of (has_access, permission_level)
+    """
+    perm_ctx = get_permission_context()
+    perm_service = get_permission_service()
+    parent_id = session_info.get("parent_session_internal_id")
+    root_session_id = parent_id if parent_id is not None else session_info.get("id")
+    perm = perm_service.get_deck_permission(
+        db, root_session_id,
+        user_id=perm_ctx.user_id if perm_ctx else None,
+        user_name=perm_ctx.user_name if perm_ctx else None,
+        group_ids=perm_ctx.group_ids if perm_ctx else None,
+    )
+    if perm is None:
+        return False, None
+    return True, perm
+
+
+def _get_session_permission_by_id(
+    session_id: str,
+    db: Session,
+) -> Tuple[bool, Optional[PermissionLevel]]:
+    """Check if current user has access to a session's slides via deck_contributors.
+
+    (Moved from slides.py:_get_session_permission.)
+
+    Resolves to the root session (parent for contributor sessions) and checks
+    the DeckContributor table for the current user's permission level.
+
+    Args:
+        session_id: Session identifier (string)
+        db: Database session
+
+    Returns:
+        Tuple of (has_access, permission_level)
+    """
+    session_manager = get_session_manager()
+    ctx = get_permission_context()
+
+    try:
+        session_info = session_manager.get_session(session_id)
+    except SessionNotFoundError:
+        return False, None
+
+    perm_service = get_permission_service()
+    parent_internal_id = session_info.get("parent_session_internal_id")
+    root_session_id = (
+        parent_internal_id if parent_internal_id is not None else session_info.get("id")
+    )
+
+    perm = perm_service.get_deck_permission(
+        db, root_session_id,
+        user_id=ctx.user_id if ctx else None,
+        user_name=ctx.user_name if ctx else None,
+        group_ids=ctx.group_ids if ctx else None,
+    )
+    if perm is None:
+        return False, None
+    return True, perm
+
+
+def _require_session_access(
+    session_info: dict,
+    db: Session,
+    min_permission: PermissionLevel = PermissionLevel.CAN_VIEW,
+) -> PermissionLevel:
+    """Require user has at least the specified permission level on a session.
+
+    (Moved from sessions.py.)
+
+    Args:
+        session_info: Session dict with created_by and profile_id
+        db: Database session
+        min_permission: Minimum required permission (default: CAN_VIEW)
+
+    Returns:
+        The user's actual permission level
+
+    Raises:
+        HTTPException 403: If user doesn't have required permission
+    """
+    has_access, permission = _get_session_permission_for_info(session_info, db)
+
+    if not has_access or permission is None:
+        raise HTTPException(
+            status_code=403,
+            detail="You don't have permission to access this session",
+        )
+
+    if PERMISSION_PRIORITY[permission] < PERMISSION_PRIORITY[min_permission]:
+        raise HTTPException(
+            status_code=403,
+            detail=f"This action requires {min_permission.value} permission",
+        )
+
+    return permission
+
+
+def _require_slide_permission(
+    session_id: str,
+    db: Session,
+    min_permission: PermissionLevel = PermissionLevel.CAN_VIEW,
+) -> PermissionLevel:
+    """Require user has at least the specified permission level on slides.
+
+    (Moved from slides.py.)
+
+    Args:
+        session_id: Session identifier
+        db: Database session
+        min_permission: Minimum required permission (default: CAN_VIEW)
+
+    Returns:
+        The user's actual permission level
+
+    Raises:
+        HTTPException 403: If user doesn't have required permission
+    """
+    has_access, permission = _get_session_permission_by_id(session_id, db)
+
+    if not has_access or permission is None:
+        raise HTTPException(
+            status_code=403,
+            detail="You don't have permission to access these slides",
+        )
+
+    if PERMISSION_PRIORITY[permission] < PERMISSION_PRIORITY[min_permission]:
+        raise HTTPException(
+            status_code=403,
+            detail=f"This action requires {min_permission.value} permission",
+        )
+
+    return permission
+
+
+def _check_deck_permission_for_session(
+    session_id: str,
+    min_permission: PermissionLevel = PermissionLevel.CAN_VIEW,
+) -> None:
+    """Look up a session by string ID, resolve root, and enforce deck permission.
+
+    (Moved from sessions.py.)
+
+    This is the standard pattern for endpoints that only have a session_id string
+    and need to gate on deck permissions.  It opens its own DB session via
+    ``get_db_session`` so it can be called from endpoints that do not already
+    have one.
+
+    Args:
+        session_id: The string session_id passed to the endpoint.
+        min_permission: Minimum required permission level.
+
+    Raises:
+        HTTPException 404: If the session does not exist (stale tab, deleted session, wrong ID).
+        HTTPException 403: If the caller lacks the required permission.
+    """
+    session_manager = get_session_manager()
+    try:
+        session_info = session_manager.get_session(session_id)
+    except SessionNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Session not found: {session_id}",
+        ) from None
+    with get_db_session() as db:
+        _require_session_access(session_info, db, min_permission)
+
+
+# ---------------------------------------------------------------------------
+# Job-ID access (export poll/download, Google Slides poll)
+# ---------------------------------------------------------------------------
+
+
+def _require_export_job_access(
+    job_id: str,
+    min_permission: PermissionLevel = PermissionLevel.CAN_VIEW,
+) -> None:
+    """Resolve an export job's session and enforce deck permission on it.
+
+    Every ExportJob row is session-bound (both enqueue sites require a
+    session_id), so possession of a job_id must not grant access to another
+    user's export — the caller needs ``min_permission`` on the job's deck.
+
+    Raises:
+        HTTPException 404: unknown job_id.
+        HTTPException 404/403: from the deck-permission check.
+    """
+    from src.database.models.session import ExportJob
+
+    with get_db_session() as db:
+        job = db.query(ExportJob).filter(ExportJob.job_id == job_id).first()
+        session_id = job.session_id if job is not None else None
+    if session_id is None:
+        raise HTTPException(status_code=404, detail="Export job not found")
+    _check_deck_permission_for_session(session_id, min_permission)
+
+
+# ---------------------------------------------------------------------------
+# HIGH-2: admin primitive — App CAN_MANAGE via OBO self-test
+# ---------------------------------------------------------------------------
+
+_ADMIN_CACHE: dict = {}
+_ADMIN_CACHE_TTL_SECONDS = 60.0
+
+
+def _is_production() -> bool:
+    return os.getenv("ENVIRONMENT", "development") == "production"
+
+
+def _admin_acl_probe(user_name: str) -> bool:
+    """Return True iff the caller's OBO client can read the app's ACL.
+
+    Reading an object's ACL in Databricks requires CAN_MANAGE on it, so a
+    successful ``apps.get_permissions`` call with the caller's own token is
+    the admin test. A CAN_USE-only caller raises ``PermissionDenied``, which
+    ``require_admin`` treats as a definitive (cacheable) deny; any other
+    error (missing OBO client, API/network failure) fails closed for the
+    current request without being cached. Missing app name -> False.
+    ``user_name`` is for logging/attribution only — the *token* is what is
+    being tested.
+    """
+    app_name = os.environ.get("DATABRICKS_APP_NAME")
+    if not app_name:
+        logger.warning("require_admin: DATABRICKS_APP_NAME unset; failing closed")
+        return False
+    from src.core.databricks_client import get_user_client
+
+    client = get_user_client()
+    client.apps.get_permissions(app_name)
+    return True
+
+
+def require_admin() -> None:
+    """FastAPI dependency: caller must hold CAN_MANAGE on the Databricks App.
+
+    - Local dev/test: bypass (dev auth is DEV_USER_ID with no token or ACL
+      behind it) — same pattern as the dev-only CORS gate in main.py.
+    - Verdicts cached per-username with a short TTL. The cache is in-memory
+      and therefore per-worker — deliberately fine here: a cache miss on
+      another worker just re-runs the ACL lookup; correctness never depends
+      on which worker got the request.
+    - Only *definitive* verdicts are cached: a probe result, or a
+      ``PermissionDenied`` from the API (the token demonstrably lacks
+      CAN_MANAGE). Transient probe errors fail closed for the current
+      request but are NOT cached — otherwise one network blip would lock a
+      real admin out for the full TTL.
+    - Fail closed (403) on non-admin, missing user, missing OBO client, or
+      lookup error.
+    """
+    if not _is_production():
+        return
+    user = get_current_user()
+    if not user:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    now = time.monotonic()
+    cached = _ADMIN_CACHE.get(user)
+    if cached is not None and now - cached[1] < _ADMIN_CACHE_TTL_SECONDS:
+        verdict = cached[0]
+    else:
+        try:
+            verdict = _admin_acl_probe(user)
+            _ADMIN_CACHE[user] = (verdict, now)
+        except PermissionDenied:
+            # Definitive API answer: the token lacks CAN_MANAGE. Cacheable.
+            verdict = False
+            _ADMIN_CACHE[user] = (verdict, now)
+        except Exception:
+            logger.warning(
+                "require_admin: ACL probe failed for %s; failing closed (uncached)",
+                user,
+                exc_info=True,
+            )
+            # Fail closed on THIS request only — do not cache error-derived
+            # denials (a transient blip must not deny an admin for the TTL).
+            verdict = False
+
+    if not verdict:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
+def reset_admin_cache() -> None:
+    """Clear the admin-verdict cache (tests)."""
+    _ADMIN_CACHE.clear()

--- a/src/api/routes/_authz.py
+++ b/src/api/routes/_authz.py
@@ -17,7 +17,6 @@ import os
 import time
 from typing import Optional, Tuple
 
-from databricks.sdk.errors import PermissionDenied
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
@@ -249,56 +248,115 @@ def _require_export_job_access(
 
 
 # ---------------------------------------------------------------------------
-# HIGH-2: admin primitive — App CAN_MANAGE via OBO self-test
+# HIGH-2: admin primitive — caller holds CAN_MANAGE in the App's ACL
 # ---------------------------------------------------------------------------
+#
+# SECURITY NOTE (why this is NOT a "can you read the ACL?" test): an earlier
+# design decided admin by whether the caller's OBO client could read the app
+# ACL, on the premise "reading an ACL requires CAN_MANAGE." That premise is
+# FALSE — ``apps.get_permissions`` only needs the ``iam.access-control:read``
+# scope, which is present on every user's OBO token, so a faithful
+# readability probe classifies EVERY authenticated user as admin (fail-OPEN).
+# The correct control is an authorization DECISION: does the caller's own
+# identity (directly, or via a group they belong to) appear in the app ACL
+# with a CAN_MANAGE grant? That is a presence-in-grant check and cannot fail
+# open to "everyone is admin."
 
 _ADMIN_CACHE: dict = {}
 _ADMIN_CACHE_TTL_SECONDS = 60.0
+
+# App ACL entries carry Databricks IAM permission levels as *strings* like
+# "CAN_MANAGE" (databricks.sdk.service.iam.PermissionLevel); do NOT confuse
+# with the deck-permission ``PermissionLevel`` imported at module top.
+_APP_CAN_MANAGE = "CAN_MANAGE"
 
 
 def _is_production() -> bool:
     return os.getenv("ENVIRONMENT", "development") == "production"
 
 
-def _admin_acl_probe(user_name: str) -> bool:
-    """Return True iff the caller's OBO client can read the app's ACL.
+def _caller_group_display_names(client, user_name: str) -> set:
+    """Resolve the caller's group *display names* via workspace SCIM.
 
-    Reading an object's ACL in Databricks requires CAN_MANAGE on it, so a
-    successful ``apps.get_permissions`` call with the caller's own token is
-    the admin test. A CAN_USE-only caller raises ``PermissionDenied``, which
-    ``require_admin`` treats as a definitive (cacheable) deny; any other
-    error (missing OBO client, API/network failure) fails closed for the
-    current request without being cached. Missing app name -> False.
-    ``user_name`` is for logging/attribution only — the *token* is what is
-    being tested.
+    The app ACL identifies groups by ``group_name`` (display name, e.g.
+    "admins"), so membership matching must be on display names — not the
+    group IDs that ``permission_context``/``get_user_groups`` return, and not
+    the request-time permission context (which is built with
+    ``fetch_groups=False`` in production). We therefore look the caller up
+    directly through the system client's SCIM ``users`` API and read the
+    ``display`` of each group they belong to.
+    """
+    users = list(
+        client.users.list(filter=f'userName eq "{user_name}"', attributes="groups")
+    )
+    names: set = set()
+    for u in users:
+        for g in (u.groups or []):
+            if g.display:
+                names.add(g.display)
+    return names
+
+
+def _admin_acl_probe(user_name: str) -> bool:
+    """Return True iff ``user_name`` holds CAN_MANAGE in the app's ACL.
+
+    Admin is a real authorization decision (presence-in-grant), not an ACL
+    readability oracle: the caller is admin iff their ``user_name`` appears
+    as a direct CAN_MANAGE grant in the app ACL, OR any group they belong to
+    appears as a CAN_MANAGE ``group_name`` grant (inherited grants — e.g. the
+    workspace ``admins`` group — count). Both the ACL read and the caller's
+    group resolution use the SP/system client, which is unambiguously
+    permitted to read them and, crucially, does not depend on the caller's
+    OBO scopes (so it cannot be tricked into a fail-open verdict).
+
+    Returns False for a caller absent from every CAN_MANAGE grant (even
+    though such a caller can still *read* the ACL). Missing app name -> False.
+    Raises on genuine infra/API errors so ``require_admin`` can fail closed
+    without caching a transient blip.
     """
     app_name = os.environ.get("DATABRICKS_APP_NAME")
     if not app_name:
         logger.warning("require_admin: DATABRICKS_APP_NAME unset; failing closed")
         return False
-    from src.core.databricks_client import get_user_client
+    from src.core.databricks_client import get_system_client
 
-    client = get_user_client()
-    client.apps.get_permissions(app_name)
-    return True
+    client = get_system_client()
+    acl = client.apps.get_permissions(app_name)
+
+    caller_groups = _caller_group_display_names(client, user_name)
+
+    for entry in (acl.access_control_list or []):
+        grants_manage = any(
+            getattr(p.permission_level, "value", p.permission_level) == _APP_CAN_MANAGE
+            for p in (entry.all_permissions or [])
+        )
+        if not grants_manage:
+            continue
+        if entry.user_name and entry.user_name == user_name:
+            return True
+        if entry.group_name and entry.group_name in caller_groups:
+            return True
+    return False
 
 
 def require_admin() -> None:
-    """FastAPI dependency: caller must hold CAN_MANAGE on the Databricks App.
+    """FastAPI dependency: caller must hold CAN_MANAGE in the app's ACL.
 
     - Local dev/test: bypass (dev auth is DEV_USER_ID with no token or ACL
       behind it) — same pattern as the dev-only CORS gate in main.py.
+    - Admin verdict = ``_admin_acl_probe`` (a presence-in-grant check against
+      the app ACL, direct or via group membership). See the SECURITY NOTE
+      above for why this is a membership decision, not an ACL-readability
+      test.
     - Verdicts cached per-username with a short TTL. The cache is in-memory
       and therefore per-worker — deliberately fine here: a cache miss on
-      another worker just re-runs the ACL lookup; correctness never depends
-      on which worker got the request.
-    - Only *definitive* verdicts are cached: a probe result, or a
-      ``PermissionDenied`` from the API (the token demonstrably lacks
-      CAN_MANAGE). Transient probe errors fail closed for the current
-      request but are NOT cached — otherwise one network blip would lock a
-      real admin out for the full TTL.
-    - Fail closed (403) on non-admin, missing user, missing OBO client, or
-      lookup error.
+      another worker just re-runs the lookup; correctness never depends on
+      which worker got the request.
+    - Only *definitive* verdicts are cached (the probe's True/False result).
+      Transient probe errors fail closed for the current request but are NOT
+      cached — otherwise one network blip would lock a real admin out for the
+      full TTL.
+    - Fail closed (403) on non-admin, missing user, or lookup error.
     """
     if not _is_production():
         return
@@ -313,14 +371,12 @@ def require_admin() -> None:
     else:
         try:
             verdict = _admin_acl_probe(user)
-            _ADMIN_CACHE[user] = (verdict, now)
-        except PermissionDenied:
-            # Definitive API answer: the token lacks CAN_MANAGE. Cacheable.
-            verdict = False
+            # Definitive membership verdict (True or False). Cacheable.
             _ADMIN_CACHE[user] = (verdict, now)
         except Exception:
             logger.warning(
-                "require_admin: ACL probe failed for %s; failing closed (uncached)",
+                "require_admin: ACL membership check failed for %s; failing "
+                "closed (uncached)",
                 user,
                 exc_info=True,
             )

--- a/src/api/routes/_authz.py
+++ b/src/api/routes/_authz.py
@@ -251,16 +251,34 @@ def _require_export_job_access(
 # HIGH-2: admin primitive — caller holds CAN_MANAGE in the App's ACL
 # ---------------------------------------------------------------------------
 #
-# SECURITY NOTE (why this is NOT a "can you read the ACL?" test): an earlier
-# design decided admin by whether the caller's OBO client could read the app
-# ACL, on the premise "reading an ACL requires CAN_MANAGE." That premise is
-# FALSE — ``apps.get_permissions`` only needs the ``iam.access-control:read``
-# scope, which is present on every user's OBO token, so a faithful
-# readability probe classifies EVERY authenticated user as admin (fail-OPEN).
-# The correct control is an authorization DECISION: does the caller's own
-# identity (directly, or via a group they belong to) appear in the app ACL
-# with a CAN_MANAGE grant? That is a presence-in-grant check and cannot fail
-# open to "everyone is admin."
+# SECURITY NOTE — admin is a DECISION, not an ACL-readability oracle; and the
+# READ and the DECISION use different-but-verified principals.
+#
+# Wrong design #1 (fail-OPEN): decide admin by whether the caller's OBO client
+# can READ the app ACL. False premise — ``apps.get_permissions`` only needs
+# ``iam.access-control:read``, present on every user's OBO token, so a
+# readability probe classifies EVERY authenticated user as admin.
+#
+# Wrong design #2 (fail-CLOSED for all): fetch the ACL + caller groups with the
+# SP/system client. Verified live: the app's own SP is NOT in its own ACL and
+# gets ``PermissionDenied: ... apps.ruleSets/get`` — the SP has LESS access
+# here, not more, so every request hit the fail-closed path.
+#
+# Correct design: SEPARATE the data fetch from the verdict.
+#   - READ the ACL and RESOLVE the caller's groups with the caller's OBO/user
+#     client. Empirically verified against the deployed sdr4437-pr2 workspace
+#     (profile tellr-dev, U2M ~= OBO scope):
+#       * ``apps.get_permissions(app)`` -> 200 OK as OBO for apps the caller
+#         both does and does NOT manage (SP -> PermissionDenied).
+#       * ``current_user.me().groups`` -> the caller's own group *display
+#         names* (e.g. 'admins','users','tellr consumers') as OBO.
+#     Using OBO to FETCH does not reintroduce fail-open, because the read is
+#     not the verdict (see below), and ``me()`` returns only the CALLER's own
+#     identity — a user cannot forge membership in a group they aren't in.
+#   - DECIDE by presence-in-grant: admit iff the caller's ``user_name`` OR one
+#     of their group display-names appears in the ACL with CAN_MANAGE. This is
+#     the real authorization decision and cannot fail open regardless of who
+#     fetched the data.
 
 _ADMIN_CACHE: dict = {}
 _ADMIN_CACHE_TTL_SECONDS = 60.0
@@ -276,51 +294,51 @@ def _is_production() -> bool:
 
 
 def _caller_group_display_names(client, user_name: str) -> set:
-    """Resolve the caller's group *display names* via workspace SCIM.
+    """Resolve the caller's own group *display names* via ``current_user.me``.
 
-    The app ACL identifies groups by ``group_name`` (display name, e.g.
-    "admins"), so membership matching must be on display names — not the
-    group IDs that ``permission_context``/``get_user_groups`` return, and not
-    the request-time permission context (which is built with
-    ``fetch_groups=False`` in production). We therefore look the caller up
-    directly through the system client's SCIM ``users`` API and read the
-    ``display`` of each group they belong to.
+    The app ACL identifies groups by ``group_name`` display name (e.g.
+    "admins"), so membership matching must be on display names — not the group
+    IDs that ``permission_context``/``get_user_groups`` return, and not the
+    request-time permission context (built with ``fetch_groups=False`` in
+    production). ``client`` MUST be the caller's OBO/user client:
+    ``current_user.me()`` returns the token holder's own identity and its
+    ``groups[].display`` are exactly the caller's group display names
+    (verified live — 'admins' among them for a workspace admin). ``user_name``
+    is accepted for signature symmetry / logging; the OBO token is what scopes
+    the answer to the caller.
     """
-    users = list(
-        client.users.list(filter=f'userName eq "{user_name}"', attributes="groups")
-    )
-    names: set = set()
-    for u in users:
-        for g in (u.groups or []):
-            if g.display:
-                names.add(g.display)
-    return names
+    me = client.current_user.me()
+    return {g.display for g in (me.groups or []) if g.display}
 
 
 def _admin_acl_probe(user_name: str) -> bool:
     """Return True iff ``user_name`` holds CAN_MANAGE in the app's ACL.
 
-    Admin is a real authorization decision (presence-in-grant), not an ACL
-    readability oracle: the caller is admin iff their ``user_name`` appears
-    as a direct CAN_MANAGE grant in the app ACL, OR any group they belong to
+    Admin is a presence-in-grant authorization decision, not an ACL
+    readability oracle: the caller is admin iff their ``user_name`` appears as
+    a direct CAN_MANAGE grant in the app ACL, OR any group they belong to
     appears as a CAN_MANAGE ``group_name`` grant (inherited grants — e.g. the
-    workspace ``admins`` group — count). Both the ACL read and the caller's
-    group resolution use the SP/system client, which is unambiguously
-    permitted to read them and, crucially, does not depend on the caller's
-    OBO scopes (so it cannot be tricked into a fail-open verdict).
+    workspace ``admins`` group — count).
 
-    Returns False for a caller absent from every CAN_MANAGE grant (even
-    though such a caller can still *read* the ACL). Missing app name -> False.
-    Raises on genuine infra/API errors so ``require_admin`` can fail closed
-    without caching a transient blip.
+    Both the ACL read and the caller's group resolution use the caller's
+    OBO/user client, because that is the principal empirically verified to be
+    able to make these calls (the app SP cannot read its own ACL). Using OBO
+    to fetch is safe: the verdict is the presence-in-grant check below, not the
+    read succeeding, and ``current_user.me()`` only ever returns the caller's
+    own identity/groups — so a non-admin cannot be admitted.
+
+    Returns False for a caller absent from every CAN_MANAGE grant (even though
+    such a caller can still *read* the ACL). Missing app name -> False. Raises
+    on genuine infra/API errors so ``require_admin`` can fail closed without
+    caching a transient blip.
     """
     app_name = os.environ.get("DATABRICKS_APP_NAME")
     if not app_name:
         logger.warning("require_admin: DATABRICKS_APP_NAME unset; failing closed")
         return False
-    from src.core.databricks_client import get_system_client
+    from src.core.databricks_client import get_user_client
 
-    client = get_system_client()
+    client = get_user_client()
     acl = client.apps.get_permissions(app_name)
 
     caller_groups = _caller_group_display_names(client, user_name)

--- a/src/api/routes/_authz.py
+++ b/src/api/routes/_authz.py
@@ -248,45 +248,41 @@ def _require_export_job_access(
 
 
 # ---------------------------------------------------------------------------
-# HIGH-2: admin primitive — caller holds CAN_MANAGE in the App's ACL
+# HIGH-2: admin primitive — caller is a member of the workspace ``admins`` group
 # ---------------------------------------------------------------------------
 #
-# SECURITY NOTE — admin is a DECISION, not an ACL-readability oracle; and the
-# READ and the DECISION use different-but-verified principals.
+# SEMANTIC DEFINITION (Robert's decision, "Direction C"): admin == the caller
+# is a member of the workspace ``admins`` group. This is NOT "holds CAN_MANAGE
+# on this specific app" — the earlier app-ACL designs are abandoned because
+# ``apps.get_permissions`` is simply the wrong primitive for a Databricks App
+# to call at runtime. Three deploys proved the walls empirically:
 #
-# Wrong design #1 (fail-OPEN): decide admin by whether the caller's OBO client
-# can READ the app ACL. False premise — ``apps.get_permissions`` only needs
-# ``iam.access-control:read``, present on every user's OBO token, so a
-# readability probe classifies EVERY authenticated user as admin.
+#   1. OBO-can-read-the-ACL as the verdict           -> fail-OPEN (every user
+#      could read the ACL, so every user was "admin").
+#   2. SP/system client reads the ACL                -> fail-CLOSED for all:
+#      PermissionDenied ``apps.ruleSets/get`` (the app's own SP is not in its
+#      own ACL).
+#   3. OBO client reads the ACL (apps.get_permissions) -> fail-CLOSED for all:
+#      ``PermissionDenied: Provided OAuth token does not have required scopes:
+#      access-management``. The runtime OBO x-forwarded-access-token is scoped
+#      down to the app's declared user_api_scopes and does NOT carry
+#      ``access-management``; only a full-scope human/CLI token does, which the
+#      app never has at runtime (that scope gap is exactly what made the first
+#      three "verifications" — all done with a CLI token — false positives).
 #
-# Wrong design #2 (fail-CLOSED for all): fetch the ACL + caller groups with the
-# SP/system client. Verified live: the app's own SP is NOT in its own ACL and
-# gets ``PermissionDenied: ... apps.ruleSets/get`` — the SP has LESS access
-# here, not more, so every request hit the fail-closed path.
-#
-# Correct design: SEPARATE the data fetch from the verdict.
-#   - READ the ACL and RESOLVE the caller's groups with the caller's OBO/user
-#     client. Empirically verified against the deployed sdr4437-pr2 workspace
-#     (profile tellr-dev, U2M ~= OBO scope):
-#       * ``apps.get_permissions(app)`` -> 200 OK as OBO for apps the caller
-#         both does and does NOT manage (SP -> PermissionDenied).
-#       * ``current_user.me().groups`` -> the caller's own group *display
-#         names* (e.g. 'admins','users','tellr consumers') as OBO.
-#     Using OBO to FETCH does not reintroduce fail-open, because the read is
-#     not the verdict (see below), and ``me()`` returns only the CALLER's own
-#     identity — a user cannot forge membership in a group they aren't in.
-#   - DECIDE by presence-in-grant: admit iff the caller's ``user_name`` OR one
-#     of their group display-names appears in the ACL with CAN_MANAGE. This is
-#     the real authorization decision and cannot fail open regardless of who
-#     fetched the data.
+# So we drop object-ACL reads entirely and decide admin from the caller's OWN
+# group membership: ``current_user.me()`` is governed by ``iam.current-user:read``,
+# which IS in the app's effective OBO scopes (unlike access-management), needs
+# no object-ACL permission and no SP. Presence-in-own-group-list cannot fail
+# open — a non-admin's ``me().groups`` will not contain ``admins`` and a caller
+# cannot forge membership in a group they are not in. ``DATABRICKS_APP_NAME`` is
+# no longer needed on this path.
 
 _ADMIN_CACHE: dict = {}
 _ADMIN_CACHE_TTL_SECONDS = 60.0
 
-# App ACL entries carry Databricks IAM permission levels as *strings* like
-# "CAN_MANAGE" (databricks.sdk.service.iam.PermissionLevel); do NOT confuse
-# with the deck-permission ``PermissionLevel`` imported at module top.
-_APP_CAN_MANAGE = "CAN_MANAGE"
+# The workspace group whose members are treated as Tellr admins.
+_ADMIN_GROUP = "admins"
 
 
 def _is_production() -> bool:
@@ -296,76 +292,46 @@ def _is_production() -> bool:
 def _caller_group_display_names(client, user_name: str) -> set:
     """Resolve the caller's own group *display names* via ``current_user.me``.
 
-    The app ACL identifies groups by ``group_name`` display name (e.g.
-    "admins"), so membership matching must be on display names — not the group
-    IDs that ``permission_context``/``get_user_groups`` return, and not the
-    request-time permission context (built with ``fetch_groups=False`` in
-    production). ``client`` MUST be the caller's OBO/user client:
-    ``current_user.me()`` returns the token holder's own identity and its
-    ``groups[].display`` are exactly the caller's group display names
-    (verified live — 'admins' among them for a workspace admin). ``user_name``
-    is accepted for signature symmetry / logging; the OBO token is what scopes
-    the answer to the caller.
+    ``client`` MUST be the caller's OBO/user client: ``current_user.me()``
+    returns the token holder's own identity, scoped by ``iam.current-user:read``
+    (present in the app's effective OBO scopes), and its ``groups[].display``
+    are exactly the caller's own group display names. ``user_name`` is accepted
+    for signature symmetry / logging; the OBO token is what scopes the answer
+    to the caller (a caller cannot enumerate another principal's groups here).
     """
     me = client.current_user.me()
     return {g.display for g in (me.groups or []) if g.display}
 
 
 def _admin_acl_probe(user_name: str) -> bool:
-    """Return True iff ``user_name`` holds CAN_MANAGE in the app's ACL.
+    """Return True iff the caller is a member of the workspace ``admins`` group.
 
-    Admin is a presence-in-grant authorization decision, not an ACL
-    readability oracle: the caller is admin iff their ``user_name`` appears as
-    a direct CAN_MANAGE grant in the app ACL, OR any group they belong to
-    appears as a CAN_MANAGE ``group_name`` grant (inherited grants — e.g. the
-    workspace ``admins`` group — count).
+    Admin is decided from the caller's OWN group membership (resolved via the
+    OBO/user client's ``current_user.me().groups``), NOT from any app-object
+    ACL — see the SEMANTIC DEFINITION / three-walls note above for why
+    ``apps.get_permissions`` cannot work from an app's runtime OBO token or SP.
 
-    Both the ACL read and the caller's group resolution use the caller's
-    OBO/user client, because that is the principal empirically verified to be
-    able to make these calls (the app SP cannot read its own ACL). Using OBO
-    to fetch is safe: the verdict is the presence-in-grant check below, not the
-    read succeeding, and ``current_user.me()`` only ever returns the caller's
-    own identity/groups — so a non-admin cannot be admitted.
-
-    Returns False for a caller absent from every CAN_MANAGE grant (even though
-    such a caller can still *read* the ACL). Missing app name -> False. Raises
-    on genuine infra/API errors so ``require_admin`` can fail closed without
-    caching a transient blip.
+    This cannot fail open: ``me().groups`` returns only the caller's own
+    memberships, so a non-admin's list will not contain ``admins`` and the
+    caller cannot forge it. Raises on genuine infra/API errors so
+    ``require_admin`` can fail closed without caching a transient blip.
     """
-    app_name = os.environ.get("DATABRICKS_APP_NAME")
-    if not app_name:
-        logger.warning("require_admin: DATABRICKS_APP_NAME unset; failing closed")
-        return False
     from src.core.databricks_client import get_user_client
 
     client = get_user_client()
-    acl = client.apps.get_permissions(app_name)
-
     caller_groups = _caller_group_display_names(client, user_name)
-
-    for entry in (acl.access_control_list or []):
-        grants_manage = any(
-            getattr(p.permission_level, "value", p.permission_level) == _APP_CAN_MANAGE
-            for p in (entry.all_permissions or [])
-        )
-        if not grants_manage:
-            continue
-        if entry.user_name and entry.user_name == user_name:
-            return True
-        if entry.group_name and entry.group_name in caller_groups:
-            return True
-    return False
+    return _ADMIN_GROUP in caller_groups
 
 
 def require_admin() -> None:
-    """FastAPI dependency: caller must hold CAN_MANAGE in the app's ACL.
+    """FastAPI dependency: caller must be a member of the workspace ``admins`` group.
 
-    - Local dev/test: bypass (dev auth is DEV_USER_ID with no token or ACL
-      behind it) — same pattern as the dev-only CORS gate in main.py.
-    - Admin verdict = ``_admin_acl_probe`` (a presence-in-grant check against
-      the app ACL, direct or via group membership). See the SECURITY NOTE
-      above for why this is a membership decision, not an ACL-readability
-      test.
+    - Local dev/test: bypass (dev auth is DEV_USER_ID with no token or group
+      membership behind it) — same pattern as the dev-only CORS gate in main.py.
+    - Admin verdict = ``_admin_acl_probe`` (caller is in the workspace
+      ``admins`` group, resolved from their own OBO ``current_user.me()``).
+      See the SEMANTIC DEFINITION note above for why this is a group-membership
+      decision and not an app-object-ACL check.
     - Verdicts cached per-username with a short TTL. The cache is in-memory
       and therefore per-worker — deliberately fine here: a cache miss on
       another worker just re-runs the lookup; correctness never depends on

--- a/src/api/routes/admin.py
+++ b/src/api/routes/admin.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from src.api.routes._authz import require_admin
 from src.api.utils.validation import validate_credentials_json
 from src.core.database import get_db
 from src.core.encryption import decrypt_data, encrypt_data
@@ -23,7 +24,10 @@ from src.database.models.google_oauth_token import GoogleOAuthToken
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/admin", tags=["admin"])
+# SDR-4437 HIGH-2: entire admin surface requires App CAN_MANAGE.
+router = APIRouter(
+    prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)]
+)
 
 _MAX_CREDENTIALS_SIZE = 100 * 1024
 

--- a/src/api/routes/admin_usage.py
+++ b/src/api/routes/admin_usage.py
@@ -1,4 +1,4 @@
-"""Admin usage-analytics endpoints (ungated, like the rest of /admin)."""
+"""Admin usage-analytics endpoints (admin-gated, like the rest of /admin)."""
 
 import logging
 from datetime import date as dt_date
@@ -7,11 +7,18 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
+from src.api.routes._authz import require_admin
 from src.api.services.usage_service import MAX_WINDOW_DAYS, UsageService
 from src.core.database import get_db
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/api/admin/usage", tags=["admin-usage"])
+
+# SDR-4437 MEDIUM-6: workspace-wide usage analytics are admin-only.
+router = APIRouter(
+    prefix="/api/admin/usage",
+    tags=["admin-usage"],
+    dependencies=[Depends(require_admin)],
+)
 
 
 def _parse_date(value: str, name: str) -> dt_date:

--- a/src/api/routes/agent_config.py
+++ b/src/api/routes/agent_config.py
@@ -7,10 +7,12 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, ValidationError
 
+from src.api.routes._authz import _check_deck_permission_for_session
 from src.api.schemas.agent_config import AgentConfig, ToolEntry, resolve_agent_config
 from src.api.services.session_manager import SessionNotFoundError, get_session_manager
 from src.core.database import get_db_session
 from src.database.models import UserSession
+from src.database.models.profile_contributor import PermissionLevel
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +85,8 @@ class PatchToolRequest(BaseModel):
 @router.get("")
 async def get_agent_config(session_id: str):
     """Return the current agent config for a session (defaults if null)."""
+    # SDR-4437 HIGH-1: reading a session's agent config requires CAN_VIEW.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_VIEW)
     try:
         mgr = get_session_manager()
         session = await asyncio.to_thread(mgr.get_session, session_id)
@@ -99,6 +103,8 @@ async def get_agent_config(session_id: str):
 @router.put("")
 async def put_agent_config(session_id: str, config: AgentConfig):
     """Replace the full agent config for a session."""
+    # SDR-4437 HIGH-1: agent-config writes repoint the session's tools — CAN_MANAGE.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_MANAGE)
     # Pydantic already validated duplicates via model_validator.
     # Now validate foreign-key references.
     _validate_references(config)
@@ -114,6 +120,8 @@ async def put_agent_config(session_id: str, config: AgentConfig):
 @router.patch("/tools")
 async def patch_tools(session_id: str, body: PatchToolRequest):
     """Add or remove a single tool from the session's agent config."""
+    # SDR-4437 HIGH-1: agent-config writes repoint the session's tools — CAN_MANAGE.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_MANAGE)
     try:
         mgr = get_session_manager()
         session = await asyncio.to_thread(mgr.get_session, session_id)

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session as DBSession
 from src.api.schemas.requests import ChatRequest
 from src.api.schemas.responses import ChatResponse
 from src.api.schemas.streaming import StreamEvent, StreamEventType
+from src.api.routes._authz import _check_deck_permission_for_session
 from src.api.services.chat_service import get_chat_service
 from src.api.services.job_queue import enqueue_job
 from src.api.services.session_manager import SessionNotFoundError, get_session_manager
@@ -573,6 +574,18 @@ async def poll_chat(
         HTTPException: 404 if request not found
     """
     session_manager = get_session_manager()
+
+    # SDR-4437 (chat-poll IDOR): a request_id must not grant access to another
+    # user's chat events/result. ChatRequest rows are session-bound — resolve
+    # the session and require CAN_VIEW on the deck.
+    session_id = await asyncio.to_thread(
+        session_manager.get_session_id_for_request, request_id
+    )
+    if session_id is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    await asyncio.to_thread(
+        _check_deck_permission_for_session, session_id, PermissionLevel.CAN_VIEW
+    )
 
     chat_request = await asyncio.to_thread(
         session_manager.get_chat_request, request_id

--- a/src/api/routes/export.py
+++ b/src/api/routes/export.py
@@ -5,11 +5,17 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
+from src.api.routes._authz import (
+    _check_deck_permission_for_session,
+    _require_export_job_access,
+    require_admin,
+)
 from src.api.services.chat_service import get_chat_service
+from src.database.models.profile_contributor import PermissionLevel
 from src.services.html_to_pptx import HtmlToPptxConverterV3, PPTXConversionError
 from src.utils.html_safety import SLIDE_CSP_META, scan_html_for_unsafe_patterns
 
@@ -392,6 +398,8 @@ async def export_to_pptx(request: ExportPPTXRequest):
     Raises:
         HTTPException: 404 if no slides, 500 on conversion error
     """
+    # SDR-4437 HIGH-1: caller must hold CAN_VIEW on the deck being exported.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
     # Log to both logger and print to ensure visibility
     log_msg = f"PPTX export request received - session_id: {request.session_id}, use_screenshot: {request.use_screenshot}"
     logger.info(log_msg)
@@ -659,6 +667,8 @@ async def start_pptx_export_async(request: ExportPPTXRequest):
     Raises:
         HTTPException: 404 if no slides available
     """
+    # SDR-4437 HIGH-1: caller must hold CAN_VIEW on the deck being exported.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
     import asyncio
     from src.api.services.export_job_queue import (
         enqueue_export_job,
@@ -764,6 +774,8 @@ async def poll_pptx_export(job_id: str):
     Raises:
         HTTPException: 404 if job not found
     """
+    # SDR-4437: job-ID IDOR — possession of a job_id must not grant access.
+    _require_export_job_access(job_id)
     from src.api.services.export_job_queue import build_export_job_response
     
     try:
@@ -786,6 +798,8 @@ async def download_pptx_export(job_id: str, background_tasks: BackgroundTasks):
     Raises:
         HTTPException: 404 if job not found, 400 if not completed
     """
+    # SDR-4437: job-ID IDOR — possession of a job_id must not grant access.
+    _require_export_job_access(job_id)
     from src.api.services.export_job_queue import (
         get_export_job_status,
         cleanup_export_job,
@@ -874,6 +888,9 @@ async def export_pptx_editable_from_records(request: ExportPPTXFromRecordsReques
     slide-px coordinates) and ``notes`` (speaker-notes string). Nothing
     here talks to headless Chromium; the browser did that work already.
     """
+    # SDR-4437 HIGH-1: when a session is referenced, the caller needs CAN_VIEW.
+    if request.session_id:
+        _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
     from src.services.pptx_from_records import build_pptx
 
     title = request.title or "slides"
@@ -913,6 +930,9 @@ class ExportPPTXFromImagesRequest(BaseModel):
 async def export_pptx_screenshot_from_images(request: ExportPPTXFromImagesRequest):
     """Screenshot-based .pptx — each slide is a single embedded image.
     Pixel-perfect fidelity, but nothing is editable."""
+    # SDR-4437 HIGH-1: when a session is referenced, the caller needs CAN_VIEW.
+    if request.session_id:
+        _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
     import base64, io, re
     from pptx import Presentation
     from pptx.util import Emu
@@ -961,6 +981,8 @@ async def export_pptx_editable(request: ExportPPTXEditableRequest):
     Synchronous (no job queue) — the sidecar is fast (<30s for typical decks)
     and the existing async path is kept intact for the raster exporter.
     """
+    # SDR-4437 HIGH-1: caller must hold CAN_VIEW on the deck being exported.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
     from src.services.html_editable_exporter import (
         export as export_editable,
         EditableExportError,
@@ -1001,13 +1023,13 @@ async def export_pptx_editable(request: ExportPPTXEditableRequest):
 # local dev. Surface as an additive 5th export mode in the frontend modal.
 
 
-@router.get("/pptx/editable/huashu/available")
+@router.get("/pptx/editable/huashu/available", dependencies=[Depends(require_admin)])
 async def export_pptx_huashu_available() -> dict:
     """Tell the frontend whether the huashu pipeline is available.
 
-    Returns the boolean plus per-check diagnostics so it's clear which
-    requirement is missing on a given deployment (helpful while we're
-    bringing chromium up on the Apps container).
+    Returns the boolean plus a slim set of per-check booleans. Full
+    diagnostics (paths, env, log tails, directory listings) are logged
+    server-side only (SDR-4437 MEDIUM-1).
     """
     import os
     import shutil
@@ -1036,57 +1058,44 @@ async def export_pptx_huashu_available() -> dict:
             setup_log_tail = "".join(lines[-40:])
         except Exception as e:  # noqa: BLE001
             setup_log_tail = f"(error reading log: {e})"
-    cache_dir_listing = []
-    cache_root = home / ".cache"
-    if cache_root.exists():
-        try:
-            cache_dir_listing = [p.name for p in cache_root.iterdir()]
-        except Exception:  # noqa: BLE001
-            pass
-    tmp_listing = []
-    try:
-        tmp_listing = sorted(p.name for p in Path("/tmp").iterdir())[:50]
-    except Exception:  # noqa: BLE001
-        pass
+    checks_full = {
+        "huashu_pipeline_enabled": os.environ.get("HUASHU_PIPELINE_ENABLED") == "1",
+        "databricks_app_name": os.environ.get("DATABRICKS_APP_NAME") or None,
+        "environment": os.environ.get("ENVIRONMENT"),
+        "node_on_path": shutil.which("node") is not None,
+        "sidecar_dir": str(SIDECAR_DIR),
+        "sidecar_script_exists": SIDECAR_SCRIPT.exists(),
+        "playwright_node_modules": (SIDECAR_DIR / "node_modules" / "playwright").exists(),
+        "pptxgenjs_node_modules": (SIDECAR_DIR / "node_modules" / "pptxgenjs").exists(),
+        "chromium_cache": _has_chromium(),
+        "chromium_cache_paths": chromium_paths,
+        "home": str(home),
+        "playwright_browsers_path_env": os.environ.get("PLAYWRIGHT_BROWSERS_PATH"),
+        "setup_log_path_exists": setup_log_path.exists(),
+        "setup_log_size": setup_log_size,
+        "setup_log_tail": setup_log_tail,
+    }
+    logger.info("huashu availability diagnostics: %s", checks_full)
     return {
         "available": is_available(),
         "checks": {
             "huashu_pipeline_enabled": os.environ.get("HUASHU_PIPELINE_ENABLED") == "1",
-            "databricks_app_name": os.environ.get("DATABRICKS_APP_NAME") or None,
-            "environment": os.environ.get("ENVIRONMENT"),
             "node_on_path": shutil.which("node") is not None,
-            "sidecar_dir": str(SIDECAR_DIR),
             "sidecar_script_exists": SIDECAR_SCRIPT.exists(),
             "playwright_node_modules": (SIDECAR_DIR / "node_modules" / "playwright").exists(),
             "pptxgenjs_node_modules": (SIDECAR_DIR / "node_modules" / "pptxgenjs").exists(),
-            "playwright_dir_listing": _list_dir_safe(SIDECAR_DIR / "node_modules" / "playwright"),
-            "playwright_core_dir_listing": _list_dir_safe(SIDECAR_DIR / "node_modules" / "playwright-core"),
             "chromium_cache": _has_chromium(),
-            "chromium_cache_paths": chromium_paths,
-            "home": str(home),
-            "playwright_browsers_path_env": os.environ.get("PLAYWRIGHT_BROWSERS_PATH"),
-            "cache_root_listing": cache_dir_listing,
-            "setup_log_path_exists": setup_log_path.exists(),
-            "setup_log_size": setup_log_size,
-            "setup_log_tail": setup_log_tail,
-            "tmp_listing": tmp_listing,
         },
     }
 
 
-def _list_dir_safe(p) -> list[str]:
-    try:
-        return sorted(c.name for c in p.iterdir())
-    except Exception:  # noqa: BLE001
-        return []
-
-
-@router.post("/pptx/editable/huashu/install-chromium")
+@router.post("/pptx/editable/huashu/install-chromium", dependencies=[Depends(require_admin)])
 async def export_pptx_huashu_install_chromium() -> dict:
-    """Synchronously run `npx playwright install chromium` and return the output.
+    """Synchronously run `npx playwright install chromium`.
 
     Diagnostic-only: lets us see exactly why the boot-time background install
-    is silently failing on the Databricks Apps container.
+    is silently failing on the Databricks Apps container. Full output is
+    logged server-side; the response is slim (SDR-4437 MEDIUM-1).
     """
     import subprocess
     from pathlib import Path
@@ -1097,7 +1106,8 @@ async def export_pptx_huashu_install_chromium() -> dict:
     env.setdefault("HOME", str(Path.home()))
     cli = SIDECAR_DIR / "node_modules" / "playwright" / "cli.js"
     if not cli.exists():
-        return {"error": f"playwright cli not found at {cli}"}
+        logger.warning("huashu install-chromium: playwright cli not found at %s", cli)
+        return {"ok": False, "error": "playwright cli not found"}
     try:
         result = subprocess.run(
             ["node", str(cli), "install", "chromium"],
@@ -1107,29 +1117,32 @@ async def export_pptx_huashu_install_chromium() -> dict:
             check=False,
             env=env,
         )
-        return {
-            "returncode": result.returncode,
-            "stdout_tail": result.stdout.decode("utf-8", errors="replace")[-4000:],
-            "stderr_tail": result.stderr.decode("utf-8", errors="replace")[-4000:],
-            "home": env.get("HOME"),
-            "path_env": env.get("PATH"),
-        }
+        logger.info(
+            "huashu install-chromium: rc=%s stdout_tail=%s stderr_tail=%s",
+            result.returncode,
+            result.stdout.decode("utf-8", errors="replace")[-4000:],
+            result.stderr.decode("utf-8", errors="replace")[-4000:],
+        )
+        return {"ok": result.returncode == 0, "returncode": result.returncode}
     except subprocess.TimeoutExpired as e:
-        return {
-            "error": "timeout",
-            "stdout_tail": (e.stdout or b"").decode("utf-8", errors="replace")[-4000:],
-            "stderr_tail": (e.stderr or b"").decode("utf-8", errors="replace")[-4000:],
-        }
+        logger.warning(
+            "huashu install-chromium timed out: stdout_tail=%s stderr_tail=%s",
+            (e.stdout or b"").decode("utf-8", errors="replace")[-4000:],
+            (e.stderr or b"").decode("utf-8", errors="replace")[-4000:],
+        )
+        return {"ok": False, "error": "timeout"}
     except Exception as e:  # noqa: BLE001
-        return {"error": f"{type(e).__name__}: {e}"}
+        logger.warning("huashu install-chromium failed: %s: %s", type(e).__name__, e)
+        return {"ok": False, "error": "install failed"}
 
 
-@router.post("/pptx/editable/huashu/probe-launch")
+@router.post("/pptx/editable/huashu/probe-launch", dependencies=[Depends(require_admin)])
 async def export_pptx_huashu_probe_launch() -> dict:
     """Spawn chromium with our standard launch options. No html2pptx, no pptxgenjs.
 
     De-risks the rest of the sidecar: if this exits 0 with PROBE_OK on the
     deployed app, chromium-on-Apps is solid and the full export will work.
+    Full output is logged server-side; the response is slim (SDR-4437 MEDIUM-1).
     """
     import subprocess
     from pathlib import Path
@@ -1138,7 +1151,8 @@ async def export_pptx_huashu_probe_launch() -> dict:
 
     probe_js = SIDECAR_DIR / "probe_launch.mjs"
     if not probe_js.exists():
-        return {"error": f"probe_launch.mjs not found at {probe_js}"}
+        logger.warning("huashu probe-launch: probe_launch.mjs not found at %s", probe_js)
+        return {"ok": False, "error": "probe script not found"}
 
     env = sidecar_subprocess_env()
     env.setdefault("HOME", str(Path.home()))
@@ -1151,19 +1165,23 @@ async def export_pptx_huashu_probe_launch() -> dict:
             check=False,
             env=env,
         )
-        return {
-            "returncode": result.returncode,
-            "stdout": result.stdout.decode("utf-8", errors="replace")[-2000:],
-            "stderr": result.stderr.decode("utf-8", errors="replace")[-2000:],
-        }
+        logger.info(
+            "huashu probe-launch: rc=%s stdout=%s stderr=%s",
+            result.returncode,
+            result.stdout.decode("utf-8", errors="replace")[-2000:],
+            result.stderr.decode("utf-8", errors="replace")[-2000:],
+        )
+        return {"ok": result.returncode == 0, "returncode": result.returncode}
     except subprocess.TimeoutExpired as e:
-        return {
-            "error": "timeout",
-            "stdout_tail": (e.stdout or b"").decode("utf-8", errors="replace")[-2000:],
-            "stderr_tail": (e.stderr or b"").decode("utf-8", errors="replace")[-2000:],
-        }
+        logger.warning(
+            "huashu probe-launch timed out: stdout_tail=%s stderr_tail=%s",
+            (e.stdout or b"").decode("utf-8", errors="replace")[-2000:],
+            (e.stderr or b"").decode("utf-8", errors="replace")[-2000:],
+        )
+        return {"ok": False, "error": "timeout"}
     except Exception as e:  # noqa: BLE001
-        return {"error": f"{type(e).__name__}: {e}"}
+        logger.warning("huashu probe-launch failed: %s: %s", type(e).__name__, e)
+        return {"ok": False, "error": "probe failed"}
 
 
 @router.post("/pptx/editable/huashu/from-html")
@@ -1175,6 +1193,8 @@ async def export_pptx_huashu_from_html(request: ExportPPTXEditableRequest):
     with an ``X-Huashu-Failures`` header carrying the per-slide error
     JSON so the frontend can surface what huashu objected to.
     """
+    # SDR-4437 HIGH-1: caller must hold CAN_VIEW on the deck being exported.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
     from src.services.pptx_from_html_huashu import (
         HuashuExportError,
         build_pptx_huashu,

--- a/src/api/routes/feedback.py
+++ b/src/api/routes/feedback.py
@@ -13,6 +13,7 @@ from src.api.schemas.feedback import (
     SurveySubmitRequest,
     SurveySubmitResponse,
 )
+from src.api.routes._authz import require_admin
 from src.api.services.feedback_service import FeedbackService
 from src.core.database import get_db
 
@@ -75,7 +76,7 @@ def submit_survey(request: SurveySubmitRequest, db: Session = Depends(get_db)):
         )
 
 
-@router.get("/report/stats")
+@router.get("/report/stats", dependencies=[Depends(require_admin)])
 def get_stats_report(weeks: int = Query(default=12, ge=1, le=52), db: Session = Depends(get_db)):
     try:
         service = FeedbackService()
@@ -88,7 +89,7 @@ def get_stats_report(weeks: int = Query(default=12, ge=1, le=52), db: Session = 
         )
 
 
-@router.get("/list")
+@router.get("/list", dependencies=[Depends(require_admin)])
 def list_feedback(
     weeks: int = Query(default=12, ge=1, le=52),
     category: str | None = Query(default=None),
@@ -115,7 +116,7 @@ def list_feedback(
         )
 
 
-@router.get("/report/summary")
+@router.get("/report/summary", dependencies=[Depends(require_admin)])
 def get_feedback_summary(weeks: int = Query(default=4, ge=1, le=52), db: Session = Depends(get_db)):
     try:
         service = FeedbackService()

--- a/src/api/routes/google_slides.py
+++ b/src/api/routes/google_slides.py
@@ -39,15 +39,20 @@ def _get_user_identity() -> str:
 
     In production (Databricks Apps) this is the authenticated user's email.
     In local dev it falls back to ``"local_dev"``.
+
+    HIGH-6 (SDR-4437): no except-Exception fallback in production — a
+    missing/failed OBO client must fail closed (UserClientRequiredError,
+    mapped to 401 in main.py), never store Google OAuth tokens under a
+    fallback identity.
     """
     if os.getenv("ENVIRONMENT") in ("development", "test"):
         return "local_dev"
-    try:
-        from src.core.databricks_client import get_user_client
-        client = get_user_client()
-        return client.current_user.me().user_name or "local_dev"
-    except Exception:
-        return "local_dev"
+    from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+    user_name = get_user_client().current_user.me().user_name
+    if not user_name:
+        raise UserClientRequiredError("OBO client resolved no user_name")
+    return user_name
 
 
 def _get_auth(db: Session) -> GoogleSlidesAuth:

--- a/src/api/routes/google_slides.py
+++ b/src/api/routes/google_slides.py
@@ -18,8 +18,13 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from src.api.services.chat_service import get_chat_service
+from src.api.routes._authz import (
+    _check_deck_permission_for_session,
+    _require_export_job_access,
+)
 from src.api.routes.export import ExportJobResponse
 from src.core.database import get_db
+from src.database.models.profile_contributor import PermissionLevel
 from src.services.drive_uploader import replace_presentation, upload_pptx_as_slides
 from src.services.google_slides_auth import GoogleSlidesAuth, GoogleSlidesAuthError
 from src.services.pptx_from_records import EmitError, build_pptx
@@ -254,6 +259,9 @@ async def start_google_slides_export(
     2. Enqueue background job for the slow LLM conversion.
     3. Return job_id so the frontend can poll.
     """
+    # SDR-4437 HIGH-1: caller must hold CAN_VIEW on the deck being exported.
+    _check_deck_permission_for_session(request_body.session_id, PermissionLevel.CAN_VIEW)
+
     from src.api.services.export_job_queue import (
         enqueue_export_job,
         generate_job_id,
@@ -343,6 +351,9 @@ async def poll_google_slides_export(job_id: str):
     When ``status`` is ``completed``, the response includes
     ``presentation_id`` and ``presentation_url``.
     """
+    # SDR-4437: job-ID IDOR — possession of a job_id must not grant access.
+    _require_export_job_access(job_id)
+
     from src.api.services.export_job_queue import build_export_job_response
 
     try:
@@ -386,6 +397,9 @@ async def export_google_slides_from_records(
 
     Re-exports on the same session overwrite the previous presentation.
     """
+    # SDR-4437 HIGH-1: caller must hold CAN_VIEW on the deck being exported.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
+
     try:
         auth = _get_auth(db)
     except GoogleSlidesAuthError as exc:
@@ -482,6 +496,9 @@ async def export_google_slides_from_huashu(
     Re-exports on the same session overwrite the previous presentation
     (same as ``/from-records``).
     """
+    # SDR-4437 HIGH-1: caller must hold CAN_VIEW on the deck being exported.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_VIEW)
+
     from src.services.pptx_from_html_huashu import (
         HuashuExportError,
         build_pptx_huashu,

--- a/src/api/routes/images.py
+++ b/src/api/routes/images.py
@@ -62,14 +62,20 @@ class ImageUpdateRequest(BaseModel):
 # --- Helper ---
 
 def _get_current_user() -> str:
-    """Get current username (dev fallback to 'system')."""
+    """Get current username (dev/test fallback to 'system').
+
+    HIGH-6 (SDR-4437): no except-Exception fallback in production — the
+    ownership checks on image writes compare against this value, so it must
+    never silently degrade to "system".
+    """
     if os.getenv("ENVIRONMENT") in ("development", "test"):
         return "system"
-    try:
-        from src.core.databricks_client import get_user_client
-        return get_user_client().current_user.me().user_name
-    except Exception:
-        return "system"
+    from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+    user_name = get_user_client().current_user.me().user_name
+    if not user_name:
+        raise UserClientRequiredError("OBO client resolved no user_name")
+    return user_name
 
 
 def _image_to_response(img: ImageAsset) -> ImageResponse:

--- a/src/api/routes/images.py
+++ b/src/api/routes/images.py
@@ -152,7 +152,9 @@ def list_images(
 ):
     """List images with optional filtering."""
     try:
-        images = image_service.search_images(db=db, category=category, query=query)
+        images = image_service.search_images(
+            db=db, category=category, query=query, uploaded_by=_get_current_user()
+        )
         return ImageListResponse(
             images=[_image_to_response(img) for img in images],
             total=len(images),
@@ -222,6 +224,13 @@ def update_image(
         if not image:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
 
+        # SDR-4437 HIGH-1: writes are owner-scoped (uploaded_by == caller).
+        if image.uploaded_by != _get_current_user():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have permission to modify this image",
+            )
+
         if request.tags is not None:
             image.tags = request.tags
         if request.description is not None:
@@ -249,7 +258,21 @@ def delete_image(image_id: int, db: Session = Depends(get_db)):
     """Soft-delete an image."""
     try:
         user = _get_current_user()
+        image = db.query(ImageAsset).filter(
+            ImageAsset.id == image_id,
+            ImageAsset.is_active == True,  # noqa: E712
+        ).first()
+        if not image:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+        # SDR-4437 HIGH-1: writes are owner-scoped (uploaded_by == caller).
+        if image.uploaded_by != user:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have permission to modify this image",
+            )
         image_service.delete_image(db, image_id, user)
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:

--- a/src/api/routes/profiles.py
+++ b/src/api/routes/profiles.py
@@ -7,8 +7,10 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from src.api.routes._authz import _check_deck_permission_for_session
 from src.api.schemas.agent_config import (
     AgentConfig,
+    GenieTool,
     resolve_agent_config,
     sanitize_agent_config_for_persist,
 )
@@ -17,6 +19,7 @@ from src.core.database import get_db_session
 from src.core.permission_context import get_permission_context
 from src.core.user_context import get_current_user
 from src.database.models.profile import ConfigProfile
+from src.database.models.profile_contributor import PermissionLevel
 from src.database.models.session import UserSession
 from src.services.permission_service import get_permission_service
 
@@ -222,6 +225,10 @@ async def save_from_session(session_id: str, body: SaveProfileRequest):
 @load_router.post("/{session_id}/load-profile/{profile_id}")
 async def load_profile_into_session(session_id: str, profile_id: int):
     """Copy a profile's agent_config into a session. Requires CAN_USE on the profile."""
+    # SDR-4437 HIGH-1 (found in plan verification): loading a profile writes
+    # session.agent_config into an arbitrary session_id — same write as the
+    # agent-config PUT, same gate: CAN_MANAGE on the session's deck.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_MANAGE)
     perm_service = get_permission_service()
     with get_db_session() as db:
         perm_service.require_use_profile(db, profile_id)

--- a/src/api/routes/sessions.py
+++ b/src/api/routes/sessions.py
@@ -13,13 +13,17 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from src.api.routes._authz import (
+    _check_deck_permission_for_session,
+    _require_session_access,
+)
 from src.api.schemas.requests import CreateSessionRequest, DuplicateSessionRequest
 from src.api.services.session_manager import (
     SessionAccessDeniedError,
@@ -47,105 +51,6 @@ class UpdateSessionRequest(BaseModel):
 
     title: Optional[str] = Field(None, description="Session/deck title")
     slide_count: Optional[int] = Field(None, ge=0, description="Deck slide count")
-
-
-def _get_session_permission(
-    session_info: dict,
-    db: Session,
-) -> Tuple[bool, Optional[PermissionLevel]]:
-    """Check user's permission on a session via deck_contributors.
-
-    Resolves to the root session (parent for contributor sessions) and checks
-    the DeckContributor table for the current user's permission level.
-
-    Args:
-        session_info: Session dict with id, created_by, parent_session_id, etc.
-        db: Database session
-
-    Returns:
-        Tuple of (has_access, permission_level)
-    """
-    perm_ctx = get_permission_context()
-    perm_service = get_permission_service()
-    parent_id = session_info.get("parent_session_internal_id")
-    root_session_id = parent_id if parent_id is not None else session_info.get("id")
-    perm = perm_service.get_deck_permission(
-        db, root_session_id,
-        user_id=perm_ctx.user_id if perm_ctx else None,
-        user_name=perm_ctx.user_name if perm_ctx else None,
-        group_ids=perm_ctx.group_ids if perm_ctx else None,
-    )
-    if perm is None:
-        return False, None
-    return True, perm
-
-
-def _require_session_access(
-    session_info: dict,
-    db: Session,
-    min_permission: PermissionLevel = PermissionLevel.CAN_VIEW,
-) -> PermissionLevel:
-    """Require user has at least the specified permission level on a session.
-    
-    Args:
-        session_info: Session dict with created_by and profile_id
-        db: Database session
-        min_permission: Minimum required permission (default: CAN_VIEW)
-        
-    Returns:
-        The user's actual permission level
-        
-    Raises:
-        HTTPException 403: If user doesn't have required permission
-    """
-    from src.services.permission_service import PERMISSION_PRIORITY
-
-    has_access, permission = _get_session_permission(session_info, db)
-    
-    if not has_access or permission is None:
-        raise HTTPException(
-            status_code=403,
-            detail="You don't have permission to access this session",
-        )
-    
-    if PERMISSION_PRIORITY[permission] < PERMISSION_PRIORITY[min_permission]:
-        raise HTTPException(
-            status_code=403,
-            detail=f"This action requires {min_permission.value} permission",
-        )
-    
-    return permission
-
-
-def _check_deck_permission_for_session(
-    session_id: str,
-    min_permission: PermissionLevel = PermissionLevel.CAN_VIEW,
-) -> None:
-    """Look up a session by string ID, resolve root, and enforce deck permission.
-
-    This is the standard pattern for endpoints that only have a session_id string
-    and need to gate on deck permissions.  It opens its own DB session via
-    ``get_db_session`` so it can be called from endpoints that do not already
-    have one.
-
-    Args:
-        session_id: The string session_id passed to the endpoint.
-        min_permission: Minimum required permission level.
-
-    Raises:
-        HTTPException 404: If the session does not exist (stale tab, deleted session, wrong ID).
-        HTTPException 403: If the caller lacks the required permission.
-    """
-    session_manager = get_session_manager()
-    try:
-        session_info = session_manager.get_session(session_id)
-    except SessionNotFoundError:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session not found: {session_id}",
-        ) from None
-    with get_db_session() as db:
-        _require_session_access(session_info, db, min_permission)
 
 
 def _substitute_deck_images(deck_dict: dict) -> None:

--- a/src/api/routes/settings/deck_prompts.py
+++ b/src/api/routes/settings/deck_prompts.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from src.api.routes._authz import require_admin
 from src.core.database import get_db
 from src.database.models import SlideDeckPromptLibrary
 
@@ -167,7 +168,8 @@ def get_deck_prompt(
         )
 
 
-@router.post("", response_model=DeckPromptResponse, status_code=status.HTTP_201_CREATED)
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.post("", response_model=DeckPromptResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_admin)])
 def create_deck_prompt(
     request: DeckPromptCreate,
     db: Session = Depends(get_db),
@@ -248,7 +250,8 @@ def create_deck_prompt(
         )
 
 
-@router.put("/{prompt_id}", response_model=DeckPromptResponse)
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.put("/{prompt_id}", response_model=DeckPromptResponse, dependencies=[Depends(require_admin)])
 def update_deck_prompt(
     prompt_id: int,
     request: DeckPromptUpdate,
@@ -341,7 +344,8 @@ def update_deck_prompt(
         )
 
 
-@router.delete("/{prompt_id}", status_code=status.HTTP_204_NO_CONTENT)
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.delete("/{prompt_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_admin)])
 def delete_deck_prompt(
     prompt_id: int,
     hard_delete: bool = False,

--- a/src/api/routes/settings/deck_prompts.py
+++ b/src/api/routes/settings/deck_prompts.py
@@ -200,12 +200,14 @@ def create_deck_prompt(
         if os.getenv("ENVIRONMENT") in ("development", "test"):
             user = "system"
         else:
-            try:
-                from src.core.databricks_client import get_user_client
-                client = get_user_client()
-                user = client.current_user.me().user_name
-            except Exception:
-                user = "system"
+            # HIGH-6 (SDR-4437): no except-Exception fallback — attribution
+            # must not silently degrade to "system"; a missing OBO client or
+            # empty user_name raises instead of storing a fallback identity.
+            from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+            user = get_user_client().current_user.me().user_name
+            if not user:
+                raise UserClientRequiredError("OBO client resolved no user_name")
         
         prompt = SlideDeckPromptLibrary(
             name=request.name,
@@ -301,12 +303,15 @@ def update_deck_prompt(
         if os.getenv("ENVIRONMENT") in ("development", "test"):
             prompt.updated_by = "system"
         else:
-            try:
-                from src.core.databricks_client import get_user_client
-                client = get_user_client()
-                prompt.updated_by = client.current_user.me().user_name
-            except Exception:
-                prompt.updated_by = "system"
+            # HIGH-6 (SDR-4437): no except-Exception fallback — attribution
+            # must not silently degrade to "system"; a missing OBO client or
+            # empty user_name raises instead of storing a fallback identity.
+            from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+            user_name = get_user_client().current_user.me().user_name
+            if not user_name:
+                raise UserClientRequiredError("OBO client resolved no user_name")
+            prompt.updated_by = user_name
         
         db.commit()
         db.refresh(prompt)
@@ -372,12 +377,15 @@ def delete_deck_prompt(
             if os.getenv("ENVIRONMENT") in ("development", "test"):
                 prompt.updated_by = "system"
             else:
-                try:
-                    from src.core.databricks_client import get_user_client
-                    client = get_user_client()
-                    prompt.updated_by = client.current_user.me().user_name
-                except Exception:
-                    prompt.updated_by = "system"
+                # HIGH-6 (SDR-4437): no except-Exception fallback — attribution
+                # must not silently degrade to "system"; a missing OBO client or
+                # empty user_name raises instead of storing a fallback identity.
+                from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+                user_name = get_user_client().current_user.me().user_name
+                if not user_name:
+                    raise UserClientRequiredError("OBO client resolved no user_name")
+                prompt.updated_by = user_name
             logger.info(f"Soft deleted deck prompt: {prompt.name} (id={prompt.id})")
         
         db.commit()

--- a/src/api/routes/settings/slide_styles.py
+++ b/src/api/routes/settings/slide_styles.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from src.api.routes._authz import require_admin
 from src.core.database import get_db, get_db_session
 from src.database.models import SlideStyleLibrary
 
@@ -178,7 +179,8 @@ def get_slide_style(
         )
 
 
-@router.post("", response_model=SlideStyleResponse, status_code=status.HTTP_201_CREATED)
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.post("", response_model=SlideStyleResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_admin)])
 def create_slide_style(
     request: SlideStyleCreate,
     db: Session = Depends(get_db),
@@ -263,7 +265,8 @@ def create_slide_style(
         )
 
 
-@router.put("/{style_id}", response_model=SlideStyleResponse)
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.put("/{style_id}", response_model=SlideStyleResponse, dependencies=[Depends(require_admin)])
 def update_slide_style(
     style_id: int,
     request: SlideStyleUpdate,
@@ -368,7 +371,8 @@ def update_slide_style(
         )
 
 
-@router.delete("/{style_id}", status_code=status.HTTP_204_NO_CONTENT)
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.delete("/{style_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_admin)])
 def delete_slide_style(
     style_id: int,
     hard_delete: bool = False,
@@ -445,7 +449,8 @@ def delete_slide_style(
         )
 
 
-@router.post("/{style_id}/set-default", response_model=SlideStyleResponse)
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.post("/{style_id}/set-default", response_model=SlideStyleResponse, dependencies=[Depends(require_admin)])
 def set_default_slide_style(style_id: int):
     """Set a slide style as the system-wide default.
 

--- a/src/api/routes/settings/slide_styles.py
+++ b/src/api/routes/settings/slide_styles.py
@@ -211,12 +211,14 @@ def create_slide_style(
         if os.getenv("ENVIRONMENT") in ("development", "test"):
             user = "system"
         else:
-            try:
-                from src.core.databricks_client import get_user_client
-                client = get_user_client()
-                user = client.current_user.me().user_name
-            except Exception:
-                user = "system"
+            # HIGH-6 (SDR-4437): no except-Exception fallback — attribution
+            # must not silently degrade to "system"; a missing OBO client or
+            # empty user_name raises instead of storing a fallback identity.
+            from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+            user = get_user_client().current_user.me().user_name
+            if not user:
+                raise UserClientRequiredError("OBO client resolved no user_name")
         
         style = SlideStyleLibrary(
             name=request.name,
@@ -325,12 +327,15 @@ def update_slide_style(
         if os.getenv("ENVIRONMENT") in ("development", "test"):
             style.updated_by = "system"
         else:
-            try:
-                from src.core.databricks_client import get_user_client
-                client = get_user_client()
-                style.updated_by = client.current_user.me().user_name
-            except Exception:
-                style.updated_by = "system"
+            # HIGH-6 (SDR-4437): no except-Exception fallback — attribution
+            # must not silently degrade to "system"; a missing OBO client or
+            # empty user_name raises instead of storing a fallback identity.
+            from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+            user_name = get_user_client().current_user.me().user_name
+            if not user_name:
+                raise UserClientRequiredError("OBO client resolved no user_name")
+            style.updated_by = user_name
         
         db.commit()
         db.refresh(style)
@@ -417,12 +422,15 @@ def delete_slide_style(
             if os.getenv("ENVIRONMENT") in ("development", "test"):
                 style.updated_by = "system"
             else:
-                try:
-                    from src.core.databricks_client import get_user_client
-                    client = get_user_client()
-                    style.updated_by = client.current_user.me().user_name
-                except Exception:
-                    style.updated_by = "system"
+                # HIGH-6 (SDR-4437): no except-Exception fallback — attribution
+                # must not silently degrade to "system"; a missing OBO client or
+                # empty user_name raises instead of storing a fallback identity.
+                from src.core.databricks_client import UserClientRequiredError, get_user_client
+
+                user_name = get_user_client().current_user.me().user_name
+                if not user_name:
+                    raise UserClientRequiredError("OBO client resolved no user_name")
+                style.updated_by = user_name
             logger.info(f"Soft deleted slide style: {style.name} (id={style.id})")
         
         db.commit()

--- a/src/api/routes/slides.py
+++ b/src/api/routes/slides.py
@@ -11,98 +11,27 @@ Slide access is controlled by session permissions:
 
 import asyncio
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from src.api.routes._authz import (
+    _check_deck_permission_for_session,  # noqa: F401 — no caller until Task 10; its red test patches this symbol
+    _require_slide_permission,
+)
 from src.api.services.chat_service import get_chat_service
-from src.api.services.session_manager import SessionNotFoundError, VersionConflictError, get_session_manager
+from src.api.services.session_manager import VersionConflictError, get_session_manager
 from src.core.context_utils import run_in_thread_with_context
 from src.core.database import get_db
-from src.core.permission_context import get_permission_context
-from src.core.user_context import get_current_user
+from src.core.permission_context import get_permission_context  # noqa: F401 — patched by integration-test fixtures
+from src.core.user_context import get_current_user  # noqa: F401 — patched by integration-test fixtures
 from src.database.models.profile_contributor import PermissionLevel
-from src.services.permission_service import get_permission_service, PERMISSION_PRIORITY
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/slides", tags=["slides"])
-
-
-def _get_session_permission(
-    session_id: str,
-    db: Session,
-) -> Tuple[bool, Optional[PermissionLevel]]:
-    """Check if current user has access to a session's slides via deck_contributors.
-
-    Resolves to the root session (parent for contributor sessions) and checks
-    the DeckContributor table for the current user's permission level.
-
-    Args:
-        session_id: Session identifier (string)
-        db: Database session
-
-    Returns:
-        Tuple of (has_access, permission_level)
-    """
-    session_manager = get_session_manager()
-    ctx = get_permission_context()
-
-    try:
-        session_info = session_manager.get_session(session_id)
-    except SessionNotFoundError:
-        return False, None
-
-    perm_service = get_permission_service()
-    parent_internal_id = session_info.get("parent_session_internal_id")
-    root_session_id = parent_internal_id if parent_internal_id is not None else session_info.get("id")
-
-    perm = perm_service.get_deck_permission(
-        db, root_session_id,
-        user_id=ctx.user_id if ctx else None,
-        user_name=ctx.user_name if ctx else None,
-        group_ids=ctx.group_ids if ctx else None,
-    )
-    if perm is None:
-        return False, None
-    return True, perm
-
-
-def _require_slide_permission(
-    session_id: str,
-    db: Session,
-    min_permission: PermissionLevel = PermissionLevel.CAN_VIEW,
-) -> PermissionLevel:
-    """Require user has at least the specified permission level on slides.
-    
-    Args:
-        session_id: Session identifier
-        db: Database session
-        min_permission: Minimum required permission (default: CAN_VIEW)
-        
-    Returns:
-        The user's actual permission level
-        
-    Raises:
-        HTTPException 403: If user doesn't have required permission
-    """
-    has_access, permission = _get_session_permission(session_id, db)
-    
-    if not has_access or permission is None:
-        raise HTTPException(
-            status_code=403,
-            detail="You don't have permission to access these slides",
-        )
-    
-    if PERMISSION_PRIORITY[permission] < PERMISSION_PRIORITY[min_permission]:
-        raise HTTPException(
-            status_code=403,
-            detail=f"This action requires {min_permission.value} permission",
-        )
-    
-    return permission
 
 
 class ReorderRequest(BaseModel):

--- a/src/api/routes/slides.py
+++ b/src/api/routes/slides.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from src.api.routes._authz import (
-    _check_deck_permission_for_session,  # noqa: F401 — no caller until Task 10; its red test patches this symbol
+    _check_deck_permission_for_session,
     _require_slide_permission,
 )
 from src.api.services.chat_service import get_chat_service
@@ -407,8 +407,11 @@ async def update_slide_verification(index: int, request: UpdateVerificationReque
     Raises:
         HTTPException: 400 for validation errors, 404 if slide not found, 500 on error
     """
+    # SDR-4437 HIGH-1: version/verification writes require CAN_EDIT.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_EDIT)
+
     from src.utils.slide_hash import compute_slide_hash
-    
+
     session_manager = get_session_manager()
 
     try:
@@ -517,6 +520,9 @@ async def create_version(request: CreateVersionRequest):
     Raises:
         HTTPException: 400 if no deck exists, 500 on error
     """
+    # SDR-4437 HIGH-1: version/verification writes require CAN_EDIT.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_EDIT)
+
     try:
         chat_service = get_chat_service()
         version_info = await asyncio.to_thread(
@@ -564,6 +570,9 @@ async def update_version_verification(
     Raises:
         HTTPException: 400 if version not found, 500 on error
     """
+    # SDR-4437 HIGH-1: version/verification writes require CAN_EDIT.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_EDIT)
+
     try:
         session_manager = get_session_manager()
         result = await asyncio.to_thread(
@@ -609,6 +618,9 @@ async def sync_latest_version_verification(request: SyncVerificationRequest):
     Returns:
         Updated version info, or empty dict if no versions exist
     """
+    # SDR-4437 HIGH-1: version/verification writes require CAN_EDIT.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_EDIT)
+
     try:
         session_manager = get_session_manager()
 
@@ -667,6 +679,9 @@ async def list_versions(session_id: str = Query(..., description="Session ID")):
     Raises:
         HTTPException: 404 if session not found, 500 on error
     """
+    # SDR-4437 HIGH-1: version reads require CAN_VIEW.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_VIEW)
+
     session_manager = get_session_manager()
 
     try:
@@ -686,6 +701,43 @@ async def list_versions(session_id: str = Query(..., description="Session ID")):
         return {"versions": [], "current_version": None}
     except Exception as e:
         logger.error(f"Failed to list versions: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# NOTE: must be registered BEFORE the parameterized "/versions/{version_number}"
+# route below — otherwise "current" matches {version_number}, fails int parsing,
+# and the request 422s before this handler (and its permission gate) ever runs.
+@router.get("/versions/current")
+async def get_current_version(session_id: str = Query(..., description="Session ID")):
+    """Get the current (latest) version number.
+
+    Args:
+        session_id: Session identifier
+
+    Returns:
+        Current version number or null if no versions exist
+
+    Raises:
+        HTTPException: 500 on error
+    """
+    # SDR-4437 HIGH-1: version reads require CAN_VIEW.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_VIEW)
+
+    session_manager = get_session_manager()
+
+    try:
+        version_number = await asyncio.to_thread(
+            session_manager.get_current_version_number,
+            session_id,
+        )
+
+        return {"current_version": version_number}
+
+    except SessionNotFoundError:
+        # Session hasn't been persisted yet (local UUID) - no versions
+        return {"current_version": None}
+    except Exception as e:
+        logger.error(f"Failed to get current version: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -709,6 +761,9 @@ async def preview_version(
     Raises:
         HTTPException: 404 if version not found, 500 on error
     """
+    # SDR-4437 HIGH-1: version reads require CAN_VIEW.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_VIEW)
+
     session_manager = get_session_manager()
 
     try:
@@ -758,6 +813,9 @@ async def restore_version(version_number: int, request: RestoreVersionRequest):
     Raises:
         HTTPException: 400 if version not found, 409 if session busy, 500 on error
     """
+    # SDR-4437 HIGH-1: restore is destructive (deletes newer versions) — CAN_MANAGE.
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_MANAGE)
+
     session_manager = get_session_manager()
 
     locked = await asyncio.to_thread(
@@ -809,32 +867,3 @@ async def restore_version(version_number: int, request: RestoreVersionRequest):
         )
 
 
-@router.get("/versions/current")
-async def get_current_version(session_id: str = Query(..., description="Session ID")):
-    """Get the current (latest) version number.
-
-    Args:
-        session_id: Session identifier
-
-    Returns:
-        Current version number or null if no versions exist
-
-    Raises:
-        HTTPException: 500 on error
-    """
-    session_manager = get_session_manager()
-
-    try:
-        version_number = await asyncio.to_thread(
-            session_manager.get_current_version_number,
-            session_id,
-        )
-
-        return {"current_version": version_number}
-
-    except SessionNotFoundError:
-        # Session hasn't been persisted yet (local UUID) - no versions
-        return {"current_version": None}
-    except Exception as e:
-        logger.error(f"Failed to get current version: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))

--- a/src/api/routes/tour.py
+++ b/src/api/routes/tour.py
@@ -17,8 +17,10 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 
+from src.api.routes._authz import _check_deck_permission_for_session
 from src.api.services.session_manager import get_session_manager
 from src.core.user_context import get_current_user
+from src.database.models.profile_contributor import PermissionLevel
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +117,8 @@ async def create_demo_deck():
 @router.post("/demo-deck/{session_id}/slides")
 async def add_demo_slides(session_id: str):
     """Phase 2: add assistant reply and pre-built slides."""
+    # SDR-4437 HIGH-1 class: writes slides into an arbitrary session_id.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_EDIT)
     current_user = get_current_user()
     try:
         result = await asyncio.to_thread(_phase2_add_slides, session_id, current_user)

--- a/src/api/routes/verification.py
+++ b/src/api/routes/verification.py
@@ -11,8 +11,10 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
+from src.api.routes._authz import _check_deck_permission_for_session
 from src.api.services.session_manager import SessionNotFoundError, get_session_manager
 from src.core.settings_db import get_settings
+from src.database.models.profile_contributor import PermissionLevel
 from src.services.evaluation import evaluate_with_judge
 
 logger = logging.getLogger(__name__)
@@ -97,6 +99,10 @@ async def verify_slide(slide_index: int, request: VerifySlideRequest):
     Raises:
         HTTPException: 404 if session/slide not found, 500 on error
     """
+    # SDR-4437 HIGH-1: verification writes state and bills an LLM-judge run —
+    # requires CAN_EDIT (viewers can no longer trigger runs / file feedback).
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_EDIT)
+
     from src.utils.slide_hash import compute_slide_hash
 
     session_manager = get_session_manager()
@@ -286,6 +292,10 @@ async def submit_feedback(slide_index: int, request: FeedbackRequest):
     Returns:
         Confirmation of feedback submission with trace linkage info
     """
+    # SDR-4437 HIGH-1: verification writes state and bills an LLM-judge run —
+    # requires CAN_EDIT (viewers can no longer trigger runs / file feedback).
+    _check_deck_permission_for_session(request.session_id, PermissionLevel.CAN_EDIT)
+
     import mlflow
     from mlflow.entities import AssessmentSource, AssessmentSourceType
 
@@ -406,6 +416,9 @@ async def get_genie_link(
     Returns:
         Genie conversation URL and metadata
     """
+    # SDR-4437 HIGH-1: read — requires CAN_VIEW on the deck.
+    _check_deck_permission_for_session(session_id, PermissionLevel.CAN_VIEW)
+
     import re
 
     from src.api.schemas.agent_config import GenieTool, resolve_agent_config

--- a/src/core/databricks_client.py
+++ b/src/core/databricks_client.py
@@ -489,26 +489,53 @@ def set_user_client(client: Optional[WorkspaceClient]) -> None:
     _user_client_var.set(client)
 
 
+class UserClientRequiredError(RuntimeError):
+    """A user-scoped operation ran without a bound per-request OBO client.
+
+    Raised in production when the request-scoped ContextVar holds no user
+    client — either the auth middleware failed to build one (missing or
+    invalid x-forwarded-access-token) or the caller is running on a thread
+    spawned without contextvars.copy_context(). Threads MUST be spawned via
+    copy_context() / src.core.context_utils / asyncio.to_thread for the user
+    client to resolve here (the chat agent and title-gen threads already do:
+    chat_service.py:1041, 1102). Mapped to HTTP 401 by main.py.
+    """
+
+
 def get_user_client() -> WorkspaceClient:
     """
     Get the user-scoped WorkspaceClient for Genie queries and tool operations.
 
-    Returns the request-scoped user client if available (set by middleware),
-    otherwise falls back to the system client (for local development).
+    Returns the request-scoped user client set by the auth middleware.
+
+    HIGH-6 (SDR-4437): in production this fails closed when no user client is
+    bound — the old behaviour silently fell back to the SP system client,
+    which also made downstream ``uploaded_by == caller`` ownership checks
+    compare against the fallback identity. The SP fallback is now restricted
+    to non-production (local dev/test).
 
     Returns:
         WorkspaceClient for user operations
+
+    Raises:
+        UserClientRequiredError: production, and no user client is bound.
     """
     client = _user_client_var.get()
     if client is not None:
         logger.warning("get_user_client: returning user-scoped client from ContextVar")
         return client
 
-    # Fallback to system client for local development
-    logger.warning(
-        "get_user_client: ContextVar empty, falling back to system client"
+    if os.getenv("ENVIRONMENT", "development") != "production":
+        # Fallback to system client for local development only
+        logger.warning(
+            "get_user_client: ContextVar empty, falling back to system client "
+            "(non-production only)"
+        )
+        return get_system_client()
+
+    raise UserClientRequiredError(
+        "No user-scoped Databricks client is bound to this request context"
     )
-    return get_system_client()
 
 
 def reset_user_client() -> None:

--- a/tests/integration/test_api_routes.py
+++ b/tests/integration/test_api_routes.py
@@ -109,13 +109,17 @@ def mock_session_manager(test_db):
          patch("src.api.routes.slides.get_session_manager") as mock_slides, \
          patch("src.api.routes.sessions.get_session_manager") as mock_sessions, \
          patch("src.api.routes.verification.get_session_manager") as mock_verify, \
+         patch("src.api.routes._authz.get_session_manager") as mock_authz, \
          patch("src.api.routes.chat.get_current_user", return_value="test@local.dev"), \
          patch("src.api.routes.slides.get_current_user", return_value="test@local.dev"), \
          patch("src.api.routes.sessions.get_current_user", return_value="test@local.dev"), \
+         patch("src.api.routes._authz.get_current_user", return_value="test@local.dev"), \
          patch("src.api.routes.chat.get_permission_context", return_value=perm_ctx), \
          patch("src.api.routes.slides.get_permission_context", return_value=perm_ctx), \
          patch("src.api.routes.sessions.get_permission_context", return_value=perm_ctx), \
-         patch("src.api.routes.sessions.get_db_session", _fake_db_session):
+         patch("src.api.routes._authz.get_permission_context", return_value=perm_ctx), \
+         patch("src.api.routes.sessions.get_db_session", _fake_db_session), \
+         patch("src.api.routes._authz.get_db_session", _fake_db_session):
 
         manager = MagicMock()
         manager.acquire_session_lock.return_value = True
@@ -132,6 +136,7 @@ def mock_session_manager(test_db):
         mock_slides.return_value = manager
         mock_sessions.return_value = manager
         mock_verify.return_value = manager
+        mock_authz.return_value = manager
         yield manager
 
 

--- a/tests/integration/test_api_routes.py
+++ b/tests/integration/test_api_routes.py
@@ -1015,6 +1015,17 @@ class TestSessionEndpoints:
 class TestVerificationEndpoints:
     """Tests for /api/verification endpoints."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_deck_gate(self, monkeypatch):
+        # SDR-4437 PR-2 (Task 7): verification writes/genie-link now require
+        # deck permission. These pre-existing tests mock get_session with a
+        # minimal dict (no id/created_by), so the gate can't resolve a grant —
+        # no-op it here; enforcement is covered by test_authz_verification.py.
+        monkeypatch.setattr(
+            "src.api.routes.verification._check_deck_permission_for_session",
+            lambda *a, **k: None,
+        )
+
     def test_verify_slide_success(self, client, mock_session_manager):
         """POST /api/verification/{index} triggers verification."""
         mock_session_manager.get_session.return_value = {

--- a/tests/integration/test_export.py
+++ b/tests/integration/test_export.py
@@ -67,6 +67,22 @@ def create_mock_slide_deck(slide_count: int, with_charts: bool = False) -> dict:
 # =============================================================================
 
 
+@pytest.fixture(autouse=True)
+def _bypass_deck_gate(monkeypatch):
+    # SDR-4437 PR-2 (Task 5): export session/job endpoints now require deck
+    # permission. These pre-existing export tests exercise the conversion
+    # layer with an unfixtured session_id, so no-op both gates here — never
+    # weaken them; their enforcement is covered by test_authz_export.py.
+    monkeypatch.setattr(
+        "src.api.routes.export._check_deck_permission_for_session",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "src.api.routes.export._require_export_job_access",
+        lambda *a, **k: None,
+    )
+
+
 @pytest.fixture
 def client():
     """Create test client."""

--- a/tests/unit/test_agent_config_routes.py
+++ b/tests/unit/test_agent_config_routes.py
@@ -7,10 +7,16 @@ from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
     """Create a test client with mocked dependencies."""
     from src.api.main import app
 
+    # SDR-4437 PR-2: these tests exercise route behaviour, not authz — no-op the
+    # deck-permission gate (gate behaviour is covered in test_authz_agent_config.py).
+    monkeypatch.setattr(
+        "src.api.routes.agent_config._check_deck_permission_for_session",
+        lambda *a, **k: None,
+    )
     return TestClient(app)
 
 

--- a/tests/unit/test_authz_admin_feedback.py
+++ b/tests/unit/test_authz_admin_feedback.py
@@ -1,0 +1,79 @@
+"""Admin gating tests for admin.py, admin_usage.py, feedback.py reads (SDR-4437)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def production(monkeypatch):
+    from src.api.routes import _authz
+
+    monkeypatch.setattr(_authz, "_is_production", lambda: True)
+    monkeypatch.setattr(_authz, "get_current_user", lambda: "user@test.com")
+    _authz.reset_admin_cache()
+    yield _authz
+    _authz.reset_admin_cache()
+
+
+@pytest.fixture
+def non_admin(production, monkeypatch):
+    monkeypatch.setattr(production, "_admin_acl_probe", lambda user: False)
+
+
+@pytest.fixture
+def admin(production, monkeypatch):
+    monkeypatch.setattr(production, "_admin_acl_probe", lambda user: True)
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("GET", "/api/admin/judge-backend"),
+        ("PUT", "/api/admin/judge-backend"),
+        ("POST", "/api/admin/google-credentials"),
+        ("GET", "/api/admin/google-credentials/status"),
+        ("DELETE", "/api/admin/google-credentials"),
+        ("GET", "/api/admin/usage/summary"),
+        ("GET", "/api/admin/usage/daily"),
+        ("GET", "/api/admin/usage/top-users"),
+        ("GET", "/api/admin/usage/funnel"),
+        ("GET", "/api/admin/usage/retention"),
+        ("GET", "/api/admin/usage/heatmap"),
+        ("GET", "/api/feedback/report/stats"),
+        ("GET", "/api/feedback/list"),
+        ("GET", "/api/feedback/report/summary"),
+    ],
+)
+def test_admin_surface_403_for_non_admin(client, non_admin, method, path):
+    resp = client.request(method, path)
+    assert resp.status_code == 403
+
+
+def test_feedback_writes_stay_open_for_non_admin(client, non_admin):
+    with patch("src.api.routes.feedback.FeedbackService") as svc:
+        svc.return_value.chat.return_value = {"content": "ok", "summary_ready": False}
+        resp = client.post(
+            "/api/feedback/chat",
+            json={"messages": [{"role": "user", "content": "hello"}]},
+        )
+    assert resp.status_code == 200
+
+
+def test_feedback_list_passes_gate_for_admin(client, admin):
+    resp = client.get("/api/feedback/list")
+    assert resp.status_code != 403
+
+
+def test_admin_routes_bypass_in_dev(client):
+    """conftest sets ENVIRONMENT=test -> require_admin bypasses (dev parity)."""
+    resp = client.get("/api/feedback/list")
+    assert resp.status_code != 403

--- a/tests/unit/test_authz_agent_config.py
+++ b/tests/unit/test_authz_agent_config.py
@@ -1,0 +1,67 @@
+"""Agent-config + load-profile gating tests (SDR-4437 PR-2)."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from src.database.models.profile_contributor import PermissionLevel
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _gate_into(calls):
+    def gate(session_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((session_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    return gate
+
+
+@pytest.fixture
+def agent_config_gate(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "src.api.routes.agent_config._check_deck_permission_for_session",
+        _gate_into(calls),
+    )
+    return calls
+
+
+def test_get_agent_config_requires_can_view(client, agent_config_gate):
+    resp = client.get("/api/sessions/s1/agent-config")
+    assert resp.status_code == 403
+    assert agent_config_gate == [("s1", PermissionLevel.CAN_VIEW)]
+
+
+def test_put_agent_config_requires_can_manage(client, agent_config_gate):
+    resp = client.put("/api/sessions/s1/agent-config", json={})
+    assert resp.status_code == 403
+    assert agent_config_gate == [("s1", PermissionLevel.CAN_MANAGE)]
+
+
+def test_patch_tools_requires_can_manage(client, agent_config_gate):
+    resp = client.patch(
+        "/api/sessions/s1/agent-config/tools",
+        json={
+            "action": "add",
+            "tool": {"type": "genie", "space_id": "sp", "space_name": "nm"},
+        },
+    )
+    assert resp.status_code == 403
+    assert agent_config_gate == [("s1", PermissionLevel.CAN_MANAGE)]
+
+
+def test_load_profile_requires_can_manage_on_session(client, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "src.api.routes.profiles._check_deck_permission_for_session",
+        _gate_into(calls),
+    )
+    resp = client.post("/api/sessions/s1/load-profile/7")
+    assert resp.status_code == 403
+    assert calls == [("s1", PermissionLevel.CAN_MANAGE)]

--- a/tests/unit/test_authz_chat_poll.py
+++ b/tests/unit/test_authz_chat_poll.py
@@ -1,0 +1,65 @@
+"""Chat-poll IDOR gate (SDR-4437 PR-2)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from src.database.models.profile_contributor import PermissionLevel
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def session_manager(monkeypatch):
+    mgr = MagicMock()
+    monkeypatch.setattr("src.api.routes.chat.get_session_manager", lambda: mgr)
+    return mgr
+
+
+def test_poll_stranger_with_leaked_request_id_403(client, session_manager, monkeypatch):
+    session_manager.get_session_id_for_request.return_value = "sess-1"
+    calls = []
+
+    def gate(session_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((session_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.chat._check_deck_permission_for_session", gate
+    )
+    resp = client.get("/api/chat/poll/req-leaked")
+    assert resp.status_code == 403
+    assert calls == [("sess-1", PermissionLevel.CAN_VIEW)]
+    session_manager.get_chat_request.assert_not_called()  # gate before data access
+
+
+def test_poll_unknown_request_404(client, session_manager, monkeypatch):
+    session_manager.get_session_id_for_request.return_value = None
+    monkeypatch.setattr(
+        "src.api.routes.chat._check_deck_permission_for_session",
+        MagicMock(),
+    )
+    resp = client.get("/api/chat/poll/req-unknown")
+    assert resp.status_code == 404
+
+
+def test_poll_authorized_proceeds(client, session_manager, monkeypatch):
+    session_manager.get_session_id_for_request.return_value = "sess-1"
+    session_manager.get_chat_request.return_value = {
+        "status": "completed", "result": {"ok": True}, "error_message": None,
+    }
+    session_manager.get_messages_for_request.return_value = []
+    monkeypatch.setattr(
+        "src.api.routes.chat._check_deck_permission_for_session",
+        MagicMock(),
+    )
+    resp = client.get("/api/chat/poll/req-1")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "completed"

--- a/tests/unit/test_authz_export.py
+++ b/tests/unit/test_authz_export.py
@@ -1,0 +1,164 @@
+"""Authorization gating tests for export.py (SDR-4437 PR-2)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from src.database.models.profile_contributor import PermissionLevel
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def deck_gate(monkeypatch):
+    """Recording denier for the deck-permission gate."""
+    calls = []
+
+    def gate(session_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((session_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.export._check_deck_permission_for_session", gate
+    )
+    return calls
+
+
+@pytest.fixture
+def job_gate(monkeypatch):
+    calls = []
+
+    def gate(job_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((job_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.export._require_export_job_access", gate
+    )
+    return calls
+
+
+def test_export_pptx_gated_can_view(client, deck_gate, monkeypatch):
+    svc = MagicMock()
+    monkeypatch.setattr(
+        "src.api.routes.export.get_chat_service", lambda: svc
+    )
+    resp = client.post("/api/export/pptx", json={"session_id": "s1"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s1", PermissionLevel.CAN_VIEW)]
+    svc.get_slides.assert_not_called()  # gate fires before deck access
+
+
+def test_export_pptx_async_gated_can_view(client, deck_gate):
+    resp = client.post("/api/export/pptx/async", json={"session_id": "s2"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s2", PermissionLevel.CAN_VIEW)]
+
+
+def test_export_pptx_editable_gated_can_view(client, deck_gate):
+    resp = client.post("/api/export/pptx/editable", json={"session_id": "s3"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s3", PermissionLevel.CAN_VIEW)]
+
+
+def test_export_huashu_from_html_gated_can_view(client, deck_gate):
+    resp = client.post(
+        "/api/export/pptx/editable/huashu/from-html", json={"session_id": "s4"}
+    )
+    assert resp.status_code == 403
+    assert deck_gate == [("s4", PermissionLevel.CAN_VIEW)]
+
+
+def test_from_records_gated_when_session_id_present(client, deck_gate):
+    resp = client.post(
+        "/api/export/pptx/editable/from-records",
+        json={"session_id": "s5", "slides": []},
+    )
+    assert resp.status_code == 403
+    assert deck_gate == [("s5", PermissionLevel.CAN_VIEW)]
+
+
+def test_from_records_open_without_session_id(client, deck_gate):
+    # Downstream conversion may 4xx/5xx in this harness; the assertions that
+    # matter are: no 403 from the gate, and the gate was never invoked.
+    resp = client.post(
+        "/api/export/pptx/editable/from-records", json={"slides": []}
+    )
+    assert resp.status_code != 403
+    assert deck_gate == []
+
+
+def test_from_images_gated_when_session_id_present(client, deck_gate):
+    resp = client.post(
+        "/api/export/pptx/editable/from-images",
+        json={"session_id": "s6", "images": []},
+    )
+    assert resp.status_code == 403
+    assert deck_gate == [("s6", PermissionLevel.CAN_VIEW)]
+
+
+def test_poll_pptx_export_gated_by_job(client, job_gate):
+    resp = client.get("/api/export/pptx/poll/job-1")
+    assert resp.status_code == 403
+    assert job_gate == [("job-1", PermissionLevel.CAN_VIEW)]
+
+
+def test_download_pptx_export_gated_by_job(client, job_gate):
+    resp = client.get("/api/export/pptx/download/job-1")
+    assert resp.status_code == 403
+    assert job_gate == [("job-1", PermissionLevel.CAN_VIEW)]
+
+
+def test_editable_available_stays_open(client, deck_gate):
+    resp = client.get("/api/export/pptx/editable/available")
+    assert resp.status_code == 200
+    assert deck_gate == []
+
+
+# --- MEDIUM-1: huashu diagnostics ------------------------------------------
+
+
+@pytest.fixture
+def production_non_admin(monkeypatch):
+    from src.api.routes import _authz
+
+    monkeypatch.setattr(_authz, "_is_production", lambda: True)
+    monkeypatch.setattr(_authz, "get_current_user", lambda: "user@test.com")
+    monkeypatch.setattr(_authz, "_admin_acl_probe", lambda user: False)
+    _authz.reset_admin_cache()
+    yield
+    _authz.reset_admin_cache()
+
+
+def test_huashu_available_requires_admin(client, production_non_admin):
+    assert client.get("/api/export/pptx/editable/huashu/available").status_code == 403
+
+
+def test_huashu_install_chromium_requires_admin(client, production_non_admin):
+    assert client.post("/api/export/pptx/editable/huashu/install-chromium").status_code == 403
+
+
+def test_huashu_probe_launch_requires_admin(client, production_non_admin):
+    assert client.post("/api/export/pptx/editable/huashu/probe-launch").status_code == 403
+
+
+def test_huashu_available_response_is_slim(client):
+    """MEDIUM-1: no env/filesystem/log detail in the response body."""
+    resp = client.get("/api/export/pptx/editable/huashu/available")
+    assert resp.status_code == 200
+    body = resp.json()
+    leak_keys = {
+        "home", "sidecar_dir", "chromium_cache_paths", "cache_root_listing",
+        "setup_log_tail", "setup_log_size", "setup_log_path_exists",
+        "tmp_listing", "playwright_dir_listing", "playwright_core_dir_listing",
+        "playwright_browsers_path_env", "environment", "databricks_app_name",
+    }
+    assert not leak_keys & set(body.get("checks", {}).keys())
+    assert "available" in body

--- a/tests/unit/test_authz_google_slides.py
+++ b/tests/unit/test_authz_google_slides.py
@@ -1,0 +1,66 @@
+"""Authorization gating tests for google_slides.py (SDR-4437 PR-2)."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from src.database.models.profile_contributor import PermissionLevel
+
+BASE = "/api/export/google-slides"
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def deck_gate(monkeypatch):
+    calls = []
+
+    def gate(session_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((session_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.google_slides._check_deck_permission_for_session", gate
+    )
+    return calls
+
+
+def test_export_gated_can_view(client, deck_gate):
+    resp = client.post(BASE, json={"session_id": "s1"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s1", PermissionLevel.CAN_VIEW)]
+
+
+def test_from_records_gated_can_view(client, deck_gate):
+    resp = client.post(
+        f"{BASE}/from-records",
+        json={"session_id": "s2", "title": "t", "slides": []},
+    )
+    assert resp.status_code == 403
+    assert deck_gate == [("s2", PermissionLevel.CAN_VIEW)]
+
+
+def test_from_huashu_gated_can_view(client, deck_gate):
+    resp = client.post(f"{BASE}/from-huashu", json={"session_id": "s3"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s3", PermissionLevel.CAN_VIEW)]
+
+
+def test_poll_gated_by_job(client, monkeypatch):
+    calls = []
+
+    def gate(job_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((job_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.google_slides._require_export_job_access", gate
+    )
+    resp = client.get(f"{BASE}/poll/job-9")
+    assert resp.status_code == 403
+    assert calls == [("job-9", PermissionLevel.CAN_VIEW)]

--- a/tests/unit/test_authz_helpers.py
+++ b/tests/unit/test_authz_helpers.py
@@ -1,0 +1,204 @@
+"""Tests for src/api/routes/_authz.py (SDR-4437 PR-2 serial gate)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# Consolidation: helpers importable from _authz with preserved signatures
+# ---------------------------------------------------------------------------
+
+
+def test_helpers_importable_from_authz():
+    from src.api.routes._authz import (  # noqa: F401
+        _check_deck_permission_for_session,
+        _require_export_job_access,
+        _require_session_access,
+        _require_slide_permission,
+        require_admin,
+        reset_admin_cache,
+    )
+
+
+def test_sessions_and_slides_reexport_helpers():
+    """Existing call sites in sessions.py / slides.py keep working."""
+    from src.api.routes import sessions, slides
+    from src.api.routes import _authz
+
+    assert sessions._check_deck_permission_for_session is _authz._check_deck_permission_for_session
+    assert sessions._require_session_access is _authz._require_session_access
+    assert slides._require_slide_permission is _authz._require_slide_permission
+
+
+def test_check_deck_permission_signature_defaults():
+    import inspect
+
+    from src.api.routes._authz import _check_deck_permission_for_session
+    from src.database.models.profile_contributor import PermissionLevel
+
+    sig = inspect.signature(_check_deck_permission_for_session)
+    params = list(sig.parameters.values())
+    assert params[0].name == "session_id"
+    assert params[1].name == "min_permission"
+    assert params[1].default == PermissionLevel.CAN_VIEW
+
+
+# ---------------------------------------------------------------------------
+# _require_export_job_access
+# ---------------------------------------------------------------------------
+
+
+def test_export_job_access_unknown_job_404(monkeypatch):
+    from src.api.routes import _authz
+
+    class _EmptyQuery:
+        def filter(self, *a, **kw):
+            return self
+
+        def first(self):
+            return None
+
+    class _FakeDB:
+        def query(self, *a, **kw):
+            return _EmptyQuery()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_db_session():
+        yield _FakeDB()
+
+    monkeypatch.setattr(_authz, "get_db_session", fake_db_session)
+    with pytest.raises(HTTPException) as exc:
+        _authz._require_export_job_access("job-unknown")
+    assert exc.value.status_code == 404
+
+
+def test_export_job_access_delegates_to_deck_permission(monkeypatch):
+    from src.api.routes import _authz
+    from src.database.models.profile_contributor import PermissionLevel
+
+    job = MagicMock()
+    job.session_id = "sess-1"
+
+    class _Query:
+        def filter(self, *a, **kw):
+            return self
+
+        def first(self):
+            return job
+
+    class _FakeDB:
+        def query(self, *a, **kw):
+            return _Query()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_db_session():
+        yield _FakeDB()
+
+    calls = []
+    monkeypatch.setattr(_authz, "get_db_session", fake_db_session)
+    monkeypatch.setattr(
+        _authz,
+        "_check_deck_permission_for_session",
+        lambda sid, min_permission=PermissionLevel.CAN_VIEW: calls.append((sid, min_permission)),
+    )
+    _authz._require_export_job_access("job-1")
+    assert calls == [("sess-1", PermissionLevel.CAN_VIEW)]
+
+
+# ---------------------------------------------------------------------------
+# require_admin
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_env(monkeypatch):
+    from src.api.routes import _authz
+
+    monkeypatch.setattr(_authz, "_is_production", lambda: True)
+    monkeypatch.setattr(_authz, "get_current_user", lambda: "user@test.com")
+    _authz.reset_admin_cache()
+    yield _authz
+    _authz.reset_admin_cache()
+
+
+def test_require_admin_bypasses_outside_production(monkeypatch):
+    from src.api.routes import _authz
+
+    monkeypatch.setattr(_authz, "_is_production", lambda: False)
+    _authz.require_admin()  # no raise
+
+
+def test_require_admin_non_admin_403(admin_env, monkeypatch):
+    monkeypatch.setattr(admin_env, "_admin_acl_probe", lambda user: False)
+    with pytest.raises(HTTPException) as exc:
+        admin_env.require_admin()
+    assert exc.value.status_code == 403
+
+
+def test_require_admin_admin_passes(admin_env, monkeypatch):
+    monkeypatch.setattr(admin_env, "_admin_acl_probe", lambda user: True)
+    admin_env.require_admin()  # no raise
+
+
+def test_require_admin_fails_closed_on_probe_error(admin_env, monkeypatch):
+    """Transient probe errors deny THIS request but must not be cached."""
+    calls = []
+
+    def probe(user):
+        calls.append(user)
+        if len(calls) == 1:
+            raise RuntimeError("workspace unreachable")
+        return True
+
+    monkeypatch.setattr(admin_env, "_admin_acl_probe", probe)
+    with pytest.raises(HTTPException) as exc:
+        admin_env.require_admin()
+    assert exc.value.status_code == 403
+    # The error-derived denial is NOT cached: the next request re-probes
+    # and, the blip gone, the real admin gets in (no 60s lockout).
+    admin_env.require_admin()  # no raise
+    assert len(calls) == 2
+
+
+def test_require_admin_permission_denied_is_cached_deny(admin_env, monkeypatch):
+    """A definitive PermissionDenied from the API is a cacheable non-admin verdict."""
+    from databricks.sdk.errors import PermissionDenied
+
+    calls = []
+
+    def probe(user):
+        calls.append(user)
+        raise PermissionDenied("no CAN_MANAGE on app")
+
+    monkeypatch.setattr(admin_env, "_admin_acl_probe", probe)
+    for _ in range(2):
+        with pytest.raises(HTTPException) as exc:
+            admin_env.require_admin()
+        assert exc.value.status_code == 403
+    assert calls == ["user@test.com"]  # second 403 served from cache
+
+
+def test_require_admin_no_user_403(admin_env, monkeypatch):
+    monkeypatch.setattr(admin_env, "get_current_user", lambda: None)
+    with pytest.raises(HTTPException) as exc:
+        admin_env.require_admin()
+    assert exc.value.status_code == 403
+
+
+def test_require_admin_caches_verdict(admin_env, monkeypatch):
+    probes = []
+
+    def probe(user):
+        probes.append(user)
+        return True
+
+    monkeypatch.setattr(admin_env, "_admin_acl_probe", probe)
+    admin_env.require_admin()
+    admin_env.require_admin()
+    assert probes == ["user@test.com"]  # second call served from cache

--- a/tests/unit/test_authz_helpers.py
+++ b/tests/unit/test_authz_helpers.py
@@ -203,42 +203,27 @@ def test_require_admin_caches_verdict(admin_env, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _admin_acl_probe — membership-in-CAN_MANAGE-grant decision (the redesign)
+# _admin_acl_probe — workspace ``admins`` group membership (Direction C)
 #
-# The probe must be a presence-in-grant check, NOT an ACL-readability oracle:
-# a caller who can READ the ACL but is absent from every CAN_MANAGE grant must
-# be DENIED. That is the exact case the old readability-probe design got wrong
-# (it would fail OPEN — every authenticated user classified admin).
+# Admin is decided from the caller's OWN group membership via the OBO client's
+# current_user.me().groups — NOT an app-object ACL read. apps.get_permissions
+# is the wrong primitive at runtime: the app's OBO token lacks the
+# access-management scope and the app SP is absent from its own ACL. Deciding
+# on the caller's own group list cannot fail open (a non-admin's me().groups
+# won't contain "admins" and cannot be forged).
 # ---------------------------------------------------------------------------
 
 
-def _acl_entry(*, user_name=None, group_name=None, level="CAN_MANAGE"):
-    """Build a fake ACL entry mirroring the SDK's AccessControlResponse shape."""
-    perm = MagicMock()
-    perm.permission_level = level  # string, as the SDK enum's .value resolves to
-    entry = MagicMock()
-    entry.user_name = user_name
-    entry.group_name = group_name
-    entry.all_permissions = [perm]
-    return entry
+def _wire_probe(monkeypatch, *, caller_groups):
+    """Patch _admin_acl_probe's only dependency: the caller's own group names.
 
-
-def _wire_probe(monkeypatch, *, acl_entries, caller_groups, app_name="tellr-app"):
-    """Patch _admin_acl_probe's dependencies: OBO client ACL read + caller groups.
-
-    The redesign fetches BOTH the app ACL and the caller's groups with the
-    OBO/user client (the app SP cannot read its own ACL — verified live), so
-    the seam is get_user_client, not get_system_client.
+    The probe resolves groups via get_user_client().current_user.me().groups
+    (OBO); the seam is _caller_group_display_names, which takes the OBO token's
+    own identity. No app name, no ACL, no SP.
     """
     from src.api.routes import _authz
 
-    monkeypatch.setenv("DATABRICKS_APP_NAME", app_name)
-
-    acl = MagicMock()
-    acl.access_control_list = acl_entries
     fake_client = MagicMock()
-    fake_client.apps.get_permissions.return_value = acl
-
     monkeypatch.setattr(
         "src.core.databricks_client.get_user_client", lambda: fake_client
     )
@@ -248,71 +233,41 @@ def _wire_probe(monkeypatch, *, acl_entries, caller_groups, app_name="tellr-app"
     return _authz
 
 
-def test_probe_direct_user_grant_is_admin(monkeypatch):
-    _authz = _wire_probe(
-        monkeypatch,
-        acl_entries=[_acl_entry(user_name="alice@test.com")],
-        caller_groups=[],
-    )
-    assert _authz._admin_acl_probe("alice@test.com") is True
-
-
-def test_probe_group_membership_grant_is_admin(monkeypatch):
-    """Admin ONLY via an inherited group (e.g. workspace 'admins') must pass."""
-    _authz = _wire_probe(
-        monkeypatch,
-        acl_entries=[_acl_entry(group_name="admins")],
-        caller_groups=["admins", "users"],
-    )
+def test_probe_admins_group_member_is_admin(monkeypatch):
+    """Caller whose own groups include 'admins' -> admin."""
+    _authz = _wire_probe(monkeypatch, caller_groups=["admins", "users"])
     assert _authz._admin_acl_probe("bob@test.com") is True
 
 
-def test_probe_can_read_but_not_in_grant_is_denied(monkeypatch):
-    """THE FLAW REGRESSION: a caller absent from every CAN_MANAGE grant is
-    NOT admin, even though they can read the whole ACL. The old readability
-    probe returned True here (fail-open); the redesign must return False."""
-    _authz = _wire_probe(
-        monkeypatch,
-        acl_entries=[
-            _acl_entry(user_name="owner@test.com"),
-            _acl_entry(group_name="admins"),
-        ],
-        caller_groups=["users", "tellr consumers"],  # not in any CAN_MANAGE grant
-    )
+def test_probe_non_admin_group_member_denied(monkeypatch):
+    """FAIL-OPEN REGRESSION: caller not in 'admins' -> DENIED, even though
+    they are an authenticated user with their own (non-admin) groups."""
+    _authz = _wire_probe(monkeypatch, caller_groups=["users", "tellr consumers"])
     assert _authz._admin_acl_probe("stranger@test.com") is False
 
 
-def test_probe_can_use_only_grant_is_not_admin(monkeypatch):
-    """A grant that is not CAN_MANAGE (e.g. CAN_USE) does not confer admin."""
-    _authz = _wire_probe(
-        monkeypatch,
-        acl_entries=[_acl_entry(user_name="alice@test.com", level="CAN_USE")],
-        caller_groups=[],
-    )
-    assert _authz._admin_acl_probe("alice@test.com") is False
+def test_probe_no_groups_denied(monkeypatch):
+    """Caller with no group memberships -> not admin."""
+    _authz = _wire_probe(monkeypatch, caller_groups=[])
+    assert _authz._admin_acl_probe("nobody@test.com") is False
 
 
-def test_probe_missing_app_name_fails_closed(monkeypatch):
+def test_probe_transient_error_raises(monkeypatch):
+    """A me() failure propagates so require_admin fails closed WITHOUT caching."""
     from src.api.routes import _authz
 
-    monkeypatch.delenv("DATABRICKS_APP_NAME", raising=False)
-    assert _authz._admin_acl_probe("alice@test.com") is False
-
-
-def test_probe_group_name_only_matched_when_caller_is_member(monkeypatch):
-    """A CAN_MANAGE group grant the caller does NOT belong to must not admit."""
-    _authz = _wire_probe(
-        monkeypatch,
-        acl_entries=[_acl_entry(group_name="some-other-team")],
-        caller_groups=["users"],
+    fake_client = MagicMock()
+    fake_client.current_user.me.side_effect = RuntimeError("workspace unreachable")
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_user_client", lambda: fake_client
     )
-    assert _authz._admin_acl_probe("carol@test.com") is False
+    with pytest.raises(RuntimeError):
+        _authz._admin_acl_probe("alice@test.com")
 
 
 def test_caller_group_display_names_reads_me_group_display(monkeypatch):
     """_caller_group_display_names returns the caller's own group *display* names
-    from current_user.me() on the OBO client (verified live: 'admins' present
-    for a workspace admin)."""
+    from current_user.me() on the OBO client (iam.current-user:read scope)."""
     from src.api.routes import _authz
 
     g1 = MagicMock(); g1.display = "admins"

--- a/tests/unit/test_authz_helpers.py
+++ b/tests/unit/test_authz_helpers.py
@@ -224,7 +224,12 @@ def _acl_entry(*, user_name=None, group_name=None, level="CAN_MANAGE"):
 
 
 def _wire_probe(monkeypatch, *, acl_entries, caller_groups, app_name="tellr-app"):
-    """Patch _admin_acl_probe's dependencies: system client ACL + caller groups."""
+    """Patch _admin_acl_probe's dependencies: OBO client ACL read + caller groups.
+
+    The redesign fetches BOTH the app ACL and the caller's groups with the
+    OBO/user client (the app SP cannot read its own ACL — verified live), so
+    the seam is get_user_client, not get_system_client.
+    """
     from src.api.routes import _authz
 
     monkeypatch.setenv("DATABRICKS_APP_NAME", app_name)
@@ -235,7 +240,7 @@ def _wire_probe(monkeypatch, *, acl_entries, caller_groups, app_name="tellr-app"
     fake_client.apps.get_permissions.return_value = acl
 
     monkeypatch.setattr(
-        "src.core.databricks_client.get_system_client", lambda: fake_client
+        "src.core.databricks_client.get_user_client", lambda: fake_client
     )
     monkeypatch.setattr(
         _authz, "_caller_group_display_names", lambda client, user: set(caller_groups)
@@ -304,15 +309,17 @@ def test_probe_group_name_only_matched_when_caller_is_member(monkeypatch):
     assert _authz._admin_acl_probe("carol@test.com") is False
 
 
-def test_caller_group_display_names_reads_scim_display(monkeypatch):
-    """_caller_group_display_names returns the SCIM group *display* names."""
+def test_caller_group_display_names_reads_me_group_display(monkeypatch):
+    """_caller_group_display_names returns the caller's own group *display* names
+    from current_user.me() on the OBO client (verified live: 'admins' present
+    for a workspace admin)."""
     from src.api.routes import _authz
 
     g1 = MagicMock(); g1.display = "admins"
     g2 = MagicMock(); g2.display = "users"
-    user = MagicMock(); user.groups = [g1, g2]
+    me = MagicMock(); me.groups = [g1, g2]
     client = MagicMock()
-    client.users.list.return_value = [user]
+    client.current_user.me.return_value = me
 
     names = _authz._caller_group_display_names(client, "alice@test.com")
     assert names == {"admins", "users"}

--- a/tests/unit/test_authz_helpers.py
+++ b/tests/unit/test_authz_helpers.py
@@ -166,15 +166,13 @@ def test_require_admin_fails_closed_on_probe_error(admin_env, monkeypatch):
     assert len(calls) == 2
 
 
-def test_require_admin_permission_denied_is_cached_deny(admin_env, monkeypatch):
-    """A definitive PermissionDenied from the API is a cacheable non-admin verdict."""
-    from databricks.sdk.errors import PermissionDenied
-
+def test_require_admin_definitive_non_admin_is_cached_deny(admin_env, monkeypatch):
+    """A definitive non-admin verdict (absent from all CAN_MANAGE grants) caches."""
     calls = []
 
     def probe(user):
         calls.append(user)
-        raise PermissionDenied("no CAN_MANAGE on app")
+        return False
 
     monkeypatch.setattr(admin_env, "_admin_acl_probe", probe)
     for _ in range(2):
@@ -202,3 +200,119 @@ def test_require_admin_caches_verdict(admin_env, monkeypatch):
     admin_env.require_admin()
     admin_env.require_admin()
     assert probes == ["user@test.com"]  # second call served from cache
+
+
+# ---------------------------------------------------------------------------
+# _admin_acl_probe — membership-in-CAN_MANAGE-grant decision (the redesign)
+#
+# The probe must be a presence-in-grant check, NOT an ACL-readability oracle:
+# a caller who can READ the ACL but is absent from every CAN_MANAGE grant must
+# be DENIED. That is the exact case the old readability-probe design got wrong
+# (it would fail OPEN — every authenticated user classified admin).
+# ---------------------------------------------------------------------------
+
+
+def _acl_entry(*, user_name=None, group_name=None, level="CAN_MANAGE"):
+    """Build a fake ACL entry mirroring the SDK's AccessControlResponse shape."""
+    perm = MagicMock()
+    perm.permission_level = level  # string, as the SDK enum's .value resolves to
+    entry = MagicMock()
+    entry.user_name = user_name
+    entry.group_name = group_name
+    entry.all_permissions = [perm]
+    return entry
+
+
+def _wire_probe(monkeypatch, *, acl_entries, caller_groups, app_name="tellr-app"):
+    """Patch _admin_acl_probe's dependencies: system client ACL + caller groups."""
+    from src.api.routes import _authz
+
+    monkeypatch.setenv("DATABRICKS_APP_NAME", app_name)
+
+    acl = MagicMock()
+    acl.access_control_list = acl_entries
+    fake_client = MagicMock()
+    fake_client.apps.get_permissions.return_value = acl
+
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda: fake_client
+    )
+    monkeypatch.setattr(
+        _authz, "_caller_group_display_names", lambda client, user: set(caller_groups)
+    )
+    return _authz
+
+
+def test_probe_direct_user_grant_is_admin(monkeypatch):
+    _authz = _wire_probe(
+        monkeypatch,
+        acl_entries=[_acl_entry(user_name="alice@test.com")],
+        caller_groups=[],
+    )
+    assert _authz._admin_acl_probe("alice@test.com") is True
+
+
+def test_probe_group_membership_grant_is_admin(monkeypatch):
+    """Admin ONLY via an inherited group (e.g. workspace 'admins') must pass."""
+    _authz = _wire_probe(
+        monkeypatch,
+        acl_entries=[_acl_entry(group_name="admins")],
+        caller_groups=["admins", "users"],
+    )
+    assert _authz._admin_acl_probe("bob@test.com") is True
+
+
+def test_probe_can_read_but_not_in_grant_is_denied(monkeypatch):
+    """THE FLAW REGRESSION: a caller absent from every CAN_MANAGE grant is
+    NOT admin, even though they can read the whole ACL. The old readability
+    probe returned True here (fail-open); the redesign must return False."""
+    _authz = _wire_probe(
+        monkeypatch,
+        acl_entries=[
+            _acl_entry(user_name="owner@test.com"),
+            _acl_entry(group_name="admins"),
+        ],
+        caller_groups=["users", "tellr consumers"],  # not in any CAN_MANAGE grant
+    )
+    assert _authz._admin_acl_probe("stranger@test.com") is False
+
+
+def test_probe_can_use_only_grant_is_not_admin(monkeypatch):
+    """A grant that is not CAN_MANAGE (e.g. CAN_USE) does not confer admin."""
+    _authz = _wire_probe(
+        monkeypatch,
+        acl_entries=[_acl_entry(user_name="alice@test.com", level="CAN_USE")],
+        caller_groups=[],
+    )
+    assert _authz._admin_acl_probe("alice@test.com") is False
+
+
+def test_probe_missing_app_name_fails_closed(monkeypatch):
+    from src.api.routes import _authz
+
+    monkeypatch.delenv("DATABRICKS_APP_NAME", raising=False)
+    assert _authz._admin_acl_probe("alice@test.com") is False
+
+
+def test_probe_group_name_only_matched_when_caller_is_member(monkeypatch):
+    """A CAN_MANAGE group grant the caller does NOT belong to must not admit."""
+    _authz = _wire_probe(
+        monkeypatch,
+        acl_entries=[_acl_entry(group_name="some-other-team")],
+        caller_groups=["users"],
+    )
+    assert _authz._admin_acl_probe("carol@test.com") is False
+
+
+def test_caller_group_display_names_reads_scim_display(monkeypatch):
+    """_caller_group_display_names returns the SCIM group *display* names."""
+    from src.api.routes import _authz
+
+    g1 = MagicMock(); g1.display = "admins"
+    g2 = MagicMock(); g2.display = "users"
+    user = MagicMock(); user.groups = [g1, g2]
+    client = MagicMock()
+    client.users.list.return_value = [user]
+
+    names = _authz._caller_group_display_names(client, "alice@test.com")
+    assert names == {"admins", "users"}

--- a/tests/unit/test_authz_images.py
+++ b/tests/unit/test_authz_images.py
@@ -1,0 +1,98 @@
+"""Authorization gating tests for images.py (SDR-4437 PR-2, HIGH-1)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def caller(monkeypatch):
+    monkeypatch.setattr(
+        "src.api.routes.images._get_current_user", lambda: "alice@test.com"
+    )
+    return "alice@test.com"
+
+
+def _fake_image(owner):
+    img = MagicMock()
+    img.id = 1
+    img.uploaded_by = owner
+    return img
+
+
+@pytest.fixture
+def db_returning(monkeypatch):
+    """Override the get_db dependency to return a stub whose query yields *img*."""
+    from src.api.main import app
+    from src.core.database import get_db
+
+    holder = {}
+
+    def set_image(img):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = img
+        app.dependency_overrides[get_db] = lambda: db
+        holder["db"] = db
+        return db
+
+    yield set_image
+    app.dependency_overrides.pop(get_db, None)
+
+
+def test_update_image_other_owner_403(client, caller, db_returning):
+    db_returning(_fake_image("bob@test.com"))
+    resp = client.put("/api/images/1", json={"description": "mine now"})
+    assert resp.status_code == 403
+
+
+def test_update_image_own_image_allowed(client, caller, db_returning):
+    db = db_returning(_fake_image("alice@test.com"))
+    resp = client.put("/api/images/1", json={"description": "updated"})
+    assert resp.status_code != 403
+    db.commit.assert_called()
+
+
+def test_delete_image_other_owner_403(client, caller, db_returning, monkeypatch):
+    db_returning(_fake_image("bob@test.com"))
+    svc_delete = MagicMock()
+    monkeypatch.setattr("src.api.routes.images.image_service.delete_image", svc_delete)
+    resp = client.delete("/api/images/1")
+    assert resp.status_code == 403
+    svc_delete.assert_not_called()
+
+
+def test_delete_image_own_image_allowed(client, caller, db_returning, monkeypatch):
+    db_returning(_fake_image("alice@test.com"))
+    svc_delete = MagicMock()
+    monkeypatch.setattr("src.api.routes.images.image_service.delete_image", svc_delete)
+    resp = client.delete("/api/images/1")
+    assert resp.status_code == 204
+    svc_delete.assert_called_once()
+
+
+def test_list_images_filters_by_caller(client, caller, db_returning, monkeypatch):
+    db_returning(None)
+    search = MagicMock(return_value=[])
+    monkeypatch.setattr("src.api.routes.images.image_service.search_images", search)
+    resp = client.get("/api/images")
+    assert resp.status_code == 200
+    assert search.call_args.kwargs["uploaded_by"] == "alice@test.com"
+
+
+def test_get_image_data_stays_open(client, caller, monkeypatch, db_returning):
+    """Accepted-risk open read: collaborator editor flow depends on it."""
+    db_returning(None)
+    monkeypatch.setattr(
+        "src.api.routes.images.image_service.get_image_base64",
+        MagicMock(return_value=("aGk=", "image/png")),
+    )
+    resp = client.get("/api/images/1/data")
+    assert resp.status_code == 200

--- a/tests/unit/test_authz_settings_admin.py
+++ b/tests/unit/test_authz_settings_admin.py
@@ -1,0 +1,48 @@
+"""HIGH-3: workspace-global prompt/style libraries admin-gated (SDR-4437)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def non_admin(monkeypatch):
+    from src.api.routes import _authz
+
+    monkeypatch.setattr(_authz, "_is_production", lambda: True)
+    monkeypatch.setattr(_authz, "get_current_user", lambda: "user@test.com")
+    monkeypatch.setattr(_authz, "_admin_acl_probe", lambda user: False)
+    _authz.reset_admin_cache()
+    yield
+    _authz.reset_admin_cache()
+
+
+@pytest.mark.parametrize(
+    "method,path,body",
+    [
+        ("POST", "/api/settings/deck-prompts", {"name": "x", "prompt_content": "y"}),
+        ("PUT", "/api/settings/deck-prompts/1", {"name": "x"}),
+        ("DELETE", "/api/settings/deck-prompts/1", None),
+        ("POST", "/api/settings/slide-styles", None),  # body irrelevant: gate fires first
+        ("PUT", "/api/settings/slide-styles/1", None),
+        ("DELETE", "/api/settings/slide-styles/1", None),
+        ("POST", "/api/settings/slide-styles/1/set-default", None),
+    ],
+)
+def test_library_writes_403_for_non_admin(client, non_admin, method, path, body):
+    resp = client.request(method, path, json=body)
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "path", ["/api/settings/deck-prompts", "/api/settings/slide-styles"]
+)
+def test_library_reads_stay_open(client, non_admin, path):
+    resp = client.get(path)
+    assert resp.status_code != 403

--- a/tests/unit/test_authz_slides_versions.py
+++ b/tests/unit/test_authz_slides_versions.py
@@ -1,0 +1,63 @@
+"""Authorization gating tests for slides.py version endpoints (SDR-4437 PR-2)."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from src.database.models.profile_contributor import PermissionLevel
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def deck_gate(monkeypatch):
+    calls = []
+
+    def gate(session_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((session_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.slides._check_deck_permission_for_session", gate
+    )
+    return calls
+
+
+@pytest.mark.parametrize(
+    "method,path,body,expected_level",
+    [
+        ("PATCH", "/api/slides/0/verification",
+         {"session_id": "s1", "verification": None}, PermissionLevel.CAN_EDIT),
+        ("POST", "/api/slides/versions/create",
+         {"session_id": "s1", "description": "cp"}, PermissionLevel.CAN_EDIT),
+        ("PATCH", "/api/slides/versions/3/verification",
+         {"session_id": "s1", "verification_map": {}}, PermissionLevel.CAN_EDIT),
+        ("POST", "/api/slides/versions/sync-verification",
+         {"session_id": "s1"}, PermissionLevel.CAN_EDIT),
+        ("POST", "/api/slides/versions/3/restore",
+         {"session_id": "s1"}, PermissionLevel.CAN_MANAGE),
+    ],
+)
+def test_version_writes_gated(client, deck_gate, method, path, body, expected_level):
+    resp = client.request(method, path, json=body)
+    assert resp.status_code == 403
+    assert deck_gate == [("s1", expected_level)]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/slides/versions",
+        "/api/slides/versions/3",
+        "/api/slides/versions/current",
+    ],
+)
+def test_version_reads_gated_can_view(client, deck_gate, path):
+    resp = client.get(path, params={"session_id": "s1"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s1", PermissionLevel.CAN_VIEW)]

--- a/tests/unit/test_authz_tour.py
+++ b/tests/unit/test_authz_tour.py
@@ -1,0 +1,29 @@
+"""Authorization gating tests for tour.py (SDR-4437 PR-2)."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from src.database.models.profile_contributor import PermissionLevel
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_add_demo_slides_requires_can_edit(client, monkeypatch):
+    calls = []
+
+    def gate(session_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((session_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.tour._check_deck_permission_for_session", gate
+    )
+    resp = client.post("/api/tour/demo-deck/victim-session/slides")
+    assert resp.status_code == 403
+    assert calls == [("victim-session", PermissionLevel.CAN_EDIT)]

--- a/tests/unit/test_authz_verification.py
+++ b/tests/unit/test_authz_verification.py
@@ -1,0 +1,49 @@
+"""Authorization gating tests for verification.py (SDR-4437 PR-2, HIGH-1)."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from src.database.models.profile_contributor import PermissionLevel
+
+
+@pytest.fixture
+def client():
+    from src.api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def deck_gate(monkeypatch):
+    calls = []
+
+    def gate(session_id, min_permission=PermissionLevel.CAN_VIEW):
+        calls.append((session_id, min_permission))
+        raise HTTPException(status_code=403, detail="denied")
+
+    monkeypatch.setattr(
+        "src.api.routes.verification._check_deck_permission_for_session", gate
+    )
+    return calls
+
+
+def test_verify_slide_requires_can_edit(client, deck_gate):
+    resp = client.post("/api/verification/0", json={"session_id": "s1"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s1", PermissionLevel.CAN_EDIT)]
+
+
+def test_slide_feedback_requires_can_edit(client, deck_gate):
+    resp = client.post(
+        "/api/verification/0/feedback",
+        json={"session_id": "s1", "slide_index": 0, "is_positive": True},
+    )
+    assert resp.status_code == 403
+    assert deck_gate == [("s1", PermissionLevel.CAN_EDIT)]
+
+
+def test_genie_link_requires_can_view(client, deck_gate):
+    resp = client.get("/api/verification/genie-link", params={"session_id": "s1"})
+    assert resp.status_code == 403
+    assert deck_gate == [("s1", PermissionLevel.CAN_VIEW)]

--- a/tests/unit/test_deck_permission_routes.py
+++ b/tests/unit/test_deck_permission_routes.py
@@ -98,16 +98,16 @@ def deck_contributor_view(db, owner_session):
 
 
 # ---------------------------------------------------------------------------
-# Test _get_session_permission in sessions.py
+# Test _get_session_permission_for_info in _authz.py (moved from sessions.py)
 # ---------------------------------------------------------------------------
 
 
 class TestSessionsGetSessionPermission:
-    """sessions.py _get_session_permission should use deck-based permissions."""
+    """_authz._get_session_permission_for_info should use deck-based permissions."""
 
     def test_creator_gets_can_manage(self, db, owner_session):
         """Session creator should get CAN_MANAGE via deck permission (creator check)."""
-        from src.api.routes.sessions import _get_session_permission
+        from src.api.routes._authz import _get_session_permission_for_info
 
         session_info = {
             "id": owner_session.id,
@@ -118,16 +118,16 @@ class TestSessionsGetSessionPermission:
         }
 
         ctx = PermissionContext(user_id="owner-uid", user_name="owner@test.com")
-        with patch("src.api.routes.sessions.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.sessions.get_current_user", return_value="owner@test.com"):
-            has_access, perm = _get_session_permission(session_info, db)
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="owner@test.com"):
+            has_access, perm = _get_session_permission_for_info(session_info, db)
 
         assert has_access is True
         assert perm == PermissionLevel.CAN_MANAGE
 
     def test_deck_contributor_gets_edit(self, db, owner_session, deck_contributor_edit):
         """User with CAN_EDIT DeckContributor entry should get CAN_EDIT."""
-        from src.api.routes.sessions import _get_session_permission
+        from src.api.routes._authz import _get_session_permission_for_info
 
         session_info = {
             "id": owner_session.id,
@@ -138,16 +138,16 @@ class TestSessionsGetSessionPermission:
         }
 
         ctx = PermissionContext(user_id="editor-uid", user_name="editor@test.com")
-        with patch("src.api.routes.sessions.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.sessions.get_current_user", return_value="editor@test.com"):
-            has_access, perm = _get_session_permission(session_info, db)
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="editor@test.com"):
+            has_access, perm = _get_session_permission_for_info(session_info, db)
 
         assert has_access is True
         assert perm == PermissionLevel.CAN_EDIT
 
     def test_stranger_gets_no_access(self, db, owner_session):
         """User with no DeckContributor entry and not creator should get no access."""
-        from src.api.routes.sessions import _get_session_permission
+        from src.api.routes._authz import _get_session_permission_for_info
 
         session_info = {
             "id": owner_session.id,
@@ -158,16 +158,16 @@ class TestSessionsGetSessionPermission:
         }
 
         ctx = PermissionContext(user_id="stranger-uid", user_name="stranger@test.com")
-        with patch("src.api.routes.sessions.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.sessions.get_current_user", return_value="stranger@test.com"):
-            has_access, perm = _get_session_permission(session_info, db)
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="stranger@test.com"):
+            has_access, perm = _get_session_permission_for_info(session_info, db)
 
         assert has_access is False
         assert perm is None
 
     def test_contributor_session_checks_parent(self, db, owner_session, contributor_session, deck_contributor_edit):
         """Contributor session should check deck permission on parent session."""
-        from src.api.routes.sessions import _get_session_permission
+        from src.api.routes._authz import _get_session_permission_for_info
 
         session_info = {
             "id": contributor_session.id,
@@ -178,25 +178,25 @@ class TestSessionsGetSessionPermission:
         }
 
         ctx = PermissionContext(user_id="editor-uid", user_name="editor@test.com")
-        with patch("src.api.routes.sessions.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.sessions.get_current_user", return_value="editor@test.com"):
-            has_access, perm = _get_session_permission(session_info, db)
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="editor@test.com"):
+            has_access, perm = _get_session_permission_for_info(session_info, db)
 
         assert has_access is True
         assert perm == PermissionLevel.CAN_EDIT
 
 
 # ---------------------------------------------------------------------------
-# Test _get_session_permission in slides.py (parallel copy)
+# Test _get_session_permission_by_id in _authz.py (moved from slides.py)
 # ---------------------------------------------------------------------------
 
 
 class TestSlidesGetSessionPermission:
-    """slides.py _get_session_permission should use deck-based permissions."""
+    """_authz._get_session_permission_by_id should use deck-based permissions."""
 
     def test_creator_gets_can_manage(self, db, owner_session):
         """Session creator gets CAN_MANAGE for slides."""
-        from src.api.routes.slides import _get_session_permission
+        from src.api.routes._authz import _get_session_permission_by_id
 
         mock_session_info = {
             "id": owner_session.id,
@@ -207,18 +207,18 @@ class TestSlidesGetSessionPermission:
         }
 
         ctx = PermissionContext(user_id="owner-uid", user_name="owner@test.com")
-        with patch("src.api.routes.slides.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.slides.get_current_user", return_value="owner@test.com"), \
-             patch("src.api.routes.slides.get_session_manager") as mock_mgr:
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="owner@test.com"), \
+             patch("src.api.routes._authz.get_session_manager") as mock_mgr:
             mock_mgr.return_value.get_session.return_value = mock_session_info
-            has_access, perm = _get_session_permission(owner_session.session_id, db)
+            has_access, perm = _get_session_permission_by_id(owner_session.session_id, db)
 
         assert has_access is True
         assert perm == PermissionLevel.CAN_MANAGE
 
     def test_stranger_gets_no_access(self, db, owner_session):
         """Stranger gets no access to slides."""
-        from src.api.routes.slides import _get_session_permission
+        from src.api.routes._authz import _get_session_permission_by_id
 
         mock_session_info = {
             "id": owner_session.id,
@@ -229,18 +229,18 @@ class TestSlidesGetSessionPermission:
         }
 
         ctx = PermissionContext(user_id="stranger-uid", user_name="stranger@test.com")
-        with patch("src.api.routes.slides.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.slides.get_current_user", return_value="stranger@test.com"), \
-             patch("src.api.routes.slides.get_session_manager") as mock_mgr:
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="stranger@test.com"), \
+             patch("src.api.routes._authz.get_session_manager") as mock_mgr:
             mock_mgr.return_value.get_session.return_value = mock_session_info
-            has_access, perm = _get_session_permission(owner_session.session_id, db)
+            has_access, perm = _get_session_permission_by_id(owner_session.session_id, db)
 
         assert has_access is False
         assert perm is None
 
     def test_deck_contributor_gets_edit(self, db, owner_session, deck_contributor_edit):
         """Deck contributor with CAN_EDIT gets edit access to slides."""
-        from src.api.routes.slides import _get_session_permission
+        from src.api.routes._authz import _get_session_permission_by_id
 
         mock_session_info = {
             "id": owner_session.id,
@@ -251,11 +251,11 @@ class TestSlidesGetSessionPermission:
         }
 
         ctx = PermissionContext(user_id="editor-uid", user_name="editor@test.com")
-        with patch("src.api.routes.slides.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.slides.get_current_user", return_value="editor@test.com"), \
-             patch("src.api.routes.slides.get_session_manager") as mock_mgr:
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="editor@test.com"), \
+             patch("src.api.routes._authz.get_session_manager") as mock_mgr:
             mock_mgr.return_value.get_session.return_value = mock_session_info
-            has_access, perm = _get_session_permission(owner_session.session_id, db)
+            has_access, perm = _get_session_permission_by_id(owner_session.session_id, db)
 
         assert has_access is True
         assert perm == PermissionLevel.CAN_EDIT

--- a/tests/unit/test_deck_permission_routes.py
+++ b/tests/unit/test_deck_permission_routes.py
@@ -508,8 +508,11 @@ class TestDuplicateDeckPermission:
         }
 
         ctx = PermissionContext(user_id="viewer-uid", user_name="viewer@test.com")
-        with patch("src.api.routes.sessions.get_permission_context", return_value=ctx), \
-             patch("src.api.routes.sessions.get_current_user", return_value="viewer@test.com"):
+        # _require_session_access was moved into _authz.py by PR-2; it resolves
+        # get_permission_context/get_current_user from that module's namespace,
+        # so patch there (matches every sibling test in this file).
+        with patch("src.api.routes._authz.get_permission_context", return_value=ctx), \
+             patch("src.api.routes._authz.get_current_user", return_value="viewer@test.com"):
             perm = _require_session_access(session_info, db, PermissionLevel.CAN_VIEW)
 
         assert perm == PermissionLevel.CAN_VIEW

--- a/tests/unit/test_genie_link_per_space.py
+++ b/tests/unit/test_genie_link_per_space.py
@@ -29,6 +29,17 @@ def mock_session_manager():
 class TestGenieLinkWithSpaceId:
     """GET /api/verification/genie-link?session_id=X&space_id=Y"""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_deck_gate(self, monkeypatch):
+        # SDR-4437 PR-2 (Task 7): genie-link now requires CAN_VIEW on the deck.
+        # These pre-existing tests use a mocked session manager without a
+        # permission fixture, so no-op the gate here — never weaken it; its
+        # enforcement is covered by tests/unit/test_authz_verification.py.
+        monkeypatch.setattr(
+            "src.api.routes.verification._check_deck_permission_for_session",
+            lambda *a, **k: None,
+        )
+
     def test_returns_link_for_specific_space(self, client, mock_session_manager):
         """When space_id is provided, should use agent_config to find conversation_id."""
         mock_session_manager.get_session.return_value = {

--- a/tests/unit/test_google_slides_routes.py
+++ b/tests/unit/test_google_slides_routes.py
@@ -218,6 +218,18 @@ class TestAuthCallback:
 
 class TestExportEndpoint:
 
+    @pytest.fixture(autouse=True)
+    def _bypass_deck_gate(self, monkeypatch):
+        # SDR-4437 PR-2 (Task 13): these legacy tests post an unfixtured
+        # session_id to assert the 400/401 credential paths. The new CAN_VIEW
+        # deck gate would 404 first ("Session not found"), so no-op it here —
+        # never weaken the gate itself; its enforcement is covered by
+        # tests/unit/test_authz_google_slides.py.
+        monkeypatch.setattr(
+            "src.api.routes.google_slides._check_deck_permission_for_session",
+            lambda *a, **k: None,
+        )
+
     def test_export_no_credentials_returns_400(self, test_client):
         """No global credentials → 400."""
         resp = test_client.post(

--- a/tests/unit/test_identity_helpers_fail_closed.py
+++ b/tests/unit/test_identity_helpers_fail_closed.py
@@ -1,0 +1,90 @@
+"""HIGH-6: identity helpers must not swallow OBO-client failures in production."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.databricks_client import UserClientRequiredError
+
+
+def _raise_user_client_required():
+    raise UserClientRequiredError("no OBO client bound")
+
+
+# --- google_slides._get_user_identity -------------------------------------
+
+
+def test_google_identity_dev_early_return(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    from src.api.routes.google_slides import _get_user_identity
+
+    assert _get_user_identity() == "local_dev"
+
+
+def test_google_identity_propagates_failure_in_production(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_user_client", _raise_user_client_required
+    )
+    from src.api.routes.google_slides import _get_user_identity
+
+    with pytest.raises(UserClientRequiredError):
+        _get_user_identity()
+
+
+def test_google_identity_returns_username_in_production(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    client = MagicMock()
+    client.current_user.me.return_value.user_name = "alice@test.com"
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_user_client", lambda: client
+    )
+    from src.api.routes.google_slides import _get_user_identity
+
+    assert _get_user_identity() == "alice@test.com"
+
+
+def test_google_identity_empty_username_fails_closed(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    client = MagicMock()
+    client.current_user.me.return_value.user_name = None
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_user_client", lambda: client
+    )
+    from src.api.routes.google_slides import _get_user_identity
+
+    with pytest.raises(UserClientRequiredError):
+        _get_user_identity()
+
+
+# --- images._get_current_user ----------------------------------------------
+
+
+def test_images_user_dev_early_return(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    from src.api.routes.images import _get_current_user
+
+    assert _get_current_user() == "system"
+
+
+def test_images_user_propagates_failure_in_production(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_user_client", _raise_user_client_required
+    )
+    from src.api.routes.images import _get_current_user
+
+    with pytest.raises(UserClientRequiredError):
+        _get_current_user()
+
+
+def test_images_user_returns_username_in_production(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    client = MagicMock()
+    client.current_user.me.return_value.user_name = "bob@test.com"
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_user_client", lambda: client
+    )
+    from src.api.routes.images import _get_current_user
+
+    assert _get_current_user() == "bob@test.com"

--- a/tests/unit/test_profile_permission_routes.py
+++ b/tests/unit/test_profile_permission_routes.py
@@ -345,6 +345,19 @@ class TestListProfilesPermissions:
 class TestLoadProfilePermissions:
     """load_profile_into_session requires CAN_USE."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_deck_gate(self, monkeypatch):
+        # SDR-4437 PR-2 (Task 14): load_profile_into_session now also requires
+        # CAN_MANAGE on the target session's deck (ratified IDOR fix). These
+        # tests exercise the orthogonal profile-permission (CAN_USE) layer and
+        # don't set up a deck grant, so no-op the deck gate here — never weaken
+        # it; its enforcement is covered by
+        # tests/unit/test_authz_agent_config.py::test_load_profile_requires_can_manage_on_session.
+        monkeypatch.setattr(
+            "src.api.routes.profiles._check_deck_permission_for_session",
+            lambda *a, **k: None,
+        )
+
     def test_load_profile_without_access_returns_403(
         self, stranger_client, owned_profile, session_for_load
     ):

--- a/tests/unit/test_profiles_routes.py
+++ b/tests/unit/test_profiles_routes.py
@@ -8,10 +8,16 @@ from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
     """Create a test client with mocked dependencies."""
     from src.api.main import app
 
+    # SDR-4437 PR-2: these tests exercise route behaviour, not authz — no-op the
+    # deck-permission gate (gate behaviour is covered in test_authz_agent_config.py).
+    monkeypatch.setattr(
+        "src.api.routes.profiles._check_deck_permission_for_session",
+        lambda *a, **k: None,
+    )
     return TestClient(app)
 
 

--- a/tests/unit/test_route_authz_coverage.py
+++ b/tests/unit/test_route_authz_coverage.py
@@ -1,0 +1,266 @@
+"""Route-table authorization coverage (SDR-4437 PR-2).
+
+Every sensitive route must be gated (permission-helper call in the handler
+source, or require_admin in its dependency tree) or carry an explicit
+allowlist entry with a rationale. This makes the "forgot the check" class of
+bug a CI failure.
+
+NOTE while PR-2 is in flight: this test is committed RED at the end of the
+serial gate and turns green as the per-router fan-out tasks land.
+"""
+
+import inspect
+import re
+from typing import get_args
+
+from fastapi.routing import APIRoute
+from pydantic import BaseModel
+
+from src.api.main import app
+from src.api.routes import _authz
+
+# Identifier names that mark a route as touching another principal's resource.
+# job_id and request_id are load-bearing: their omission from the original
+# review's heuristic is exactly how the export poll/download and chat-poll
+# IDORs escaped its endpoint list.
+TRIGGER_PARAMS = {"session_id", "image_id", "job_id", "request_id"}
+
+# Verified gating-call names. Extend ONLY with a name you have verified
+# actually enforces the caller's deck/admin permission (add a comment).
+# The trailing [(,] is load-bearing: it matches BOTH call shapes in the
+# codebase — the direct call `_gate(session_id, ...)` AND the bare-reference
+# form `await asyncio.to_thread(_gate, session_id, level)`, where the helper
+# name is followed by a comma, not `(`. Six already-gated sessions.py routes
+# (GET .../slides, POST .../export, the three lock endpoints, PUT
+# .../lock/heartbeat) and the Task-12 chat-poll gate use the to_thread form;
+# a `name\s*\(`-only regex reports all of them as ungated.
+_PERMISSION_CALL_RE = re.compile(
+    r"\b("
+    r"_check_deck_permission_for_session"
+    r"|_require_session_access"
+    r"|_require_slide_permission"
+    r"|_require_export_job_access"
+    r"|_check_chat_permission"      # chat.py send/stream/async
+    r"|_require_manage"             # deck_contributors.py
+    r"|get_deck_permission"         # profiles.py / sessions.py inline checks
+    r")\s*[(,]"
+)
+
+ADMIN_PATH_PREFIXES = (
+    "/api/admin",                     # admin.py + admin_usage.py
+    "/api/settings/deck-prompts",     # HIGH-3
+    "/api/settings/slide-styles",     # HIGH-3
+)
+
+FEEDBACK_READ_PATHS = {
+    "/api/feedback/report/stats",
+    "/api/feedback/list",
+    "/api/feedback/report/summary",
+}
+
+IMAGE_READ_ACCEPTED_RISK = (
+    "Explicitly accepted cross-user IDOR risk — accepted because images are a "
+    "shared library with no per-deck binding to authorize against. Image IDs "
+    "are sequential integers, so any authenticated workspace user can "
+    "enumerate IDs and retrieve every user's image metadata (uploaded_by, "
+    "tags, description) and raw bytes. Reads stay open so a CAN_EDIT "
+    "collaborator opening the HTML editor on a shared deck can fetch the "
+    "author's images. Revisit if per-deck image binding lands; a cheaper "
+    "interim hardening is a random-UUID public identifier."
+)
+
+TOOLS_DISCOVERY_RATIONALE = (
+    "Discovery endpoint: enumerates Genie spaces / vector endpoints / model "
+    "endpoints for the caller's own agent config; results are already scoped "
+    "by the caller's OBO client; returns no deck data."
+)
+
+IDENTITIES_RATIONALE = (
+    "Workspace user/group lookup feeding the sharing picker (plus provider "
+    "info); authenticated-user metadata by design; returns no deck data."
+)
+
+FEEDBACK_WRITE_RATIONALE = (
+    "Feedback write endpoint: how regular users submit feedback; stays open."
+)
+
+# (method, path) -> rationale. Exemptions must be visible in review, not
+# implicit in the heuristic. Entries that do not trip the heuristic are kept
+# anyway for review visibility; the liveness test below keeps them honest.
+ALLOWLIST = {
+    ("GET", "/api/export/pptx/editable/available"):
+        "Capability probe: returns a boolean, no deck data.",
+    ("GET", "/api/export/google-slides/auth/callback"):
+        "OAuth callback (GET, popup flow); state-nonce binding lands in PR-4 "
+        "(MEDIUM-3).",
+    ("GET", "/api/images/{image_id}"): IMAGE_READ_ACCEPTED_RISK,
+    ("GET", "/api/images/{image_id}/data"): IMAGE_READ_ACCEPTED_RISK,
+    ("POST", "/api/images/upload"):
+        "Shared image library: any authenticated user may upload; writes to "
+        "existing images are owner-scoped (SDR-4437 HIGH-1).",
+    ("POST", "/api/feedback/chat"): FEEDBACK_WRITE_RATIONALE,
+    ("POST", "/api/feedback/submit"): FEEDBACK_WRITE_RATIONALE,
+    ("POST", "/api/feedback/survey"): FEEDBACK_WRITE_RATIONALE,
+    ("POST", "/api/sessions"):
+        "Creates a new session owned by the caller; the optional body "
+        "session_id names the NEW session — it does not reference another "
+        "principal's resource.",
+    # NOT exemptions — these two ARE gated, by an inline creator-only check
+    # (session.created_by != get_current_user() -> 403, sessions.py). That is
+    # STRICTER than deck CAN_VIEW (conversations are private even to deck
+    # contributors) and has no helper name for the detector to match. Listed
+    # here for review visibility; tests/unit covers the 403 behavior.
+    ("GET", "/api/sessions/{session_id}/messages"):
+        "Gated inline: creator-only privacy check (403 for non-creators), "
+        "stricter than deck CAN_VIEW; no helper name to detect.",
+    ("POST", "/api/sessions/{session_id}/messages"):
+        "Gated inline: creator-only privacy check (403 for non-creators), "
+        "stricter than deck CAN_VIEW; no helper name to detect.",
+    # HIGH-3 gates library WRITES only — reads stay open (users browse the
+    # prompt/style libraries to pick one); flagged only because the whole
+    # settings prefix is marked sensitive.
+    ("GET", "/api/settings/deck-prompts"):
+        "Read-only library browse; HIGH-3 admin-gates writes only.",
+    ("GET", "/api/settings/deck-prompts/{prompt_id}"):
+        "Read-only library browse; HIGH-3 admin-gates writes only.",
+    ("GET", "/api/settings/slide-styles"):
+        "Read-only library browse; HIGH-3 admin-gates writes only.",
+    ("GET", "/api/settings/slide-styles/{style_id}"):
+        "Read-only library browse; HIGH-3 admin-gates writes only.",
+    ("GET", "/api/tools/available"): TOOLS_DISCOVERY_RATIONALE,
+    ("GET", "/api/tools/discover/genie"): TOOLS_DISCOVERY_RATIONALE,
+    ("GET", "/api/tools/discover/vector"): TOOLS_DISCOVERY_RATIONALE,
+    ("GET", "/api/tools/discover/vector/{endpoint_name}/indexes"): TOOLS_DISCOVERY_RATIONALE,
+    # NOTE: APIRoute.path preserves the raw ":path" converter suffix.
+    ("GET", "/api/tools/discover/vector/{endpoint_name}/{index_name:path}/columns"): TOOLS_DISCOVERY_RATIONALE,
+    ("GET", "/api/tools/discover/mcp"): TOOLS_DISCOVERY_RATIONALE,
+    ("GET", "/api/tools/discover/model-endpoints"): TOOLS_DISCOVERY_RATIONALE,
+    ("GET", "/api/tools/discover/agent-bricks"): TOOLS_DISCOVERY_RATIONALE,
+    ("GET", "/api/settings/identities/provider"): IDENTITIES_RATIONALE,
+    ("GET", "/api/settings/identities/users"): IDENTITIES_RATIONALE,
+    ("GET", "/api/settings/identities/groups"): IDENTITIES_RATIONALE,
+    ("GET", "/api/settings/identities/search"): IDENTITIES_RATIONALE,
+}
+
+
+def _api_routes():
+    for route in app.routes:
+        if isinstance(route, APIRoute) and route.path.startswith("/api"):
+            yield route
+
+
+def _model_classes(annotation):
+    """Yield Pydantic models in an annotation, unwrapping Optional/Union."""
+    if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
+        yield annotation
+        return
+    for arg in get_args(annotation):
+        yield from _model_classes(arg)
+
+
+def _route_param_names(route: APIRoute) -> set:
+    """Path params + query/body param names + fields of Pydantic body models.
+
+    The body-model recursion is load-bearing: ExportPPTXRequest.session_id,
+    VerifySlideRequest.session_id and ChatRequest.session_id only exist as
+    body-model fields — path/query inspection alone would never flag those
+    routes, which is the exact regression this test exists to prevent.
+    """
+    names = set(route.param_convertors.keys())
+    try:
+        # eval_str resolves string annotations (from __future__ import annotations)
+        sig = inspect.signature(route.endpoint, eval_str=True)
+    except (NameError, TypeError):
+        sig = inspect.signature(route.endpoint)
+    for param in sig.parameters.values():
+        names.add(param.name)
+        for model in _model_classes(param.annotation):
+            names.update(model.model_fields.keys())
+    return names
+
+
+def _has_require_admin(route: APIRoute) -> bool:
+    return any(
+        dep.call is _authz.require_admin for dep in route.dependant.dependencies
+    )
+
+
+def _has_permission_call(route: APIRoute) -> bool:
+    """True if the handler source MENTIONS a verified gate name.
+
+    This is a mention test, not an enforcement test: a listed name in a
+    comment, docstring, or log line — or a call that resolves a permission
+    without raising on it — matches just the same. The coverage test is
+    therefore a tripwire for *forgotten* gates only; the per-endpoint 403
+    tests each fan-out task writes are the behavioral enforcement
+    guarantee. Never satisfy this test by merely naming a helper in
+    handler source.
+    """
+    try:
+        source = inspect.getsource(route.endpoint)
+    except (OSError, TypeError):
+        return False
+    return bool(_PERMISSION_CALL_RE.search(source))
+
+
+def _is_sensitive(route: APIRoute) -> bool:
+    if route.path.startswith(ADMIN_PATH_PREFIXES):
+        return True
+    if route.path in FEEDBACK_READ_PATHS:
+        return True
+    return bool(TRIGGER_PARAMS & _route_param_names(route))
+
+
+def test_every_sensitive_route_is_gated():
+    failures = []
+    for route in _api_routes():
+        for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
+            if not _is_sensitive(route):
+                continue
+            if (method, route.path) in ALLOWLIST:
+                continue
+            if _has_require_admin(route) or _has_permission_call(route):
+                continue
+            failures.append(f"{method} {route.path} ({route.endpoint.__name__})")
+    assert not failures, (
+        "Ungated sensitive routes (add a permission gate, or an ALLOWLIST "
+        "entry with a written rationale):\n  " + "\n  ".join(failures)
+    )
+
+
+def test_allowlist_entries_are_live_routes():
+    """A deleted/renamed route must not leave a stale exemption behind."""
+    live = {
+        (method, route.path)
+        for route in _api_routes()
+        for method in route.methods
+    }
+    stale = [key for key in ALLOWLIST if key not in live]
+    assert not stale, f"Stale ALLOWLIST entries: {stale}"
+
+
+def test_trigger_detection_recurses_into_body_models():
+    """Self-test for the load-bearing body-model recursion."""
+    route = next(
+        r for r in _api_routes()
+        if r.path == "/api/export/pptx" and "POST" in r.methods
+    )
+    # session_id exists ONLY as an ExportPPTXRequest body field here.
+    assert "session_id" in _route_param_names(route)
+
+
+def test_permission_call_detection_matches_to_thread_form():
+    """Self-test: gates invoked as `asyncio.to_thread(_gate, ...)` must count.
+
+    GET /api/sessions/{session_id}/slides is already gated via
+    `await asyncio.to_thread(_check_deck_permission_for_session, session_id,
+    PermissionLevel.CAN_VIEW)` (sessions.py) — the helper name is followed by
+    a comma there, not `(`. If the detector regresses to a direct-call-only
+    regex, this test fails before the six to_thread-gated sessions.py routes
+    (and the Task-12 chat-poll gate) show up as false red.
+    """
+    route = next(
+        r for r in _api_routes()
+        if r.path == "/api/sessions/{session_id}/slides" and "GET" in r.methods
+    )
+    assert _has_permission_call(route)

--- a/tests/unit/test_route_authz_coverage.py
+++ b/tests/unit/test_route_authz_coverage.py
@@ -123,6 +123,16 @@ ALLOWLIST = {
     ("POST", "/api/sessions/{session_id}/messages"):
         "Gated inline: creator-only privacy check (403 for non-creators), "
         "stricter than deck CAN_VIEW; no helper name to detect.",
+    # Duplicate-deck (added by #213, post-dates PR-2's fan-out). Gated in the
+    # service layer, not the route facade: the handler calls
+    # session_manager.duplicate_session(..., min_permission=CAN_VIEW), which
+    # runs _require_deck_permission on the SOURCE deck and raises
+    # SessionAccessDeniedError -> 403 before copying. Verified enforcing
+    # (session_manager.py:553-554); no route-level helper name to detect.
+    ("POST", "/api/sessions/{session_id}/duplicate"):
+        "Gated in service layer: duplicate_session(min_permission=CAN_VIEW) "
+        "enforces deck CAN_VIEW on the source before copying; no helper name "
+        "to detect at the route.",
     # HIGH-3 gates library WRITES only — reads stay open (users browse the
     # prompt/style libraries to pick one); flagged only because the whole
     # settings prefix is marked sensitive.

--- a/tests/unit/test_route_authz_coverage.py
+++ b/tests/unit/test_route_authz_coverage.py
@@ -44,6 +44,13 @@ _PERMISSION_CALL_RE = re.compile(
     r"|_require_manage"             # deck_contributors.py
     r"|get_deck_permission"         # profiles.py / sessions.py inline checks
     r")\s*[(,]"
+    # images.py PUT/DELETE enforce HIGH-1 owner-scoping with a bespoke inline
+    # check rather than a deck-permission helper: `if image.uploaded_by !=
+    # <caller>: raise HTTPException(403, ...)`. Verified enforcing (per-endpoint
+    # 403 tests: test_update_image_other_owner_403 / test_delete_image_other_owner_403
+    # in test_authz_images.py) — the `!=`-then-raise IS the gate. Matched as a
+    # verified enforcement token per the Task-4/Task-15 decision procedure.
+    r"|image\.uploaded_by\s*!="
 )
 
 ADMIN_PATH_PREFIXES = (

--- a/tests/unit/test_security_permission_checks.py
+++ b/tests/unit/test_security_permission_checks.py
@@ -168,8 +168,11 @@ class TestGetSessionSlidesPermission:
         mock_mgr.get_slide_deck.return_value = None
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_stranger_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_stranger_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(get_session_slides(owner_session.session_id))
             assert exc_info.value.status_code == 403
@@ -183,8 +186,11 @@ class TestGetSessionSlidesPermission:
         mock_mgr.get_slide_deck.return_value = None
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_viewer_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_viewer_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             result = _run(get_session_slides(owner_session.session_id))
             assert "session_id" in result
 
@@ -197,8 +203,11 @@ class TestGetSessionSlidesPermission:
         mock_mgr.get_slide_deck.return_value = None
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_owner_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_owner_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             result = _run(get_session_slides(owner_session.session_id))
             assert "session_id" in result
 
@@ -219,8 +228,11 @@ class TestExportSessionPermission:
         mock_mgr.get_session.return_value = _make_session_info(owner_session)
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_stranger_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_stranger_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(export_session(owner_session.session_id))
             assert exc_info.value.status_code == 403
@@ -234,8 +246,11 @@ class TestExportSessionPermission:
         mock_mgr.get_slide_deck.return_value = None
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_viewer_ctx()), \
+             patch("src.api.routes._authz.get_permission_context", return_value=_viewer_ctx()), \
              patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)), \
              patch("src.api.routes.sessions.Path"):
             import builtins
             with patch.object(builtins, "open", MagicMock()):
@@ -259,9 +274,12 @@ class TestAcquireEditingLockPermission:
         mock_mgr.get_session.return_value = _make_session_info(owner_session)
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_current_user", return_value="stranger@test.com"), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_stranger_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_stranger_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(acquire_editing_lock(owner_session.session_id))
             assert exc_info.value.status_code == 403
@@ -275,9 +293,12 @@ class TestAcquireEditingLockPermission:
         mock_mgr.get_session.return_value = _make_session_info(owner_session)
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_current_user", return_value="viewer@test.com"), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_viewer_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_viewer_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(acquire_editing_lock(owner_session.session_id))
             assert exc_info.value.status_code == 403
@@ -290,9 +311,12 @@ class TestAcquireEditingLockPermission:
         mock_mgr.acquire_editing_lock.return_value = {"locked": True}
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_current_user", return_value="editor@test.com"), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_editor_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_editor_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             result = _run(acquire_editing_lock(owner_session.session_id))
             assert result == {"locked": True}
 
@@ -310,9 +334,12 @@ class TestAcquireEditingLockPermission:
         )
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_current_user", return_value="editor@test.com"), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_editor_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_editor_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(acquire_editing_lock(missing_id))
             assert exc_info.value.status_code == 404
@@ -330,9 +357,12 @@ class TestReleaseEditingLockPermission:
         mock_mgr.get_session.return_value = _make_session_info(owner_session)
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_current_user", return_value="stranger@test.com"), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_stranger_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_stranger_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(release_editing_lock(owner_session.session_id))
             assert exc_info.value.status_code == 403
@@ -349,8 +379,11 @@ class TestGetEditingLockStatusPermission:
         mock_mgr.get_session.return_value = _make_session_info(owner_session)
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_stranger_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_stranger_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(get_editing_lock_status(owner_session.session_id))
             assert exc_info.value.status_code == 403
@@ -363,8 +396,11 @@ class TestGetEditingLockStatusPermission:
         mock_mgr.get_editing_lock_status.return_value = {"locked": False}
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_viewer_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_viewer_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             result = _run(get_editing_lock_status(owner_session.session_id))
             assert result == {"locked": False}
 
@@ -380,9 +416,12 @@ class TestHeartbeatEditingLockPermission:
         mock_mgr.get_session.return_value = _make_session_info(owner_session)
 
         with patch("src.api.routes.sessions.get_session_manager", return_value=mock_mgr), \
+             patch("src.api.routes._authz.get_session_manager", return_value=mock_mgr), \
              patch("src.api.routes.sessions.get_current_user", return_value="stranger@test.com"), \
              patch("src.api.routes.sessions.get_permission_context", return_value=_stranger_ctx()), \
-             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)):
+             patch("src.api.routes._authz.get_permission_context", return_value=_stranger_ctx()), \
+             patch("src.api.routes.sessions.get_db_session", _fake_db_session(db)), \
+             patch("src.api.routes._authz.get_db_session", _fake_db_session(db)):
             with pytest.raises(HTTPException) as exc_info:
                 _run(heartbeat_editing_lock(owner_session.session_id))
             assert exc_info.value.status_code == 403

--- a/tests/unit/test_user_client_fail_closed.py
+++ b/tests/unit/test_user_client_fail_closed.py
@@ -1,0 +1,117 @@
+"""HIGH-6 regression tests: get_user_client() fails closed in production.
+
+The chat path spawns the agent and title-gen threads via
+contextvars.copy_context() (chat_service.py:1041/1102) — that dependency is
+what the two thread tests pin down.
+"""
+
+import contextvars
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.databricks_client import (
+    get_user_client,
+    reset_user_client,
+    set_user_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    reset_user_client()
+    yield
+    reset_user_client()
+
+
+def test_error_class_exists():
+    from src.core.databricks_client import UserClientRequiredError
+
+    assert issubclass(UserClientRequiredError, Exception)
+
+
+def test_raises_in_production_when_unbound(monkeypatch):
+    from src.core.databricks_client import UserClientRequiredError
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    with pytest.raises(UserClientRequiredError):
+        get_user_client()
+
+
+def test_returns_bound_client_in_production(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    client = MagicMock()
+    set_user_client(client)
+    assert get_user_client() is client
+
+
+def test_falls_back_to_system_client_outside_production(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    fake_system = object()
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda: fake_system
+    )
+    assert get_user_client() is fake_system
+
+
+def test_thread_without_context_propagation_raises(monkeypatch):
+    """A thread spawned WITHOUT copy_context must fail closed, not run as SP."""
+    from src.core.databricks_client import UserClientRequiredError
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    set_user_client(MagicMock())  # bound on the spawning thread only
+    outcome = {}
+
+    def worker():
+        try:
+            get_user_client()
+            outcome["result"] = "resolved"
+        except UserClientRequiredError:
+            outcome["result"] = "raised"
+
+    t = threading.Thread(target=worker)  # threading.Thread does NOT copy context
+    t.start()
+    t.join()
+    assert outcome["result"] == "raised"
+
+
+def test_thread_with_copy_context_resolves(monkeypatch):
+    """The chat-path pattern (copy_context) keeps working after the change."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    client = MagicMock()
+    set_user_client(client)
+    ctx = contextvars.copy_context()
+    outcome = {}
+
+    def worker():
+        outcome["client"] = ctx.run(get_user_client)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    assert outcome["client"] is client
+
+
+# ---------------------------------------------------------------------------
+# 401 mapping in main.py
+# ---------------------------------------------------------------------------
+
+
+def test_exception_handler_registered_on_app():
+    from src.api.main import app
+    from src.core.databricks_client import UserClientRequiredError
+
+    assert UserClientRequiredError in app.exception_handlers
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_returns_401_reauthenticate():
+    from src.api.main import user_client_required_handler
+    from src.core.databricks_client import UserClientRequiredError
+
+    resp = await user_client_required_handler(
+        MagicMock(), UserClientRequiredError("no client")
+    )
+    assert resp.status_code == 401
+    assert b"re-authenticate" in resp.body


### PR DESCRIPTION
## SDR-4437 PR-2 — Authorization / IDOR + admin role

Per-handler deck-permission gates on every session/job/request/image-scoped route, an admin primitive, fail-closed `get_user_client()`, and a route-table coverage test that makes any future ungated route a CI failure.

- **HIGH-1 / HIGH-4** — ownership/permission gates on previously-ungated handlers (export session+job IDOR, image owner-scoped writes, verification, tour, slides version endpoints, chat-poll IDOR, Google Slides export/poll, agent-config). Consolidated helpers into `src/api/routes/_authz.py`.
- **HIGH-2** — admin primitive `require_admin` (see admin-model note).
- **HIGH-3** — global library / deck-prompt / slide-style **writes** behind admin.
- **HIGH-6** — `get_user_client()` fails closed in production + 401 handler; removed the exception-swallowing identity fallbacks.
- **MEDIUM-1** — huashu diagnostics admin-gated + response-slimmed. **MEDIUM-6** — admin/admin_usage/feedback-read gates.
- Ratified scope addition: `profiles.load_profile_into_session` (a cross-user `agent_config` write IDOR the spec missed) gated CAN_MANAGE.
- Fixed a latent route-shadowing bug found in passing (`GET /versions/current` shadowed by `/versions/{version_number}`).

### Admin-model note (design corrected during deployed testing)
The admin check went through three failed designs, all defeated by the same trap: each was validated against a full-scope CLI token, but a Databricks App runs on a **scoped-down OBO `x-forwarded-access-token`** that behaves differently. `apps.get_permissions` proved unusable as the primitive — the OBO token lacks the `access-management` scope, and the app's own SP is not in its own app ACL. Final design (**Direction C**): admin == the caller is a member of the workspace **`admins`** group, resolved from the caller's *own* OBO identity (`current_user.me().groups`, governed by `iam.current-user:read`, which the OBO token does carry). Presence-in-own-group → **cannot fail open** (a non-admin's `me().groups` won't contain `admins`, and a caller can't forge their own membership). Note this defines admin as **workspace-admin**, not per-app CAN_MANAGE.

**Verified on the deployed app** (`sdr4437-pr2`, `0.3.13.dev15`) as a real admin identity: the full admin surface (`/api/admin/*`, feedback reports, slide-style writes) returns 200; a non-`admins` caller is denied. Regression test `test_probe_non_admin_group_member_denied` locks the fail-open case shut.

**Tests:** route-authz coverage test GREEN; `test_authz_helpers.py` 17 passed (incl. all admin cases); zero net-new failures vs the pre-existing environmental baseline.

Baseline: `main@7c50339`.

This pull request and its description were written by Isaac.