### PR TITLE
gslides export: render each list as one text box, not one box per bullet

### DIFF
--- a/src/services/google_slides_prompts_defaults.py
+++ b/src/services/google_slides_prompts_defaults.py
@@ -87,10 +87,15 @@ TABLES (<table>):
     'textRange': {'type': 'ALL'}, 'style': {'fontSize': {'magnitude': 8, 'unit': 'PT'}}, 'fields': 'fontSize'}})
 
 BULLET / LIST ITEMS (<ul>, <ol>):
-- For each <li>, insertText the item text, then use createParagraphBullets (NOT updateParagraphStyle):
+- CRITICAL: render an ENTIRE <ul>/<ol> as ONE TEXT_BOX with one paragraph per <li>. Do NOT
+  create a separate shape/text box for each <li> — that produces a stack of single-line boxes
+  that is broken and painful to edit. One list => one createShape.
+- Build it as: one createShape (TEXT_BOX sized for the whole list), then ONE insertText whose
+  text is every <li> joined by newlines ('\\n'), then createParagraphBullets over the FULL range:
   {'createParagraphBullets': {'objectId': id,
-    'textRange': {'type': 'FIXED_RANGE', 'startIndex': start, 'endIndex': end},
+    'textRange': {'type': 'ALL'},
     'bulletPreset': 'BULLET_DISC_CIRCLE_SQUARE'}}
+  Every newline-separated line becomes its own bulleted paragraph in that single box.
 - CRITICAL: bulletPreset is ONLY valid inside createParagraphBullets. Do NOT put it inside updateParagraphStyle.
 - Ordered lists: use bulletPreset 'NUMBERED_DIGIT_ALPHA_ROMAN'.
 - To adjust indentation after bullets, use a separate updateParagraphStyle with indentStart/indentFirstLine.


### PR DESCRIPTION
The Google Slides codegen prompt told the LLM to insertText + createParagraphBullets per `<li>` but never said the `<li>`s of a list must share ONE text box. The model routinely emitted a separate TEXT_BOX per bullet, so a single `<ul>` became a stack of disconnected single-line boxes that is awkward to select, move, and edit in Slides.

Make the invariant explicit: an entire `<ul>/<ol>` is ONE createShape, one insertText with the items joined by newlines, and one createParagraphBullets over the full range so each line becomes its own bulleted paragraph in that box.

Co-authored-by: Isaac