### PR TITLE
fix(encryption): boot-time Fernet key migration + app.yaml scrub (SDR-4437 CRITICAL-3)

### DIFF
--- a/.claude/skills/deploy-tellr-dev/SKILL.md
+++ b/.claude/skills/deploy-tellr-dev/SKILL.md
@@ -75,8 +75,8 @@ so the next fork inherits them too. See
 
 The Fernet master key lives in the `encryption_keys` Lakebase table, not
 `app.yaml`. **Boot** owns the one-time legacy→table migration: it seeds the row
-from `GOOGLE_OAUTH_ENCRYPTION_KEY` when the table is empty, then scrubs the
-plaintext key from `app.yaml`. The deploy tools only *carry any existing key
+from `GOOGLE_OAUTH_ENCRYPTION_KEY` when the table is empty, then best-effort
+scrubs the plaintext key from `app.yaml`. The deploy tools only *carry any existing key
 forward* into the regenerated `app.yaml` so boot can migrate it — they do not
 relocate it via DDL, and neither should any future dev-loop change (that
 deploy-only divergence is exactly what caused the original bug). The devloop fork

--- a/.claude/skills/deploy-tellr-dev/SKILL.md
+++ b/.claude/skills/deploy-tellr-dev/SKILL.md
@@ -71,6 +71,19 @@ role (via a serverless granter job) so its migrations run as owner through
 so the next fork inherits them too. See
 `docs/technical/lakebase-table-ownership.md` for the ownership model.
 
+## Fernet key handling (do not add a deploy-time migration)
+
+The Fernet master key lives in the `encryption_keys` Lakebase table, not
+`app.yaml`. **Boot** owns the one-time legacy→table migration: it seeds the row
+from `GOOGLE_OAUTH_ENCRYPTION_KEY` when the table is empty, then scrubs the
+plaintext key from `app.yaml`. The deploy tools only *carry any existing key
+forward* into the regenerated `app.yaml` so boot can migrate it — they do not
+relocate it via DDL, and neither should any future dev-loop change (that
+deploy-only divergence is exactly what caused the original bug). The devloop fork
+inherits the key by copy-on-write, so the fork preflight aborts unless the source
+env was migrated once first. See `docs/technical/dev-deploy.md` for the full
+rationale.
+
 ## Reading deploy logs
 
 App logs require OAuth (not PAT):

--- a/docs/superpowers/plans/2026-07-20-fernet-key-boot-migration.md
+++ b/docs/superpowers/plans/2026-07-20-fernet-key-boot-migration.md
@@ -1,0 +1,1037 @@
+# Fernet Key Boot Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Fernet master-key migration self-contained in the app artifact so every upgrade path (UI Deploy button, `tellr.update()`, `deploy_local`) migrates the legacy `GOOGLE_OAUTH_ENCRYPTION_KEY` into the `encryption_keys` table at boot instead of only in the deploy tool — eliminating the silent data-loss bug where a non-deploy-tool upgrade generates a fresh key and orphans existing ciphertext.
+
+**Architecture:** Three units. (1) Boot-time seed: `_seed_value()` reads the env var first, so the SELECT-first resolver seeds the table from it on the one-time cutover boot. (2) Boot-time self-scrub: a new best-effort `_scrub_app_yaml_key()` removes the plaintext key from the workspace app.yaml after confirming the table holds the matching valid key, never blocking boot. (3) Deploy-tool carry-forward: `tellr.update()` and `deploy_local update` stop doing deploy-time DDL relocation and instead re-emit the existing key into the regenerated app.yaml so boot can migrate it; the fork/branching precondition that guards against forking an unmigrated source is KEPT.
+
+**Tech Stack:** Python 3.11 (Databricks Apps runtime), SQLAlchemy (SQLite in tests, Lakebase Postgres in prod), `cryptography.fernet`, `databricks-sdk` (`WorkspaceClient`), `string.Template` for app.yaml generation, PyYAML, pytest.
+
+## Global Constraints
+
+- **Target runtime is Python 3.11** — no `os.unshare`, no 3.12-only APIs; `datetime.utcnow` is avoided (the model supplies `CURRENT_TIMESTAMP` in SQL).
+- **`encryption.py` SQL statements stay schema-UNQUALIFIED** — the module runs against SQLite (tests) and Lakebase (where `search_path` resolves the bare name). Do NOT add schema qualification to statements in `src/core/encryption.py`.
+- **The scrub must NEVER raise out of the boot hook** — it is best-effort; a scrub failure can never abort boot or gate the data-loss fix. It lives in its own `try/except` call site in `run.py`, outside the `ensure_encryption_key()` block that does `raise SystemExit(1)`.
+- **The scrub must NEVER remove the last copy of the key** — it re-reads and validates the table key, and only removes the app.yaml entry when it exactly matches that validated key.
+- **`_read_existing_encryption_key` stays strict** — it raises `DeploymentError` on an unreadable app.yaml (never returns None on error), because a silent skip would orphan ciphertext.
+- **The legacy-key fork precondition in `_check_branching_preconditions` is KEPT** — carry-forward does not run on the branching/fork path; the precondition is the only guard against forking an unmigrated source.
+- **Model contract for `encryption_keys`:** columns are exactly `{id: INTEGER PK non-autoincrement, key_value: TEXT NOT NULL, created_at: TIMESTAMP NOT NULL}`. Every insert path supplies `CURRENT_TIMESTAMP` explicitly.
+- **Commit after every task.** Branch off `main` (see Task 0). Do NOT push.
+- Env var name is exactly `GOOGLE_OAUTH_ENCRYPTION_KEY`. Runtime app-name env var is exactly `DATABRICKS_APP_NAME`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/core/encryption.py` | Boot key resolver + new self-scrub | Modify `_seed_value()`; add `_scrub_app_yaml_key()`; rewrite module docstring |
+| `packages/databricks-tellr-app/databricks_tellr_app/run.py` | Boot hook | Add a separate scrub call after the `ensure_encryption_key()` block |
+| `packages/databricks-tellr/databricks_tellr/deploy.py` | Deploy tool | Add `encryption_key` param to `_write_app_yaml`; convert `_update_databricks` to carry-forward; delete `_migrate_encryption_key_to_lakebase` |
+| `packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template` | Generated app.yaml | Add `$ENCRYPTION_KEY_BLOCK` placeholder |
+| `scripts/deploy_local.py` | Local deploy tool | Convert `update_local` to carry-forward; remove dead imports; KEEP fork precondition |
+| `tests/unit/test_encryption.py` | Unit tests | Add env-seed + scrub tests |
+| `tests/unit/test_deploy_encryption_key_migration.py` | Unit tests | Repurpose from DDL-relocation to carry-forward |
+| `tests/unit/test_deploy_local_preflight.py` | Unit tests | Unchanged assertions (precondition kept) — verify still green |
+| `.claude/skills/deploy-tellr-dev/`, `docs/technical/dev-deploy.md` | Docs | Document boot-migration + carry-forward |
+
+---
+
+## Task 0: Branch setup
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Create the working branch off main**
+
+The spec scopes this as new work separate from the review-clean PR-4 branch. Verify the current branch, then branch off `main`.
+
+Run:
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator
+git status --short && git branch --show-current
+```
+Expected: shows the current branch (likely `security/sdr4437-pr4-oauth-errors`). The plan/spec docs under `docs/superpowers/` are untracked or committed there.
+
+- [ ] **Step 2: Branch off main**
+
+Run:
+```bash
+git fetch origin
+git checkout -b security/fernet-key-boot-migration origin/main
+```
+Expected: new branch created from `origin/main`.
+
+- [ ] **Step 3: Bring the spec + plan onto the branch**
+
+The spec (`docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md`) and this plan were committed on the previous branch. Cherry-pick or copy them so they travel with the work:
+```bash
+git checkout security/sdr4437-pr4-oauth-errors -- docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md docs/superpowers/plans/2026-07-20-fernet-key-boot-migration.md
+git add docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md docs/superpowers/plans/2026-07-20-fernet-key-boot-migration.md
+git commit -m "docs: carry fernet-key-boot-migration spec + plan onto feature branch"
+```
+Expected: both docs present on `security/fernet-key-boot-migration`.
+
+> Note: if `main` already contains these docs (merged), skip Step 3.
+
+---
+
+## Task 1: Boot-time env-var seed (the correctness fix)
+
+**Files:**
+- Modify: `src/core/encryption.py` (`_seed_value`, lines 66-74; module docstring, lines 1-24)
+- Test: `tests/unit/test_encryption.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `_seed_value()` now returns the `GOOGLE_OAUTH_ENCRYPTION_KEY` env value (as `bytes`) when set and the table is empty; unchanged return type (`bytes`). `get_encryption_key()` behaviour is unchanged except for this new highest-priority seed source.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_encryption.py` (the `db` fixture already patches the session factory and `_KEY_FILE`; env is controlled via `monkeypatch`):
+
+```python
+def test_env_var_seeds_empty_table(db, monkeypatch):
+    """SDR-4437: the one-time legacy→table migration. An empty table plus a
+    GOOGLE_OAUTH_ENCRYPTION_KEY env var seeds the table from that env value."""
+    engine, _ = db
+    legacy = Fernet.generate_key().decode()
+    monkeypatch.setenv("GOOGLE_OAUTH_ENCRYPTION_KEY", legacy)
+    assert get_encryption_key() == legacy.encode()
+    assert _stored_key(engine) == legacy
+
+
+def test_env_var_takes_priority_over_key_file(db, tmp_path, monkeypatch):
+    """When both are present on an empty table, the env var (migration source)
+    wins over the legacy key file."""
+    engine, _ = db
+    env_key = Fernet.generate_key().decode()
+    file_key = Fernet.generate_key().decode()
+    (tmp_path / ".encryption_key").write_text(file_key)
+    monkeypatch.setenv("GOOGLE_OAUTH_ENCRYPTION_KEY", env_key)
+    assert get_encryption_key() == env_key.encode()
+    assert _stored_key(engine) == env_key
+
+
+def test_existing_row_ignores_env_var(db, monkeypatch):
+    """One-time cutover: once the row exists, the env var is never consulted."""
+    engine, session = db
+    existing = Fernet.generate_key().decode()
+    with session() as s:
+        s.execute(
+            text(
+                "INSERT INTO encryption_keys (id, key_value, created_at) "
+                "VALUES (1, :k, CURRENT_TIMESTAMP)"
+            ),
+            {"k": existing},
+        )
+    monkeypatch.setenv("GOOGLE_OAUTH_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    assert get_encryption_key() == existing.encode()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/unit/test_encryption.py::test_env_var_seeds_empty_table tests/unit/test_encryption.py::test_env_var_takes_priority_over_key_file -v`
+Expected: FAIL — `test_env_var_seeds_empty_table` and `_takes_priority` fail because `_seed_value()` currently ignores the env var (it generates a fresh key or reads the file). (`test_existing_row_ignores_env_var` will already PASS because SELECT-first never calls `_seed_value` — that's fine; it locks in the invariant.)
+
+- [ ] **Step 3: Modify `_seed_value()` to read the env var first**
+
+In `src/core/encryption.py`, replace the current `_seed_value` (lines 66-74):
+
+```python
+def _seed_value() -> bytes:
+    """Pick the value to seed an empty encryption_keys table with."""
+    if _KEY_FILE.exists():
+        key = _KEY_FILE.read_text().strip()
+        if key:
+            logger.info("Seeding encryption_keys from legacy key file %s", _KEY_FILE)
+            return key.encode()
+    logger.info("Generating new Fernet master key (fresh install)")
+    return Fernet.generate_key()
+```
+
+with:
+
+```python
+def _seed_value() -> bytes:
+    """Pick the value to seed an empty encryption_keys table with.
+
+    Priority (SELECT-first in get_encryption_key means this runs only when the
+    table is empty):
+    1. GOOGLE_OAUTH_ENCRYPTION_KEY env var — the one-time legacy→table
+       migration (SDR-4437 CRITICAL-3 follow-up). Present on the cutover boot
+       via the reused app.yaml (UI Deploy) or carry-forward (deploy tools).
+    2. legacy .encryption_key file (local dev — keeps dev ciphertext readable).
+    3. a freshly generated key (genuinely new install).
+    """
+    env_key = os.getenv("GOOGLE_OAUTH_ENCRYPTION_KEY")
+    if env_key and env_key.strip():
+        logger.info("Seeding encryption_keys from GOOGLE_OAUTH_ENCRYPTION_KEY (migration)")
+        return env_key.strip().encode()
+    if _KEY_FILE.exists():
+        key = _KEY_FILE.read_text().strip()
+        if key:
+            logger.info("Seeding encryption_keys from legacy key file %s", _KEY_FILE)
+            return key.encode()
+    logger.info("Generating new Fernet master key (fresh install)")
+    return Fernet.generate_key()
+```
+
+Add `import os` to the imports at the top of the file if not already present (currently the file imports `logging`, `functools.lru_cache`, `pathlib.Path` — `os` is NOT yet imported, so add it).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_encryption.py -v`
+Expected: PASS — all new tests plus the existing suite (fresh-install, existing-row-wins, key-file-seed, concurrent-seed, roundtrip, corrupt-key) stay green.
+
+- [ ] **Step 5: Rewrite the module docstring**
+
+In `src/core/encryption.py`, replace the "There is deliberately NO env-var fallback…" paragraph (lines 20-23) with:
+
+```
+The seed order on an empty table is env var → legacy key file → fresh generate
+(see ``_seed_value``). The ``GOOGLE_OAUTH_ENCRYPTION_KEY`` env-var read is the
+one-time legacy→table migration (SDR-4437 CRITICAL-3 follow-up): it reverses
+PR-3's original "no env-var fallback" decision, which caused silent data loss on
+any upgrade that did not go through the deploy tool. Because resolution is
+SELECT-first, the env var is consulted only on the cutover boot; every later
+boot reads the row. ``_scrub_app_yaml_key`` then removes the now-redundant
+plaintext key from the workspace app.yaml (best-effort).
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/encryption.py tests/unit/test_encryption.py
+git commit -m "fix(encryption): seed encryption_keys from env var (boot-time key migration)
+
+Re-adds the GOOGLE_OAUTH_ENCRYPTION_KEY read to _seed_value as the highest-
+priority seed source. Because get_encryption_key is SELECT-first, this is a
+one-time cutover that fixes the CRITICAL-3 data-loss bug on every upgrade path.
+
+Co-authored-by: Isaac"
+```
+
+---
+
+## Task 2: Boot-time self-scrub function
+
+**Files:**
+- Modify: `src/core/encryption.py` (add `_scrub_app_yaml_key()`)
+- Test: `tests/unit/test_encryption.py`
+
+**Interfaces:**
+- Consumes: `get_encryption_key()` (to obtain/validate the table key), `os.getenv("DATABRICKS_APP_NAME")`, `src.core.databricks_client.get_system_client()` → `WorkspaceClient`.
+- Produces: `_scrub_app_yaml_key() -> None`. Best-effort; never raises. Removes the `GOOGLE_OAUTH_ENCRYPTION_KEY` env entry from `{default_source_code_path}/app.yaml` only when its value equals the validated table key.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_encryption.py`:
+
+```python
+import yaml
+from unittest.mock import MagicMock
+
+
+def _app_yaml_bytes(with_key: str | None) -> bytes:
+    env = [{"name": "ENVIRONMENT", "value": "production"}]
+    if with_key is not None:
+        env.append({"name": "GOOGLE_OAUTH_ENCRYPTION_KEY", "value": with_key})
+    return yaml.safe_dump({"name": "tellr", "env": env}).encode()
+
+
+def _mock_ws_with_app_yaml(content_bytes: bytes, source_path="/Workspace/x"):
+    ws = MagicMock()
+    ws.apps.get.return_value = MagicMock(default_source_code_path=source_path)
+    resp = MagicMock()
+    resp.read.return_value = content_bytes
+    ws.workspace.download.return_value = resp
+    return ws
+
+
+def test_scrub_noop_when_app_name_unset(db, monkeypatch):
+    """Local/SQLite/tests have no DATABRICKS_APP_NAME → scrub is a no-op."""
+    from src.core.encryption import _scrub_app_yaml_key
+    monkeypatch.delenv("DATABRICKS_APP_NAME", raising=False)
+    called = []
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client",
+        lambda *a, **k: called.append(1),
+    )
+    _scrub_app_yaml_key()
+    assert called == []  # never even built a client
+
+
+def test_scrub_removes_entry_on_value_match(db, monkeypatch):
+    from src.core.encryption import _scrub_app_yaml_key
+    # Seed the table so get_encryption_key returns a known key.
+    key = get_encryption_key().decode()
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = _mock_ws_with_app_yaml(_app_yaml_bytes(with_key=key))
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()
+    # uploaded content must no longer contain the key entry
+    uploaded = ws.workspace.upload.call_args
+    assert uploaded is not None
+    body = uploaded.args[1] if len(uploaded.args) > 1 else uploaded.kwargs["content"]
+    text_body = body.decode() if isinstance(body, bytes) else (
+        body.read().decode() if hasattr(body, "read") else str(body)
+    )
+    assert "GOOGLE_OAUTH_ENCRYPTION_KEY" not in text_body
+
+
+def test_scrub_leaves_entry_on_value_mismatch(db, monkeypatch):
+    """A divergent key must NOT be removed — it might be the only copy of a
+    different key. Log and leave it."""
+    from src.core.encryption import _scrub_app_yaml_key
+    get_encryption_key()  # seed table
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = _mock_ws_with_app_yaml(_app_yaml_bytes(with_key="a-different-key"))
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()
+    ws.workspace.upload.assert_not_called()
+
+
+def test_scrub_noop_when_no_key_entry(db, monkeypatch):
+    """Already-scrubbed app.yaml → nothing to do, no upload (idempotent)."""
+    from src.core.encryption import _scrub_app_yaml_key
+    get_encryption_key()
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = _mock_ws_with_app_yaml(_app_yaml_bytes(with_key=None))
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()
+    ws.workspace.upload.assert_not_called()
+
+
+def test_scrub_swallows_download_failure(db, monkeypatch):
+    """Any failure (no ACL, download error) is caught — scrub never raises."""
+    from src.core.encryption import _scrub_app_yaml_key
+    get_encryption_key()
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = MagicMock()
+    ws.apps.get.return_value = MagicMock(default_source_code_path="/Workspace/x")
+    ws.workspace.download.side_effect = OSError("no read ACL")
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()  # must NOT raise
+    ws.workspace.upload.assert_not_called()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/unit/test_encryption.py -k scrub -v`
+Expected: FAIL — `ImportError: cannot import name '_scrub_app_yaml_key'`.
+
+- [ ] **Step 3: Implement `_scrub_app_yaml_key()`**
+
+Add to `src/core/encryption.py` (after `ensure_encryption_key`). Note `import os` and `import yaml` at the top (add `import yaml` — the module does not import it yet):
+
+```python
+def _scrub_app_yaml_key() -> None:
+    """Best-effort: remove the now-redundant plaintext GOOGLE_OAUTH_ENCRYPTION_KEY
+    from the deployed workspace app.yaml (SDR-4437 CRITICAL-3 hygiene).
+
+    NEVER raises and NEVER blocks boot. Only removes the entry when its value
+    matches the validated table key, so it can only ever delete a redundant
+    copy. No-op outside a Databricks Apps runtime. The rewritten app.yaml takes
+    effect on the NEXT deploy; the table is already the runtime source of truth.
+    """
+    app_name = os.getenv("DATABRICKS_APP_NAME")
+    if not app_name:
+        return  # local/SQLite/tests — nothing to scrub
+
+    try:
+        # 1. Re-read + validate the table key (never remove the last valid copy).
+        table_key = get_encryption_key()  # bytes; raises if corrupt
+        Fernet(table_key)  # explicit validation guard
+        table_key_str = table_key.decode()
+
+        # 2. Locate our own source folder.
+        from src.core.databricks_client import get_system_client
+
+        ws = get_system_client()
+        source_path = ws.apps.get(name=app_name).default_source_code_path
+        if not source_path:
+            logger.warning("Scrub: app has no default_source_code_path; skipping")
+            return
+
+        # 3. Download + parse the deployed app.yaml.
+        resp = ws.workspace.download(f"{source_path}/app.yaml")
+        raw = resp.read() if hasattr(resp, "read") else resp
+        content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+        parsed = yaml.safe_load(content) or {}
+        env_list = parsed.get("env", [])
+
+        entry = next(
+            (e for e in env_list if e.get("name") == "GOOGLE_OAUTH_ENCRYPTION_KEY"),
+            None,
+        )
+        if entry is None:
+            return  # already scrubbed / never had it — idempotent
+
+        # 4. Only remove on exact value match with the validated table key.
+        if entry.get("value") != table_key_str:
+            logger.warning(
+                "Scrub: app.yaml GOOGLE_OAUTH_ENCRYPTION_KEY differs from the "
+                "table key — leaving it in place for manual inspection."
+            )
+            return
+
+        parsed["env"] = [
+            e for e in env_list if e.get("name") != "GOOGLE_OAUTH_ENCRYPTION_KEY"
+        ]
+        new_content = yaml.safe_dump(parsed, sort_keys=False)
+        from databricks.sdk.service.workspace import ImportFormat
+
+        ws.workspace.upload(
+            f"{source_path}/app.yaml",
+            new_content.encode("utf-8"),
+            format=ImportFormat.AUTO,
+            overwrite=True,
+        )
+        logger.info("Scrub: removed plaintext encryption key from deployed app.yaml")
+    except Exception as exc:  # never propagate — best-effort by contract
+        logger.warning("Scrub: could not remove key from app.yaml (%s)", exc)
+```
+
+> NOTE on the test's upload-body assertion: the implementation passes the content as a positional `bytes` arg. The test reads `uploaded.args[1]`. Keep them consistent — content is arg index 1 (path is arg 0).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_encryption.py -k scrub -v`
+Expected: PASS — all five scrub tests green.
+
+- [ ] **Step 5: Run the full encryption suite**
+
+Run: `pytest tests/unit/test_encryption.py -v`
+Expected: PASS — Task 1 + Task 2 tests + pre-existing tests all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/encryption.py tests/unit/test_encryption.py
+git commit -m "feat(encryption): best-effort boot-time app.yaml key scrub
+
+Adds _scrub_app_yaml_key: removes the redundant plaintext key from the deployed
+app.yaml only after validating the table holds the matching key. Never raises,
+never blocks boot, no-op outside a Databricks Apps runtime.
+
+Co-authored-by: Isaac"
+```
+
+---
+
+## Task 3: Wire the scrub into the boot hook
+
+**Files:**
+- Modify: `packages/databricks-tellr-app/databricks_tellr_app/run.py` (`init_database`, after lines 65-75)
+- Test: `tests/unit/test_encryption.py`
+
+**Interfaces:**
+- Consumes: `src.core.encryption._scrub_app_yaml_key` (from Task 2).
+- Produces: `init_database()` calls the scrub in its own `try/except` after the `ensure_encryption_key()` block; a scrub exception is logged and swallowed (does NOT `SystemExit`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_encryption.py` (reuses the `_load_run_module` helper already in that file):
+
+```python
+def test_init_database_invokes_scrub_after_key_hook(monkeypatch):
+    """run.py::init_database calls _scrub_app_yaml_key after ensure_encryption_key."""
+    run = _load_run_module()
+    order = []
+    monkeypatch.setattr("src.core.database.init_db", lambda: None)
+    monkeypatch.setattr(
+        "src.core.init_default_profile.seed_defaults",
+        lambda include_databricks: None,
+    )
+    monkeypatch.setattr(
+        "src.core.encryption.ensure_encryption_key", lambda: order.append("ensure")
+    )
+    monkeypatch.setattr(
+        "src.core.encryption._scrub_app_yaml_key", lambda: order.append("scrub")
+    )
+    run.init_database()
+    assert order == ["ensure", "scrub"]
+
+
+def test_init_database_survives_scrub_failure(monkeypatch):
+    """A scrub failure must NOT abort boot (it is best-effort)."""
+    run = _load_run_module()
+    monkeypatch.setattr("src.core.database.init_db", lambda: None)
+    monkeypatch.setattr(
+        "src.core.init_default_profile.seed_defaults",
+        lambda include_databricks: None,
+    )
+    monkeypatch.setattr("src.core.encryption.ensure_encryption_key", lambda: None)
+
+    def _boom():
+        raise RuntimeError("scrub blew up")
+
+    monkeypatch.setattr("src.core.encryption._scrub_app_yaml_key", _boom)
+    # Must return normally — NO SystemExit.
+    run.init_database()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/unit/test_encryption.py -k "scrub_after or survives_scrub" -v`
+Expected: FAIL — `init_database` does not call `_scrub_app_yaml_key` yet.
+
+- [ ] **Step 3: Add the scrub call site in `run.py`**
+
+In `packages/databricks-tellr-app/databricks_tellr_app/run.py`, after the existing encryption-key block (the `try/except` ending at line 75 that logs "Encryption key ready"), add a SEPARATE block:
+
+```python
+    # Best-effort: remove the now-redundant plaintext key from the deployed
+    # app.yaml (SDR-4437 CRITICAL-3 hygiene). Deliberately a SEPARATE block with
+    # its own swallow-all except — a scrub failure must never abort boot, so it
+    # must not share the ensure_encryption_key block above (which SystemExits).
+    logger.info("Scrubbing legacy key from app.yaml (best-effort)...")
+    try:
+        from src.core.encryption import _scrub_app_yaml_key
+        _scrub_app_yaml_key()
+    except Exception as e:  # noqa: BLE001 — best-effort, never blocks boot
+        logger.warning(f"app.yaml key scrub skipped: {e}")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_encryption.py -k "scrub_after or survives_scrub" -v`
+Expected: PASS — ordering test and survive-failure test both green.
+
+- [ ] **Step 5: Run the run.py-related suite**
+
+Run: `pytest tests/unit/test_encryption.py -k "init_database" -v`
+Expected: PASS — the two pre-existing `init_database` tests plus the two new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/databricks-tellr-app/databricks_tellr_app/run.py tests/unit/test_encryption.py
+git commit -m "feat(run): call best-effort app.yaml key scrub at boot
+
+Separate try/except after ensure_encryption_key so a scrub failure logs and is
+swallowed rather than reaching the SystemExit(1) path.
+
+Co-authored-by: Isaac"
+```
+
+---
+
+## Task 4: Add `$ENCRYPTION_KEY_BLOCK` to the app.yaml template + `_write_app_yaml`
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template`
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py` (`_write_app_yaml`, lines 1363-1418)
+- Test: `tests/unit/test_deploy_encryption_key_migration.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `_write_app_yaml(..., encryption_key: str | None = None)`. When `encryption_key` is a non-empty string, the generated app.yaml contains a `GOOGLE_OAUTH_ENCRYPTION_KEY` env entry with that value; when `None`/empty, the app.yaml is keyless (exactly as today).
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new test class to `tests/unit/test_deploy_encryption_key_migration.py`:
+
+```python
+class TestWriteAppYamlKeyBlock:
+    def _read_yaml(self, staging):
+        import yaml
+        return yaml.safe_load((staging / "app.yaml").read_text())
+
+    def test_keyless_when_no_key(self, tmp_path):
+        from databricks_tellr.deploy import _write_app_yaml
+        _write_app_yaml(
+            tmp_path, "lb", SCHEMA,
+            lakebase_result={"type": "provisioned"},
+        )
+        parsed = self._read_yaml(tmp_path)
+        names = [e["name"] for e in parsed["env"]]
+        assert "GOOGLE_OAUTH_ENCRYPTION_KEY" not in names
+
+    def test_emits_entry_when_key_present(self, tmp_path):
+        from databricks_tellr.deploy import _write_app_yaml
+        _write_app_yaml(
+            tmp_path, "lb", SCHEMA,
+            lakebase_result={"type": "provisioned"},
+            encryption_key=KEY,
+        )
+        parsed = self._read_yaml(tmp_path)
+        entry = next(
+            e for e in parsed["env"] if e["name"] == "GOOGLE_OAUTH_ENCRYPTION_KEY"
+        )
+        assert entry["value"] == KEY
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/unit/test_deploy_encryption_key_migration.py::TestWriteAppYamlKeyBlock -v`
+Expected: FAIL — `_write_app_yaml` has no `encryption_key` param (`TypeError: unexpected keyword argument`), and the template has no key block.
+
+- [ ] **Step 3: Add the placeholder to the template**
+
+In `packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template`, add `$ENCRYPTION_KEY_BLOCK` as the LAST line of the `env:` section (after the `HUASHU_PIPELINE_ENABLED` block, lines 68-69). Place it at column 0 so the substituted block controls its own indentation:
+
+```yaml
+  - name: HUASHU_PIPELINE_ENABLED
+    value: "1"
+$ENCRYPTION_KEY_BLOCK
+```
+
+> `string.Template` requires EVERY `$name` to be supplied to `.substitute()` or it raises `KeyError`. Task adds the key to the substitute call in Step 4, so the template stays renderable.
+
+- [ ] **Step 4: Add the `encryption_key` param and block rendering to `_write_app_yaml`**
+
+In `packages/databricks-tellr/databricks_tellr/deploy.py`, change the signature (line 1363-1370) to add the param:
+
+```python
+def _write_app_yaml(
+    staging_dir: Path,
+    lakebase_name: str,
+    schema_name: str,
+    seed_databricks_defaults: bool = False,
+    lakebase_result: dict[str, Any] | None = None,
+    mlflow_tracing: dict[str, str] | None = None,
+    encryption_key: str | None = None,
+) -> None:
+```
+
+Update the docstring's first paragraph (lines 1373-1374) to:
+
+```
+    The Fernet encryption key is written ONLY when ``encryption_key`` is
+    provided (the one-time legacy→table carry-forward). Boot seeds the
+    encryption_keys table from it and then scrubs it from app.yaml. When
+    ``encryption_key`` is None the app.yaml is keyless (steady state).
+```
+
+Immediately before the `content = Template(...).substitute(...)` call (line 1401), build the block:
+
+```python
+    if encryption_key:
+        key_block = (
+            "  - name: GOOGLE_OAUTH_ENCRYPTION_KEY\n"
+            f'    value: "{encryption_key}"'
+        )
+    else:
+        key_block = ""
+```
+
+Add `ENCRYPTION_KEY_BLOCK=key_block,` to the `.substitute(...)` keyword arguments (alongside the existing `LAKEBASE_INSTANCE=...` etc.).
+
+> The block uses two-space indentation to match the other `- name:` entries under `env:`. When empty, the `$ENCRYPTION_KEY_BLOCK` line becomes a blank line, which is valid YAML.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_deploy_encryption_key_migration.py::TestWriteAppYamlKeyBlock -v`
+Expected: PASS — keyless and key-present cases both correct.
+
+- [ ] **Step 6: Verify the existing keyless-template test still passes**
+
+There is an existing test asserting the template/app.yaml is keyless (from PR-3, e.g. `test_write_app_yaml_is_keyless`). Run the full deploy test module:
+
+Run: `pytest tests/unit/test_deploy_encryption_key_migration.py -v`
+Expected: the `TestWriteAppYamlKeyBlock` tests PASS; note any failures in the `TestUpdateDatabricksWiring` / `TestMigrateEncryptionKey` classes — those are rewritten in Task 5, so failures there are expected and handled next.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_encryption_key_migration.py
+git commit -m "feat(deploy): _write_app_yaml can carry the encryption key forward
+
+Adds a \$ENCRYPTION_KEY_BLOCK placeholder + optional encryption_key param so the
+regenerated app.yaml re-emits GOOGLE_OAUTH_ENCRYPTION_KEY when a legacy key is
+carried forward; keyless otherwise.
+
+Co-authored-by: Isaac"
+```
+
+---
+
+## Task 5: Convert `_update_databricks` to carry-forward + delete the DDL relocation
+
+**Files:**
+- Modify: `packages/databricks-tellr/databricks_tellr/deploy.py` (`_update_databricks` key block lines 548-568; delete `_migrate_encryption_key_to_lakebase` lines 791-847)
+- Test: `tests/unit/test_deploy_encryption_key_migration.py`
+
+**Interfaces:**
+- Consumes: `_write_app_yaml(..., encryption_key=...)` (Task 4), `_read_existing_encryption_key` (kept).
+- Produces: `_update_databricks` reads any legacy key and passes it to `_write_app_yaml`; it no longer opens a Lakebase connection for key migration and no longer calls `_migrate_encryption_key_to_lakebase` (which is deleted).
+
+- [ ] **Step 1: Rewrite the wiring tests**
+
+Replace the `TestMigrateEncryptionKey` class AND the `TestUpdateDatabricksWiring` class in `tests/unit/test_deploy_encryption_key_migration.py` with carry-forward tests. Keep the `TestReadExistingEncryptionKeyStrict` class unchanged (the strict reader stays). Keep the top-of-file constants (`KEY`, `OTHER_KEY`, `CLIENT_ID`, `SCHEMA`). Update the import block (lines 9-13) to drop the deleted symbol:
+
+```python
+from databricks_tellr.deploy import (
+    DeploymentError,
+    _read_existing_encryption_key,
+)
+```
+
+Replace both classes with:
+
+```python
+class TestUpdateDatabricksCarryForward:
+    @patch("databricks_tellr.deploy._get_workspace_client")
+    @patch("databricks_tellr.deploy._get_or_create_lakebase")
+    @patch("databricks_tellr.deploy._check_breaking_migrations")
+    @patch("databricks_tellr.deploy._read_existing_encryption_key", return_value=KEY)
+    @patch("databricks_tellr.deploy._write_requirements")
+    @patch("databricks_tellr.deploy._write_app_yaml")
+    @patch("databricks_tellr.deploy._upload_files")
+    def test_legacy_key_is_carried_into_app_yaml(
+        self, mock_upload, mock_yaml, mock_reqs, mock_read,
+        mock_check, mock_lakebase, mock_ws_factory,
+    ):
+        from databricks_tellr.deploy import _update_databricks
+
+        ws = MagicMock()
+        mock_ws_factory.return_value = ws
+        mock_lakebase.return_value = {"type": "provisioned", "name": "lb"}
+        ws.apps.get.return_value = MagicMock(url="https://app")
+
+        _update_databricks(
+            app_name="app", app_file_workspace_path="/Workspace/x",
+            lakebase_name="lb", schema_name=SCHEMA,
+        )
+        # key is carried forward into the regenerated app.yaml
+        assert mock_yaml.call_args.kwargs.get("encryption_key") == KEY
+
+    @patch("databricks_tellr.deploy._get_workspace_client")
+    @patch("databricks_tellr.deploy._get_or_create_lakebase")
+    @patch("databricks_tellr.deploy._check_breaking_migrations")
+    @patch("databricks_tellr.deploy._read_existing_encryption_key", return_value=None)
+    @patch("databricks_tellr.deploy._write_requirements")
+    @patch("databricks_tellr.deploy._write_app_yaml")
+    @patch("databricks_tellr.deploy._upload_files")
+    def test_no_legacy_key_writes_keyless(
+        self, mock_upload, mock_yaml, mock_reqs, mock_read,
+        mock_check, mock_lakebase, mock_ws_factory,
+    ):
+        from databricks_tellr.deploy import _update_databricks
+
+        ws = MagicMock()
+        mock_ws_factory.return_value = ws
+        mock_lakebase.return_value = {"type": "provisioned", "name": "lb"}
+        ws.apps.get.return_value = MagicMock(url="https://app")
+
+        _update_databricks(
+            app_name="app", app_file_workspace_path="/Workspace/x",
+            lakebase_name="lb", schema_name=SCHEMA,
+        )
+        # keyless: encryption_key is None (or absent)
+        assert not mock_yaml.call_args.kwargs.get("encryption_key")
+
+    def test_migrate_function_is_removed(self):
+        """The deploy-time DDL relocation is gone; boot owns migration now."""
+        import databricks_tellr.deploy as d
+        assert not hasattr(d, "_migrate_encryption_key_to_lakebase")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/unit/test_deploy_encryption_key_migration.py::TestUpdateDatabricksCarryForward -v`
+Expected: FAIL — `_update_databricks` still runs DDL relocation and does not pass `encryption_key` to `_write_app_yaml`; `_migrate_encryption_key_to_lakebase` still exists.
+
+- [ ] **Step 3: Rewrite the `_update_databricks` key block**
+
+In `packages/databricks-tellr/databricks_tellr/deploy.py`, the current block (lines 527-529 read the key; lines 548-568 relocate it via DDL). Replace the DDL-relocation block (the whole `if encryption_key:` block at lines 552-568, starting `if encryption_key:` and ending at `print("   Key relocated ...`)` with NOTHING — remove it — and change the `_write_app_yaml` call (lines 573-580) to pass the key:
+
+The read at lines 527-529 stays:
+```python
+    # Preserve the existing key so boot can migrate it (carry-forward).
+    if not encryption_key:
+        encryption_key = _read_existing_encryption_key(ws, app_file_workspace_path)
+```
+
+Delete lines 548-568 (the `# CRITICAL-3 migration:` comment through `print("   Key relocated ...")`).
+
+Change the `_write_app_yaml` call to add `encryption_key=encryption_key`:
+```python
+            _write_app_yaml(
+                staging,
+                lakebase_name,
+                schema_name,
+                seed_databricks_defaults=seed_databricks_defaults,
+                lakebase_result=lakebase_result,
+                mlflow_tracing=mlflow_subs,
+                encryption_key=encryption_key,
+            )
+```
+
+- [ ] **Step 4: Delete `_migrate_encryption_key_to_lakebase`**
+
+Delete the entire function `_migrate_encryption_key_to_lakebase` (lines 791-847, from `def _migrate_encryption_key_to_lakebase(` through the closing `)` of the GRANT block). Leave `_read_existing_encryption_key` (lines 757-788) in place.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_deploy_encryption_key_migration.py -v`
+Expected: PASS — `TestUpdateDatabricksCarryForward` (3 tests), `TestReadExistingEncryptionKeyStrict` (3 tests), `TestWriteAppYamlKeyBlock` (2 tests) all green.
+
+- [ ] **Step 6: Update the DDL-validation test docstring**
+
+`tests/unit/test_ddl_identifier_validation.py` line 55 (docstring prose only, not an import) lists `_migrate_encryption_key_to_lakebase` as a validated site. Remove it from that docstring list so the doc stays accurate:
+
+Change lines 54-55 from:
+```
+    Validated sites (all call validate_schema_name before interpolating):
+    _migrate_encryption_key_to_lakebase, _setup_database_schema, _reset_schema,
+```
+to:
+```
+    Validated sites (all call validate_schema_name before interpolating):
+    _setup_database_schema, _reset_schema,
+```
+
+Run: `pytest tests/unit/test_ddl_identifier_validation.py -v`
+Expected: PASS — unchanged (the function was never imported there).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/databricks-tellr/databricks_tellr/deploy.py tests/unit/test_deploy_encryption_key_migration.py tests/unit/test_ddl_identifier_validation.py
+git commit -m "refactor(deploy): carry key forward in _update_databricks, delete DDL relocation
+
+tellr.update() now re-emits the legacy key into the regenerated app.yaml (boot
+migrates it) instead of doing a deploy-time DDL relocation into Lakebase.
+Deletes _migrate_encryption_key_to_lakebase.
+
+Co-authored-by: Isaac"
+```
+
+---
+
+## Task 6: Convert `deploy_local.update_local` to carry-forward + clean imports
+
+**Files:**
+- Modify: `scripts/deploy_local.py` (imports lines 33-49; `update_local` non-branching block lines 700-716; `_write_app_yaml` call lines 768-775)
+- Test: `tests/unit/test_deploy_local_preflight.py` (verify unchanged assertions still pass)
+
+**Interfaces:**
+- Consumes: `_write_app_yaml(..., encryption_key=...)` (Task 4), `_read_existing_encryption_key` (kept).
+- Produces: `update_local` carries any legacy key forward into the regenerated app.yaml; no Lakebase connection for key migration; the fork precondition (`_check_branching_preconditions`) is UNCHANGED.
+
+- [ ] **Step 1: Initialise the carry-forward variable before the branching split**
+
+In `scripts/deploy_local.py::update_local`, `legacy_key` is currently assigned only inside the non-branching `else:` (line 700). The shared `_write_app_yaml` call (line 768) runs on BOTH paths, so wire a value that is `None` on the fork path. Immediately before the `if branch_from_env:` split (before line 631), add:
+
+```python
+        # Carry-forward of the legacy encryption key into the regenerated
+        # app.yaml (boot migrates it). Only the non-branching path reads a
+        # source key; the fork path inherits the key via the COW table, so it
+        # stays None here.
+        carry_forward_key: str | None = None
+```
+
+- [ ] **Step 2: Rewrite the non-branching relocation block**
+
+Replace the non-branching `else:` relocation block (lines 700-716, from `legacy_key = _read_existing_encryption_key(ws, workspace_path)` through `print("   Key relocated")`) with:
+
+```python
+            legacy_key = _read_existing_encryption_key(ws, workspace_path)
+            if legacy_key:
+                # CRITICAL-3: carry the key forward into the regenerated
+                # app.yaml; boot seeds the table from it and scrubs. No more
+                # deploy-time DDL relocation.
+                carry_forward_key = legacy_key
+                print("   Carrying existing encryption key forward into app.yaml")
+```
+
+- [ ] **Step 3: Pass the key into the shared `_write_app_yaml` call**
+
+Change the `_write_app_yaml` call (lines 768-775) to add `encryption_key=carry_forward_key`:
+
+```python
+            _write_app_yaml(
+                staging_dir,
+                lakebase_name,
+                schema_name,
+                seed_databricks_defaults=seed_databricks_defaults,
+                lakebase_result=lakebase_result,
+                mlflow_tracing=mlflow_subs,
+                encryption_key=carry_forward_key,
+            )
+```
+
+- [ ] **Step 4: Remove now-dead imports**
+
+In the `from databricks_tellr.deploy import (...)` block (lines 33-49), remove two names that are no longer used:
+- `_migrate_encryption_key_to_lakebase` (line 40) — function deleted in Task 5.
+- `_get_lakebase_connection` (line 37) — its only use was the deleted relocation block (line 706); lines 548/687 are comments, not calls.
+
+> Keep `_read_existing_encryption_key` (line 44) — used by both the retained fork precondition (line 282) and the carry-forward read (line 700).
+
+Verify no other live use of `_get_lakebase_connection` remains:
+```bash
+grep -n "_get_lakebase_connection(" scripts/deploy_local.py
+```
+Expected: NO matches (only the comment mentions at 548/687, which don't have the trailing `(`). If a real call appears, keep the import and note it.
+
+- [ ] **Step 5: Verify the module imports cleanly**
+
+Run:
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator
+python -c "import sys; sys.path.insert(0, 'packages/databricks-tellr'); import scripts.deploy_local"
+```
+Expected: no `ImportError`, no `NameError`. (If `scripts` is not a package, run `python scripts/deploy_local.py --help` instead and expect the argparse help, not an import error.)
+
+- [ ] **Step 6: Run the preflight tests (must stay green — precondition kept)**
+
+Run: `pytest tests/unit/test_deploy_local_preflight.py -v`
+Expected: PASS — all 8 tests, unchanged. The legacy-key rejection (`test_preflight_fails_when_source_still_has_legacy_key`) and the not-deployed probe (`test_preflight_fails_when_source_not_deployed`) both still pass because `_check_branching_preconditions` is untouched.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/deploy_local.py
+git commit -m "refactor(deploy_local): carry key forward in update_local, drop dead imports
+
+update_local carries the legacy key into the regenerated app.yaml (boot
+migrates) instead of DDL relocation. Removes the _migrate_encryption_key_to_lakebase
+and _get_lakebase_connection imports (now unused). Fork precondition kept.
+
+Co-authored-by: Isaac"
+```
+
+---
+
+## Task 7: Full unit-suite convergence check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full backend unit suite**
+
+Run:
+```bash
+cd /Users/robert.whiffin/Documents/slide-generator/ai-slide-generator
+pytest tests/unit -q
+```
+Expected: PASS except the KNOWN pre-existing baseline failures documented in project memory (cairo/SVG-render, mlflow-tracing, autoscaling-mock). Confirm ZERO net-new failures attributable to this change. If any failure references `encryption`, `_write_app_yaml`, `_migrate_encryption_key_to_lakebase`, `deploy_local`, or `run.py`, fix it before proceeding.
+
+- [ ] **Step 2: Grep for any lingering references to the deleted function**
+
+Run:
+```bash
+grep -rn "_migrate_encryption_key_to_lakebase" --include="*.py" . | grep -v build/ | grep -v worktrees/
+```
+Expected: NO matches outside comments/docstrings. If a live import/call remains, remove it.
+
+- [ ] **Step 3: Commit any convergence fixes**
+
+```bash
+git add -A
+git commit -m "test: converge unit suite for fernet key boot migration
+
+Co-authored-by: Isaac"
+```
+(Skip if Step 1 was clean and nothing changed.)
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+- Modify: `docs/technical/dev-deploy.md`
+- Modify: `.claude/skills/deploy-tellr-dev/SKILL.md` (or the skill's main doc file — check the directory)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Inspect the deploy-tellr-dev skill file**
+
+Run:
+```bash
+ls -la .claude/skills/deploy-tellr-dev/
+```
+Identify the main doc (likely `SKILL.md`).
+
+- [ ] **Step 2: Add a "Fernet key handling" note to `docs/technical/dev-deploy.md`**
+
+Add a section stating:
+- The Fernet master key lives in the `encryption_keys` Lakebase table, not app.yaml.
+- On upgrade, boot seeds the table from `GOOGLE_OAUTH_ENCRYPTION_KEY` if the table is empty (one-time cutover), then best-effort scrubs the key from app.yaml.
+- Deploy tools (`tellr.update`, `deploy_local update`) carry any existing key forward into the regenerated app.yaml so boot can migrate it — they no longer relocate it via DDL.
+- The devloop/fork path relies on COW inheritance of the table and requires the source env to be migrated once first (enforced by the fork preflight).
+- **Rule reinforced:** because boot owns migration identically on every path, code that works under `deploy_local` also works under a UI-button upgrade — there is no dev/prod divergence in key handling.
+
+- [ ] **Step 3: Update the deploy-tellr-dev skill doc**
+
+Add the same key-handling summary (2-3 sentences) so a future dev-loop deploy does not reintroduce a deploy-only migration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/technical/dev-deploy.md .claude/skills/deploy-tellr-dev/
+git commit -m "docs(deploy): document boot-time key migration + carry-forward
+
+Co-authored-by: Isaac"
+```
+
+---
+
+## Task 9: Live verification (deployed instance — run from the MAIN session)
+
+> **Operational, not unit-testable.** Per project memory: CLI/local tests do NOT prove deployed OBO/SP behavior — only a deployed app does. Live deploys run from the MAIN session (coordinator-relayed deploys are classifier-blocked). Requires publishing a dev build (`publish-dev.yml` → `.devN`) and `deploy_local`.
+
+- [ ] **Step 1: Publish a dev build**
+
+Run: `gh workflow run publish-dev.yml` and note the published `.devN` version.
+
+- [ ] **Step 2: Stand up a legacy-style instance**
+
+Deploy a `0.3.12`-era build (env key in app.yaml) on a disposable devloop instance, log in as a real user, connect a Google credential so a real `token_encrypted` row is written under the legacy key.
+
+- [ ] **Step 3: UI-button upgrade → verify**
+
+Upgrade the instance to the new `.devN` via the Databricks Apps UI Deploy button (reuses the old app.yaml). Then verify:
+- Boot log shows "Seeding encryption_keys from GOOGLE_OAUTH_ENCRYPTION_KEY (migration)".
+- The stored Google token still decrypts (open the app, confirm the credential is present/usable).
+- The `encryption_keys` table has the row equal to the legacy key.
+- app.yaml is scrubbed (`GOOGLE_OAUTH_ENCRYPTION_KEY` gone) OR a "Scrub: could not remove key" warning is logged — **record which** (this is the write-ACL probe: it tells us whether boot-scrub lands in prod or whether the deploy tool's keyless template is the effective scrubber).
+
+- [ ] **Step 4: Deploy-tool upgrade → verify carry-forward**
+
+On a SECOND legacy-style instance, upgrade via `./scripts/deploy_local.sh update --env devtest --profile tellr-dev --from-pypi <version>`. Verify the same three assertions (table seeded, token decrypts, scrub or logged warning) — this proves carry-forward re-emits the key into the regenerated app.yaml.
+
+- [ ] **Step 5: Idempotency**
+
+Redeploy/restart the upgraded instance. Verify boot uses the table row (SELECT-first; no "Seeding … from GOOGLE_OAUTH…" log the second time) and the scrub is a no-op (no key entry to remove).
+
+- [ ] **Step 6: Record the write-ACL outcome in the spec**
+
+Update the spec's Unit 2 "Empirical unknown" and Goal "Requirement framing" with the observed write-ACL result and whether a tool-driven deploy is therefore required for SDR sign-off.
+
+- [ ] **Step 7: Tear down**
+
+```bash
+./scripts/deploy_local.sh delete --env devloop --instance <name>
+```
+
+---
+
+## Task 10: PR
+
+- [ ] **Step 1: Review the branch diff**
+
+Run: `git log --oneline origin/main..HEAD` and `git diff origin/main --stat`
+Expected: the Task 1-8 commits (+ Task 9's spec update).
+
+- [ ] **Step 2: Consider Isaac Review before opening the PR**
+
+Tip: these changes haven't been reviewed with Isaac Review yet — you can run /review (Databricks' recommended code-review pipeline) before or after pushing.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin security/fernet-key-boot-migration
+```
+Open a PR against `main` describing: the data-loss bug, the three-unit fix, the KEPT fork precondition (and why), and the Task 9 live-verification results (esp. the write-ACL outcome).

--- a/docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md
+++ b/docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md
@@ -1,0 +1,340 @@
+# Design: Fernet key migration + scrub at app boot (SDR-4437 CRITICAL-3 follow-up)
+
+> Supersedes the handoff `docs/superpowers/specs/2026-07-17-fernet-key-migration-handoff.md`.
+> Fixes the silent data-loss bug where any upgrade NOT run through `deploy_local
+> update` boots the new keyless code, finds `encryption_keys` empty, ignores the
+> env-var key still in app.yaml, and generates a fresh key — orphaning every
+> existing encrypted Google credential/token.
+
+## Problem
+
+SDR-4437 CRITICAL-3 moved the Google-OAuth Fernet master key out of `app.yaml`
+(`GOOGLE_OAUTH_ENCRYPTION_KEY` env var) into the `encryption_keys` Lakebase
+table. The relocation was implemented **only in the deploy tool**
+(`_migrate_encryption_key_to_lakebase`), and the boot-time key resolver
+(`src/core/encryption.py`) was given **deliberately no env-var fallback**.
+
+Consequence: any upgrade that does not go through the deploy tool's relocation —
+most importantly the **Databricks Apps UI "Deploy" button**, which reuses the
+existing (still-key-bearing) app.yaml — boots the new code against an empty
+`encryption_keys` table, ignores the env-var key, and generates a fresh key.
+All existing ciphertext becomes undecryptable, and the app self-deletes the
+"stale" rows on read. Silent, permanent data loss.
+
+The root cause is that the migration lived in the deploy tool instead of being
+self-contained in the artifact. The three real upgrade paths diverge in whether
+the env var is present at first boot:
+
+| Path | app.yaml at first boot | Env var present? |
+|------|------------------------|------------------|
+| UI "Deploy" button | old app.yaml reused | **yes** |
+| `tellr.update()` (`_update_databricks`) | regenerated from keyless template | no (unless carried forward) |
+| `deploy_local update` (`update_local`) | regenerated from keyless template | no (unless carried forward) |
+
+## Goal
+
+One migration mechanism, self-contained in the artifact, behaving **identically
+in dev and prod**. Correctness (no data loss) must never depend on which tool
+performed the upgrade. The plaintext key must be removed from app.yaml at rest
+(SDR hard requirement), but that removal must never be able to cause data loss.
+
+**Requirement framing (an honest tension to name up front):** the two goals above
+can conflict. The scrub (Unit 2) is best-effort and never blocks boot, so if the
+app SP lacks write ACL on its own source folder, boot-scrub cannot land. In that
+case the hard requirement is met only by a **tool-driven deploy** (`tellr.update`
+/ `deploy_local`) writing the keyless template — which becomes the *guaranteed*
+mechanism, not merely a backstop. Concretely: an install upgraded **only** via
+the UI Deploy button whose SP lacks source-folder write ACL will retain the
+plaintext key in app.yaml indefinitely (surfaced only by a boot log line) until a
+tool-driven deploy runs. The write-ACL probe (Unit 2) determines which regime we
+are in; the plan must decide whether a tool-driven deploy is therefore mandatory
+for SDR sign-off, or whether best-effort boot-scrub is accepted with the log as
+the escape hatch. We do NOT block boot to force the requirement — data
+availability outranks at-rest hygiene at boot time.
+
+## Design decisions (settled with the user)
+
+1. **The key MUST be scrubbed from app.yaml at rest** (SDR hard requirement),
+   with a safeguard: never scrub before the table is confirmed to hold the
+   matching, valid key.
+2. **Scrub happens at boot (self-scrub)**, decoupled from correctness — it is
+   strictly best-effort and never blocks boot or gates the data-loss fix.
+3. **No ciphertext-aware empty-table guard.** The legacy-install state
+   (ciphertext under the env key + an empty `encryption_keys` table) *is* a
+   real ciphertext-with-empty-table state — but it is fully **handled** by
+   env-var seeding (Unit 1), not something we need a guard for. Beyond that
+   migration, ciphertext is only ever written by `encrypt_data()`, which calls
+   `get_encryption_key()`, which seeds the table first — so a *new* orphaning
+   ciphertext-with-empty-table state cannot arise through normal operation. Given
+   both the legacy case (handled) and the steady state (can't occur), a runtime
+   guard is YAGNI. Boot-seed is the simple SELECT-first → env → key-file → fresh
+   ladder.
+4. **The deploy tools carry the existing key forward** into the regenerated
+   app.yaml (instead of doing a deploy-time DDL relocation). Boot then seeds the
+   table and scrubs. This makes boot the single migrator on every path.
+
+## Architecture
+
+Three units, one responsibility each:
+
+### Unit 1 — Boot-time seed (the correctness fix)
+
+`src/core/encryption.py`. `get_encryption_key()` already does **SELECT-first,
+then seed-if-absent**. The only change is what `_seed_value()` reads. Re-add the
+env-var read as the *migration* source, ahead of the existing key-file/fresh
+ladder:
+
+```
+_seed_value():   # only reached on an empty table (SELECT-first miss)
+  1. GOOGLE_OAUTH_ENCRYPTION_KEY env var, if set   ← NEW (legacy → table migration)
+  2. legacy .encryption_key file (local dev)        ← unchanged
+  3. Fernet.generate_key() (fresh install)          ← unchanged
+```
+
+Because the resolver is SELECT-first, this is a **one-time cutover**: the first
+boot of the migrated code seeds the table from whatever env var is present;
+every boot thereafter reads the row and never consults the env var again. This
+reverses PR-3's documented "no env-var fallback" decision — an intentional
+reversal; the module docstring (encryption.py:20-23) is rewritten to describe
+the migration + scrub semantics.
+
+**Item 2 ("create the table if absent") is already handled** and needs no new
+migration entry. Boot order today is:
+
+```
+run.py::init_database()
+  └─ src/core/database.py::init_db()
+       ├─ Base.metadata.create_all()   # creates encryption_keys (registered model)
+       └─ _run_migrations()            # ALTERs existing tables only
+  └─ (default content seeding)
+  └─ src/core/encryption.py::ensure_encryption_key()   # SELECT-first → _seed_value()
+```
+
+`_run_migrations()` only alters existing tables, so table *creation* is covered
+by `create_all()`. The "run migrations" hook the handoff refers to is this
+existing `ensure_encryption_key()` step — enhanced, not newly added.
+
+This single change fixes the data-loss bug on all three upgrade paths (given
+Unit 3 supplies the env var on the tool paths).
+
+### Unit 2 — Boot-time self-scrub (the SDR hygiene guarantee)
+
+`src/core/encryption.py::_scrub_app_yaml_key()` (new). **Best-effort; never
+raises; never blocks boot.**
+
+**Call site (load-bearing):** invoke it as its **own** step in
+`run.py::init_database()`, immediately after the existing `ensure_encryption_key()`
+block — NOT folded inside `ensure_encryption_key()`. That existing block is
+wrapped in a `try/except` that does `raise SystemExit(1)` (run.py:68-75); if the
+scrub lived inside it, a scrub bug that leaked an exception would abort boot,
+directly violating "never blocks boot." Give the scrub its own call wrapped in
+its own broad `try/except` that only logs — so a scrub failure can never reach
+the SystemExit path and can never gate the data-loss fix.
+
+```
+_scrub_app_yaml_key():
+  0. Guard: return unless DATABRICKS_APP_NAME is set (no-op on local/SQLite/tests).
+  1. SELECT the key from the table and validate it as a real Fernet key.
+     Missing/invalid → DO NOT scrub, log error, return.
+     (Never remove the last copy unless the table copy is proven good.)
+  2. ws = get_system_client(); path = ws.apps.get(DATABRICKS_APP_NAME).default_source_code_path
+  3. download {path}/app.yaml → parse. No GOOGLE_OAUTH_ENCRYPTION_KEY entry → return (idempotent).
+  4. entry value == validated table key → drop the entry, re-serialise, upload (overwrite), log "scrubbed".
+     entry value != table key → DO NOT scrub, log loud warning (divergent key — human must inspect).
+  5. try/except around the whole body: any failure (no write ACL, download/parse/upload error)
+     → log clearly, return. Boot continues.
+```
+
+Two safety properties:
+
+- **Ordering prevents data loss.** Step 1 validates the table key before
+  app.yaml is touched; step 4 removes the env entry only when it *matches* that
+  validated key. The scrub can therefore only ever remove a redundant copy. On
+  any anomaly the plaintext key stays as a SELECT-first-ignored backup.
+- **No live-process impact.** The rewritten app.yaml takes effect only on the
+  next deploy; the table is already the runtime source of truth. The scrub only
+  changes what is at rest in the workspace file.
+
+**Empirical unknown (probe during implementation):** whether the app SP holds
+write ACL on its own `default_source_code_path` (often owned by the deploying
+human). If not, step 4's upload fails → caught → logged → boot proceeds, and the
+plaintext key persists until a tool-driven deploy overwrites it with the keyless
+template (Unit 3 is the backstop). Correctness holds either way.
+
+### Unit 3 — Deploy-tool carry-forward (item 1)
+
+`packages/databricks-tellr/databricks_tellr/deploy.py::_update_databricks` and
+`scripts/deploy_local.py::update_local`. Replace the deploy-time DDL relocation
+with **carry-forward** so boot is the single migrator.
+
+```
+OLD (remove): read legacy key → open Lakebase conn → _migrate_encryption_key_to_lakebase(DDL+GRANT+INSERT)
+NEW (keep):   read legacy key → pass it into _write_app_yaml so the regenerated
+              app.yaml re-includes GOOGLE_OAUTH_ENCRYPTION_KEY iff a legacy key
+              was present. Boot seeds the table from it, then scrubs on first boot.
+```
+
+- `_write_app_yaml` gains an optional `encryption_key` param. When set, it emits
+  the `GOOGLE_OAUTH_ENCRYPTION_KEY` env entry; when `None` (already-migrated and
+  fresh installs), app.yaml stays keyless exactly as today. **Templating note:**
+  `_write_app_yaml` renders via `string.Template(...).substitute(...)`
+  (`deploy.py:1401`) and `app.yaml.template` currently has *no* key placeholder
+  at all. `string.Template` supports no conditionals and raises `KeyError` on any
+  unmatched `$` placeholder, so "emit the entry only when a key is present" needs
+  a concrete mechanism — e.g. a full-block placeholder (`$ENCRYPTION_KEY_BLOCK`)
+  substituted with either the complete `- name:/value:` entry or the empty string
+  (taking care not to emit malformed YAML) — not a placeholder that is merely
+  "absent when no key."
+- **`update_local` branching-path guard:** `legacy_key` is assigned only inside
+  the non-branching `else:` block (`deploy_local.py:700`), but the shared
+  `_write_app_yaml` call (`deploy_local.py:768`) runs on both the branching and
+  non-branching paths. Initialise the carry-forward value to `None` before the
+  branching `if/else` (the fork path never reads a source key), or the branching
+  path will `NameError` when the key is wired into that shared call.
+- **Delete** `_migrate_encryption_key_to_lakebase` and its deploy-time Lakebase
+  connection for key purposes. This also removes the ownership-gated DDL/GRANT
+  against Lakebase that was itself a source of fork-permission pain. **Also
+  remove its top-level import at `scripts/deploy_local.py:40`** (inside the
+  `from databricks_tellr.deploy import (...)` block) — otherwise every
+  `deploy_local` invocation (create / update / delete) fails at import with
+  `ImportError`, not just the update path. The `_get_lakebase_connection` import
+  (`deploy_local.py:37`) also becomes dead once the update-path relocation block
+  is removed (its only remaining use is the migration at line 706); drop it too
+  for cleanliness.
+- **Keep** `_read_existing_encryption_key` (strict reader — still needed to
+  detect and carry the legacy key; raising on an unreadable app.yaml stays, so a
+  transient read failure can't silently skip the migration).
+- **Everything else in the deploy tools stays** (handoff correction): Lakebase
+  branching, schema setup, SP role grants, breaking-migration checks. Only the
+  key mechanism moves to boot.
+- **`create` / `_create_databricks` needs no change** — already writes keyless
+  and boots to generate a fresh key for a genuinely new install.
+- **KEEP the legacy-key fork precondition** in
+  `deploy_local.py::_check_branching_preconditions` (the `if legacy_key:`
+  rejection at lines 289-297). This is a correction to an earlier draft that
+  proposed deleting it: carry-forward does **not** run on the branching/fork
+  path. Tracing `update_local`, the key logic lives only in the non-branching
+  `else:` block (deploy_local.py:694-716); the branching path (631-693) never
+  reads or carries a key — the fork inherits the key via copy-on-write of the
+  `encryption_keys` table and its app.yaml is generated keyless. So if a fork is
+  created while its source env is still **unmigrated** (env key in app.yaml,
+  empty table), the fork's COW table is empty AND its app.yaml carries no env var
+  → boot's `_seed_value()` finds nothing → `Fernet.generate_key()` → the
+  COW-inherited ciphertext is orphaned and self-deleted. That is the exact
+  CRITICAL-3 bug on the exact path the handoff documented as broken. The
+  precondition is the only guard against forking an unmigrated source, and boot
+  does **not** replace it on this path. Operational consequence (acceptable): a
+  source env must be migrated once (via UI button / `tellr.update` /
+  `deploy_local` carry-forward, all of which run boot-seed) before it can be
+  forked — after which forks inherit the key by COW and boot is SELECT-first.
+  Do NOT resurrect the reverted "downgrade preflight to warn" hack.
+- **`_read_existing_encryption_key` stays load-bearing in the preflight for a
+  second reason:** lines 281-287 wrap it in a `try/except` that doubles as the
+  "source env not deployed / unreachable" probe (re-raised as "not deployed"),
+  which `test_deploy_local_preflight.py::test_preflight_fails_when_source_not_deployed`
+  depends on. Both the read and the `if legacy_key:` rejection stay.
+
+## Data flow (all paths converge on boot)
+
+```
+Legacy install (env key in app.yaml, encrypted rows under that key)
+        │
+        ├─ UI "Deploy" button ─────────► old app.yaml reused (env var present) ─┐
+        ├─ tellr.update() ─────────────► carry-forward writes env var into new app.yaml ─┤
+        └─ deploy_local update ────────► carry-forward writes env var into new app.yaml ─┤
+                                                                                          ▼
+                                          Boot: init_db (create_all + migrations)
+                                                ensure_encryption_key():
+                                                  SELECT id=1 → empty
+                                                  _seed_value() → env var → INSERT
+                                                  (old ciphertext now decryptable) ✓
+                                                _scrub_app_yaml_key():
+                                                  validate table key → matches env → scrub app.yaml
+                                                  (or log + keep if SP lacks write ACL)
+                                                                                          ▼
+                                          Every later boot / redeploy on ANY path:
+                                                SELECT id=1 → row present → use it (env ignored)
+                                                scrub → no entry → no-op (idempotent) ✓
+```
+
+Once an install has migrated once (table holds the key), all three paths are
+already safe by SELECT-first; the env var matters only for the single legacy
+cutover boot.
+
+**The devloop/branching fork path is deliberately absent from the diagram above**
+because it does NOT carry the key forward. A fork inherits the key by
+copy-on-write of the `encryption_keys` table, which is only populated once the
+source env has itself been migrated. The `_check_branching_preconditions`
+legacy-key check (retained — see Unit 3) enforces that ordering: it refuses to
+fork a source whose app.yaml still carries an unmigrated key. So the fork path is
+safe not because carry-forward reaches it, but because it can only run against an
+already-migrated source whose table row the fork inherits.
+
+## Testing
+
+**Unit** (extend existing files):
+
+- `test_encryption.py` — seed order: (a) env present → table seeded from env;
+  (b) no env, key file present → from file; (c) neither → fresh generated;
+  (d) SELECT-first: existing row wins, env var ignored even when set (one-time
+  cutover + idempotency).
+- `test_encryption.py` — `_scrub_app_yaml_key` (mock `WorkspaceClient`): no-op
+  when `DATABRICKS_APP_NAME` unset; no-op when table key invalid/missing (safety
+  gate); removes entry only on value-match; **leaves entry on mismatch**;
+  swallows download/upload failure and returns without raising (boot continues).
+- `test_deploy_encryption_key_migration.py` — repurpose from "DDL relocation" to
+  "carry-forward": `_write_app_yaml(encryption_key=...)` emits the env entry;
+  `encryption_key=None` stays keyless; `_update_databricks`/`update_local` pass
+  the read legacy key through to `_write_app_yaml` and **no longer** open a
+  Lakebase connection for key migration.
+- `test_deploy_local_preflight.py` — the legacy-key fork precondition is **kept**
+  (see Unit 3), so its assertions stay. Keep
+  `test_preflight_fails_when_source_not_deployed` (relies on the retained
+  `_read_existing_encryption_key` deployment probe) and the "source still carries
+  a legacy key → reject the fork" assertion.
+
+**Live verification** (hard-won lesson: CLI ≠ deployed OBO/SP behavior — only a
+deployed app proves runtime paths). On disposable devloop instance(s) carrying
+**real legacy ciphertext**:
+
+1. Stand up a legacy-style install (env key in app.yaml + a real encrypted
+   Google token row).
+2. **UI-button upgrade** to the new build → assert: table seeded from env, old
+   token still decrypts, app.yaml scrubbed (or a loud log if the SP lacks write
+   ACL — **this is the write-ACL probe**).
+3. **`tellr.update()` / `deploy_local` upgrade** on a second instance → same
+   assertions (proves carry-forward).
+4. Idempotency: second boot/redeploy is a no-op (SELECT-first; nothing to scrub).
+
+## Docs
+
+- Rewrite `encryption.py` module docstring (lines 20-23): the "deliberately NO
+  env-var fallback" paragraph becomes the migration + scrub semantics.
+- Update `.claude/skills/deploy-tellr-dev/` and `docs/technical/dev-deploy.md`
+  (handoff item 3): the key lives in the table, boot migrates + scrubs, and dev
+  tools carry the key forward exactly like prod — so the dev/prod divergence
+  that let CRITICAL-3 pass in dev but lose data in prod cannot recur.
+- This spec supersedes the handoff doc.
+
+## Rollout / PR scoping
+
+New work, separate from the review-clean, already-pushed PR-4
+(`security/sdr4437-pr4-oauth-errors`). Recommend its **own branch/PR off `main`**
+so it does not destabilise merge-ready PR-4. Confirm branch state at plan time
+(the tree may have moved).
+
+## Out of scope / explicitly rejected
+
+- Ciphertext-aware empty-table hard-fail (YAGNI — see decision 3).
+- Keeping the env var permanently as a backup (violates the SDR hard
+  requirement — decision 1).
+- Keeping deploy-time relocation as belt-and-suspenders (keeps the
+  not-self-contained problem and two divergent mechanisms — decision 4).
+- Weakening `_check_branching_preconditions` to a warning (the reverted hack).
+  Note: the legacy-key fork precondition itself is **kept**, not deleted — see
+  Unit 3. Boot carry-forward does not run on the fork path, so that precondition
+  remains the only guard against forking an unmigrated source.
+- Adding source-key carry-forward into the branching/fork path (the fork inherits
+  the key by copy-on-write of the `encryption_keys` table; requiring the source
+  to be migrated-once before it can be forked is the accepted operational
+  constraint instead).

--- a/docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md
+++ b/docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md
@@ -40,17 +40,25 @@ performed the upgrade. The plaintext key must be removed from app.yaml at rest
 
 **Requirement framing (an honest tension to name up front):** the two goals above
 can conflict. The scrub (Unit 2) is best-effort and never blocks boot, so if the
-app SP lacks write ACL on its own source folder, boot-scrub cannot land. In that
-case the hard requirement is met only by a **tool-driven deploy** (`tellr.update`
-/ `deploy_local`) writing the keyless template — which becomes the *guaranteed*
-mechanism, not merely a backstop. Concretely: an install upgraded **only** via
-the UI Deploy button whose SP lacks source-folder write ACL will retain the
-plaintext key in app.yaml indefinitely (surfaced only by a boot log line) until a
-tool-driven deploy runs. The write-ACL probe (Unit 2) determines which regime we
-are in; the plan must decide whether a tool-driven deploy is therefore mandatory
-for SDR sign-off, or whether best-effort boot-scrub is accepted with the log as
-the escape hatch. We do NOT block boot to force the requirement — data
-availability outranks at-rest hygiene at boot time.
+app SP lacks write ACL on its own source folder, boot-scrub cannot land.
+**Boot-scrub is the ONLY automated mechanism that removes a still-present key
+from app.yaml.** A tool-driven deploy is *not* a backstop for this: Unit 3 is
+carry-forward — `tellr.update` / `deploy_local` read the existing app.yaml key
+and *re-emit* it into the regenerated app.yaml so boot can migrate it. When the
+key is still present (e.g. a prior boot-scrub failed on write-ACL), a tool deploy
+therefore **re-carries** it, not drops it; a tool deploy yields a keyless
+app.yaml only once the key is *already* gone. Consequence: an install whose SP
+lacks source-folder write ACL retains the plaintext key in app.yaml indefinitely
+(surfaced only by a boot log line) — no automated path removes it, and manual
+removal is required to satisfy the SDR hard requirement. Data safety is
+unaffected either way: SELECT-first makes the re-carried key inert (the table row
+wins), so a lingering app.yaml key never causes data loss — it is purely an
+at-rest-hygiene gap. The write-ACL probe (Unit 2 / Task 9) determines which
+regime we are in; the plan must decide whether, in the no-write-ACL regime, the
+SDR hard requirement is met by (a) documenting a manual key-removal step, or
+(b) accepting best-effort boot-scrub with the log as the escape hatch. We do NOT
+block boot to force the requirement — data availability outranks at-rest hygiene
+at boot time.
 
 ## Design decisions (settled with the user)
 
@@ -158,8 +166,11 @@ Two safety properties:
 **Empirical unknown (probe during implementation):** whether the app SP holds
 write ACL on its own `default_source_code_path` (often owned by the deploying
 human). If not, step 4's upload fails → caught → logged → boot proceeds, and the
-plaintext key persists until a tool-driven deploy overwrites it with the keyless
-template (Unit 3 is the backstop). Correctness holds either way.
+plaintext key persists in app.yaml. Note there is **no automated backstop**: Unit 3
+is carry-forward, which re-emits a still-present key rather than dropping it (see
+the Goal's "Requirement framing"), so a failed boot-scrub means the key stays
+until removed manually. Correctness holds either way — SELECT-first makes the
+lingering key inert, so this is an at-rest-hygiene gap, never data loss.
 
 ### Unit 3 — Deploy-tool carry-forward (item 1)
 

--- a/docs/technical/dev-deploy.md
+++ b/docs/technical/dev-deploy.md
@@ -94,3 +94,38 @@ and run `ALTER`-bearing migrations against inherited prod tables. Ownership of
 deploy triggers a serverless job (running as a dedicated granter SP) that grants
 the instance's service principal into that role, so its migrations can alter the
 inherited tables. See `docs/technical/lakebase-table-ownership.md`.
+
+## Fernet key handling (why there is no dev/prod divergence)
+
+The Fernet master key that encrypts OAuth credentials lives in the
+`encryption_keys` Lakebase table (row `id = 1`), **not** in `app.yaml`. This is
+the runtime source of truth on every path (see `src/core/encryption.py`).
+
+**Boot owns the one-time legacy→table migration.** On the cutover boot, if the
+table is empty, boot seeds the row from the `GOOGLE_OAUTH_ENCRYPTION_KEY` env
+var (the old app.yaml location), then best-effort scrubs that plaintext key out
+of the deployed `app.yaml`. Because key resolution is SELECT-first, the env var
+is read only on that first boot; every later boot reads the row. The scrub never
+blocks boot and only deletes a copy that exactly matches the validated table key.
+
+**Deploy tools carry the key forward — they do not relocate it via DDL.** Both
+`tellr.update` and `deploy_local update` read any existing
+`GOOGLE_OAUTH_ENCRYPTION_KEY` out of the deployed `app.yaml` and re-emit it into
+the regenerated `app.yaml`, so the *next* boot can perform the migration above.
+The earlier deploy-time DDL relocation was removed: deploy tools no longer touch
+the `encryption_keys` table.
+
+**The devloop/fork path inherits the key via copy-on-write.** A forked branch
+already carries the seeded `encryption_keys` row from prod, so no key is written
+into the fork's `app.yaml`. This only works if the source env was migrated once
+first — the fork preflight (`_check_branching_preconditions`) deliberately
+**aborts** if the source env's `app.yaml` still carries a legacy key, telling you
+to update the source env first. Keep that check.
+
+**The rule this enforces:** boot performs the migration identically on every
+path — the UI **Deploy** button (which reuses the existing `app.yaml`),
+`tellr.update`, and `deploy_local update`. So code that works under
+`deploy_local` also works under a UI-button upgrade; there is no dev/prod
+divergence in key handling. This is the divergence that caused the original
+data-loss bug, and it is why the migration lives in boot rather than in a deploy
+step.

--- a/packages/databricks-tellr-app/databricks_tellr_app/run.py
+++ b/packages/databricks-tellr-app/databricks_tellr_app/run.py
@@ -74,6 +74,17 @@ def init_database(seed_databricks_defaults: bool = False) -> None:
         logger.error(f"Failed to ensure encryption key: {e}\n{tb}")
         raise SystemExit(1) from e
 
+    # Best-effort: remove the now-redundant plaintext key from the deployed
+    # app.yaml (SDR-4437 CRITICAL-3 hygiene). Deliberately a SEPARATE block with
+    # its own swallow-all except — a scrub failure must never abort boot, so it
+    # must not share the ensure_encryption_key block above (which SystemExits).
+    logger.info("Scrubbing legacy key from app.yaml (best-effort)...")
+    try:
+        from src.core.encryption import _scrub_app_yaml_key
+        _scrub_app_yaml_key()
+    except Exception as e:  # noqa: BLE001 — best-effort, never blocks boot
+        logger.warning(f"app.yaml key scrub skipped: {e}")
+
 
 def main() -> None:
     """Start the uvicorn server."""

--- a/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
+++ b/packages/databricks-tellr/databricks_tellr/_templates/app.yaml.template
@@ -67,3 +67,4 @@ env:
   # Set to "0" if you want to force-disable the fast path entirely.
   - name: HUASHU_PIPELINE_ENABLED
     value: "1"
+$ENCRYPTION_KEY_BLOCK

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -1367,11 +1367,14 @@ def _write_app_yaml(
     seed_databricks_defaults: bool = False,
     lakebase_result: dict[str, Any] | None = None,
     mlflow_tracing: dict[str, str] | None = None,
+    encryption_key: str | None = None,
 ) -> None:
     """Generate app.yaml with environment variables.
 
-    The Fernet encryption key is deliberately NOT written here (SDR-4437
-    CRITICAL-3): the app reads/seeds it from the encryption_keys table.
+    The Fernet encryption key is written ONLY when ``encryption_key`` is
+    provided (the one-time legacy→table carry-forward). Boot seeds the
+    encryption_keys table from it and then scrubs it from app.yaml. When
+    ``encryption_key`` is None the app.yaml is keyless (steady state).
 
     Args:
         staging_dir: Directory to write the app.yaml file
@@ -1397,8 +1400,17 @@ def _write_app_yaml(
     if mlflow_tracing is None:
         mlflow_tracing = _mlflow_substitutions_for_app_yaml()
 
+    if encryption_key:
+        key_block = (
+            "  - name: GOOGLE_OAUTH_ENCRYPTION_KEY\n"
+            f'    value: "{encryption_key}"'
+        )
+    else:
+        key_block = ""
+
     template_content = _load_template("app.yaml.template")
     content = Template(template_content).substitute(
+        ENCRYPTION_KEY_BLOCK=key_block,
         LAKEBASE_INSTANCE=lakebase_name,
         LAKEBASE_SCHEMA=schema_name,
         INIT_DATABASE_CALL=init_call,

--- a/packages/databricks-tellr/databricks_tellr/deploy.py
+++ b/packages/databricks-tellr/databricks_tellr/deploy.py
@@ -287,9 +287,9 @@ def update(
         reset_database: If True, drop and recreate the schema (tables recreated on app startup)
         client: External WorkspaceClient (optional)
         profile: Databricks CLI profile name (optional)
-        encryption_key: Override for the legacy Fernet key to relocate into
-            the encryption_keys table. Default: read from the deployed
-            app.yaml. The key is no longer written to app.yaml.
+        encryption_key: Override for the legacy Fernet key to carry forward
+            into the regenerated app.yaml (boot then migrates it into the
+            encryption_keys table). Default: read from the deployed app.yaml.
         mlflow_tracing: Optional overrides for UC tracing env vars (same keys as ``create``).
             Values from deployment YAML are not loaded on update; use this argument or
             ``TELLR_DEPLOY_MLFLOW_*`` environment variables.
@@ -504,9 +504,9 @@ def _update_databricks(
         client: External WorkspaceClient (optional)
         profile: Databricks CLI profile name (optional)
         seed_databricks_defaults: If True, seed Databricks-specific content on startup
-        encryption_key: Override for the legacy Fernet key to relocate into
-            the encryption_keys table. Default: read from the deployed
-            app.yaml. The key is no longer written to app.yaml.
+        encryption_key: Override for the legacy Fernet key to carry forward
+            into the regenerated app.yaml (boot then migrates it into the
+            encryption_keys table). Default: read from the deployed app.yaml.
         mlflow_tracing: Optional overrides for UC tracing placeholders in ``app.yaml``.
 
     Returns:
@@ -524,7 +524,7 @@ def _update_databricks(
         overrides=mlflow_tracing,
     )
 
-    # Preserve the existing encryption key so we don't invalidate encrypted data
+    # Preserve the existing key so boot can migrate it (carry-forward).
     if not encryption_key:
         encryption_key = _read_existing_encryption_key(ws, app_file_workspace_path)
 
@@ -545,28 +545,6 @@ def _update_databricks(
             print(f"   Schema '{schema_name}' reset (tables will be recreated on app startup)")
             print()
 
-        # CRITICAL-3 migration: relocate the legacy app.yaml key into the
-        # encryption_keys table BEFORE the new (keyless) app.yaml overwrites
-        # it. Runs at most once per install: after it succeeds, the deployed
-        # app.yaml has no key entry and encryption_key is None on re-runs.
-        if encryption_key:
-            print("Relocating encryption key into Lakebase (encryption_keys)...")
-            app_for_grant = ws.apps.get(name=app_name)
-            grant_client_id = _get_app_client_id(app_for_grant)
-            if not grant_client_id:
-                print("   Warning: no app client ID — table grant will be skipped")
-            mig_conn, _ = _get_lakebase_connection(
-                ws, lakebase_name, lakebase_result=lakebase_result
-            )
-            try:
-                with mig_conn.cursor() as cur:
-                    _migrate_encryption_key_to_lakebase(
-                        cur, schema_name, grant_client_id, encryption_key
-                    )
-            finally:
-                mig_conn.close()
-            print("   Key relocated (relocate, not rotate — no re-encryption)")
-
         # Generate and upload updated files
         with _staging_dir() as staging:
             _write_requirements(staging, app_version)
@@ -577,6 +555,7 @@ def _update_databricks(
                 seed_databricks_defaults=seed_databricks_defaults,
                 lakebase_result=lakebase_result,
                 mlflow_tracing=mlflow_subs,
+                encryption_key=encryption_key,
             )
             _upload_files(ws, staging, app_file_workspace_path)
             print("   Files updated")
@@ -786,65 +765,6 @@ def _read_existing_encryption_key(
                 print("   Found legacy encryption key in deployed app.yaml")
                 return key
     return None
-
-
-def _migrate_encryption_key_to_lakebase(
-    cur: Any,
-    schema_name: str,
-    client_id: str | None,
-    encryption_key: str,
-) -> None:
-    """Relocate the legacy app.yaml Fernet key into <schema>.encryption_keys.
-
-    SDR-4437 CRITICAL-3, deploy-time migration. Relocate, not rotate: no
-    re-encryption of existing rows. Idempotent: re-running with the same key
-    is a no-op. A *different* pre-existing key is a hard error — silently
-    keeping either key would orphan the ciphertext encrypted under the other.
-
-    The GRANT is unconditional: the original deployer's ALTER DEFAULT
-    PRIVILEGES attaches to the creating role, so when a different identity
-    runs the upgrade this explicit grant is the only one that applies.
-    INSERT is included so the app's boot seed (insert-when-missing branch)
-    can never be privilege-blocked.
-
-    Takes an open cursor so callers control the endpoint (prod branch,
-    devloop fork, ...). Caller owns the connection lifecycle.
-    """
-    validate_schema_name(schema_name)
-    if client_id is not None:
-        validate_client_id(client_id)
-
-    # Matches the SQLAlchemy model (src/database/models/encryption_key.py):
-    # id INTEGER PK (no autoincrement), key_value TEXT, created_at TIMESTAMP.
-    cur.execute(
-        f'CREATE TABLE IF NOT EXISTS "{schema_name}".encryption_keys ('
-        "id INTEGER PRIMARY KEY, "
-        "key_value TEXT NOT NULL, "
-        "created_at TIMESTAMP NOT NULL)"
-    )
-    cur.execute(
-        f'INSERT INTO "{schema_name}".encryption_keys (id, key_value, created_at) '
-        "VALUES (1, %s, CURRENT_TIMESTAMP) ON CONFLICT (id) DO NOTHING",
-        (encryption_key,),
-    )
-    cur.execute(
-        f'SELECT key_value FROM "{schema_name}".encryption_keys WHERE id = 1'
-    )
-    row = cur.fetchone()
-    if not row or row[0] != encryption_key:
-        raise DeploymentError(
-            "encryption_keys already holds a DIFFERENT key than the deployed "
-            "app.yaml. Refusing to continue: proceeding would orphan ciphertext "
-            "encrypted under one of the two keys. Determine which key decrypts "
-            "the existing google_oauth_tokens/google_global_credentials rows, "
-            "fix the encryption_keys row (or the app.yaml) to match, then "
-            "re-run the update. See SDR-4437 PR-3 design."
-        )
-    if client_id:
-        cur.execute(
-            f'GRANT SELECT, INSERT ON "{schema_name}".encryption_keys '
-            f'TO "{client_id}"'
-        )
 
 
 def _load_deployment_config(config_yaml_path: str) -> dict[str, str]:

--- a/scripts/deploy_local.py
+++ b/scripts/deploy_local.py
@@ -34,10 +34,8 @@ from databricks_tellr.deploy import (
     DeploymentError,
     _branch_exists,
     _delete_branch,
-    _get_lakebase_connection,
     _get_workspace_client,
     _get_or_create_lakebase,
-    _migrate_encryption_key_to_lakebase,
     _mlflow_flat_from_env_section,
     _mlflow_substitutions_for_app_yaml,
     _probe_autoscaling_available,
@@ -627,6 +625,12 @@ def update_local(
     print()
 
     try:
+        # Carry-forward of the legacy encryption key into the regenerated
+        # app.yaml (boot migrates it). Only the non-branching path reads a
+        # source key; the fork path inherits the key via the COW table, so it
+        # stays None here.
+        carry_forward_key: str | None = None
+
         # Branching mode: preflight + recreate branch
         if branch_from_env:
             print("Running branching preflight checks...")
@@ -699,21 +703,11 @@ def update_local(
             )
             legacy_key = _read_existing_encryption_key(ws, workspace_path)
             if legacy_key:
-                # CRITICAL-3: relocate before the keyless app.yaml overwrites it
-                print("Relocating encryption key into Lakebase (encryption_keys)...")
-                app_for_grant = ws.apps.get(name=app_name)
-                grant_client_id = _get_app_client_id(app_for_grant)
-                mig_conn, _ = _get_lakebase_connection(
-                    ws, lakebase_name, lakebase_result=lakebase_result
-                )
-                try:
-                    with mig_conn.cursor() as cur:
-                        _migrate_encryption_key_to_lakebase(
-                            cur, schema_name, grant_client_id, legacy_key
-                        )
-                finally:
-                    mig_conn.close()
-                print("   Key relocated")
+                # CRITICAL-3: carry the key forward into the regenerated
+                # app.yaml; boot seeds the table from it and scrubs. No more
+                # deploy-time DDL relocation.
+                carry_forward_key = legacy_key
+                print("   Carrying existing encryption key forward into app.yaml")
 
         lakebase_type = lakebase_result.get("type", "provisioned")
         print(f"   Lakebase: {lakebase_result['name']} (type={lakebase_type})")
@@ -772,6 +766,7 @@ def update_local(
                 seed_databricks_defaults=seed_databricks_defaults,
                 lakebase_result=lakebase_result,
                 mlflow_tracing=mlflow_subs,
+                encryption_key=carry_forward_key,
             )
             print("   Generated app.yaml")
 

--- a/src/core/encryption.py
+++ b/src/core/encryption.py
@@ -32,6 +32,7 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
+import yaml
 from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import text
 
@@ -125,6 +126,73 @@ def ensure_encryption_key() -> None:
     local dev and replicas regardless).
     """
     get_encryption_key()
+
+
+def _scrub_app_yaml_key() -> None:
+    """Best-effort: remove the now-redundant plaintext GOOGLE_OAUTH_ENCRYPTION_KEY
+    from the deployed workspace app.yaml (SDR-4437 CRITICAL-3 hygiene).
+
+    NEVER raises and NEVER blocks boot. Only removes the entry when its value
+    matches the validated table key, so it can only ever delete a redundant
+    copy. No-op outside a Databricks Apps runtime. The rewritten app.yaml takes
+    effect on the NEXT deploy; the table is already the runtime source of truth.
+    """
+    app_name = os.getenv("DATABRICKS_APP_NAME")
+    if not app_name:
+        return  # local/SQLite/tests — nothing to scrub
+
+    try:
+        # 1. Re-read + validate the table key (never remove the last valid copy).
+        table_key = get_encryption_key()  # bytes; raises if corrupt
+        Fernet(table_key)  # explicit validation guard
+        table_key_str = table_key.decode()
+
+        # 2. Locate our own source folder.
+        from src.core.databricks_client import get_system_client
+
+        ws = get_system_client()
+        source_path = ws.apps.get(name=app_name).default_source_code_path
+        if not source_path:
+            logger.warning("Scrub: app has no default_source_code_path; skipping")
+            return
+
+        # 3. Download + parse the deployed app.yaml.
+        resp = ws.workspace.download(f"{source_path}/app.yaml")
+        raw = resp.read() if hasattr(resp, "read") else resp
+        content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+        parsed = yaml.safe_load(content) or {}
+        env_list = parsed.get("env", [])
+
+        entry = next(
+            (e for e in env_list if e.get("name") == "GOOGLE_OAUTH_ENCRYPTION_KEY"),
+            None,
+        )
+        if entry is None:
+            return  # already scrubbed / never had it — idempotent
+
+        # 4. Only remove on exact value match with the validated table key.
+        if entry.get("value") != table_key_str:
+            logger.warning(
+                "Scrub: app.yaml GOOGLE_OAUTH_ENCRYPTION_KEY differs from the "
+                "table key — leaving it in place for manual inspection."
+            )
+            return
+
+        parsed["env"] = [
+            e for e in env_list if e.get("name") != "GOOGLE_OAUTH_ENCRYPTION_KEY"
+        ]
+        new_content = yaml.safe_dump(parsed, sort_keys=False)
+        from databricks.sdk.service.workspace import ImportFormat
+
+        ws.workspace.upload(
+            f"{source_path}/app.yaml",
+            new_content.encode("utf-8"),
+            format=ImportFormat.AUTO,
+            overwrite=True,
+        )
+        logger.info("Scrub: removed plaintext encryption key from deployed app.yaml")
+    except Exception as exc:  # never propagate — best-effort by contract
+        logger.warning("Scrub: could not remove key from app.yaml (%s)", exc)
 
 
 def encrypt_data(plaintext: str) -> str:

--- a/src/core/encryption.py
+++ b/src/core/encryption.py
@@ -17,13 +17,18 @@ Resolution is SELECT-first, then race-safe INSERT-if-absent:
 3. ``INSERT ... ON CONFLICT (id) DO NOTHING`` + read-back, so concurrent
    workers/replicas converge on one key.
 
-There is deliberately NO env-var fallback: the deploy tool relocates the
-legacy ``GOOGLE_OAUTH_ENCRYPTION_KEY`` into this table at update time, and
-old-tool + new-wheel skew is unsupported (see the SDR-4437 remediation
-design, PR-3).
+The seed order on an empty table is env var → legacy key file → fresh generate
+(see ``_seed_value``). The ``GOOGLE_OAUTH_ENCRYPTION_KEY`` env-var read is the
+one-time legacy→table migration (SDR-4437 CRITICAL-3 follow-up): it reverses
+PR-3's original "no env-var fallback" decision, which caused silent data loss on
+any upgrade that did not go through the deploy tool. Because resolution is
+SELECT-first, the env var is consulted only on the cutover boot; every later
+boot reads the row. ``_scrub_app_yaml_key`` then removes the now-redundant
+plaintext key from the workspace app.yaml (best-effort).
 """
 
 import logging
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -64,7 +69,20 @@ def _validated(key: bytes) -> bytes:
 
 
 def _seed_value() -> bytes:
-    """Pick the value to seed an empty encryption_keys table with."""
+    """Pick the value to seed an empty encryption_keys table with.
+
+    Priority (SELECT-first in get_encryption_key means this runs only when the
+    table is empty):
+    1. GOOGLE_OAUTH_ENCRYPTION_KEY env var — the one-time legacy→table
+       migration (SDR-4437 CRITICAL-3 follow-up). Present on the cutover boot
+       via the reused app.yaml (UI Deploy) or carry-forward (deploy tools).
+    2. legacy .encryption_key file (local dev — keeps dev ciphertext readable).
+    3. a freshly generated key (genuinely new install).
+    """
+    env_key = os.getenv("GOOGLE_OAUTH_ENCRYPTION_KEY")
+    if env_key and env_key.strip():
+        logger.info("Seeding encryption_keys from GOOGLE_OAUTH_ENCRYPTION_KEY (migration)")
+        return env_key.strip().encode()
     if _KEY_FILE.exists():
         key = _KEY_FILE.read_text().strip()
         if key:

--- a/src/core/encryption.py
+++ b/src/core/encryption.py
@@ -136,6 +136,15 @@ def _scrub_app_yaml_key() -> None:
     matches the validated table key, so it can only ever delete a redundant
     copy. No-op outside a Databricks Apps runtime. The rewritten app.yaml takes
     effect on the NEXT deploy; the table is already the runtime source of truth.
+
+    This is the ONLY automated remover of a still-present app.yaml key: the
+    deploy tools carry a present key forward (re-emit it), they do not drop it,
+    so a failed scrub here leaves the key until it is removed manually.
+
+    Note: the rewrite goes through ``yaml.safe_dump``, so the deployed app.yaml
+    loses its comments and its multi-line ``command`` block is reflowed. The
+    result is semantically identical (all env entries and the ``sh -c`` command
+    string reload unchanged), just visually reformatted.
     """
     app_name = os.getenv("DATABRICKS_APP_NAME")
     if not app_name:

--- a/tests/unit/test_ddl_identifier_validation.py
+++ b/tests/unit/test_ddl_identifier_validation.py
@@ -52,7 +52,7 @@ class TestDeploySitesValidate:
     """The deploy.py DDL sites reject bad identifiers BEFORE any execute.
 
     Validated sites (all call validate_schema_name before interpolating):
-    _migrate_encryption_key_to_lakebase, _setup_database_schema, _reset_schema,
+    _setup_database_schema, _reset_schema,
     _grant_schema_permissions, and _check_breaking_migrations (the last was the
     5th interpolation site MEDIUM-5's original "three sites" claim under-counted).
     """

--- a/tests/unit/test_deploy_app_yaml.py
+++ b/tests/unit/test_deploy_app_yaml.py
@@ -27,7 +27,12 @@ def test_generated_app_yaml_has_no_custom_index_url(tmp_path: Path):
 
 
 def test_write_app_yaml_is_keyless():
-    """CRITICAL-3: app.yaml must not carry the Fernet key or accept one."""
+    """CRITICAL-3: app.yaml is keyless in steady state.
+
+    The Fernet-key boot migration adds an optional ``encryption_key``
+    param (default None) used only for the one-time legacy carry-forward;
+    with no key passed the generated app.yaml stays keyless.
+    """
     import inspect as _inspect
     import tempfile
     from pathlib import Path
@@ -35,7 +40,7 @@ def test_write_app_yaml_is_keyless():
     from databricks_tellr import deploy
 
     sig = _inspect.signature(deploy._write_app_yaml)
-    assert "encryption_key" not in sig.parameters
+    assert sig.parameters["encryption_key"].default is None
 
     with tempfile.TemporaryDirectory() as td:
         deploy._write_app_yaml(Path(td), "lb", "app_data")

--- a/tests/unit/test_deploy_encryption_key_migration.py
+++ b/tests/unit/test_deploy_encryption_key_migration.py
@@ -1,4 +1,4 @@
-"""CRITICAL-3 (SDR-4437): deploy-time relocation of the Fernet key into Lakebase."""
+"""CRITICAL-3 (SDR-4437): carry-forward of the Fernet key via app.yaml + strict reader."""
 
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/test_deploy_encryption_key_migration.py
+++ b/tests/unit/test_deploy_encryption_key_migration.py
@@ -160,3 +160,32 @@ class TestUpdateDatabricksWiring:
             lakebase_name="lb", schema_name=SCHEMA,
         )
         mock_migrate.assert_not_called()
+
+
+class TestWriteAppYamlKeyBlock:
+    def _read_yaml(self, staging):
+        import yaml
+        return yaml.safe_load((staging / "app.yaml").read_text())
+
+    def test_keyless_when_no_key(self, tmp_path):
+        from databricks_tellr.deploy import _write_app_yaml
+        _write_app_yaml(
+            tmp_path, "lb", SCHEMA,
+            lakebase_result={"type": "provisioned"},
+        )
+        parsed = self._read_yaml(tmp_path)
+        names = [e["name"] for e in parsed["env"]]
+        assert "GOOGLE_OAUTH_ENCRYPTION_KEY" not in names
+
+    def test_emits_entry_when_key_present(self, tmp_path):
+        from databricks_tellr.deploy import _write_app_yaml
+        _write_app_yaml(
+            tmp_path, "lb", SCHEMA,
+            lakebase_result={"type": "provisioned"},
+            encryption_key=KEY,
+        )
+        parsed = self._read_yaml(tmp_path)
+        entry = next(
+            e for e in parsed["env"] if e["name"] == "GOOGLE_OAUTH_ENCRYPTION_KEY"
+        )
+        assert entry["value"] == KEY

--- a/tests/unit/test_deploy_encryption_key_migration.py
+++ b/tests/unit/test_deploy_encryption_key_migration.py
@@ -8,7 +8,6 @@ pytest.importorskip("databricks_tellr", reason="databricks-tellr package not ins
 
 from databricks_tellr.deploy import (
     DeploymentError,
-    _migrate_encryption_key_to_lakebase,
     _read_existing_encryption_key,
 )
 
@@ -16,58 +15,6 @@ KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 OTHER_KEY = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
 CLIENT_ID = "12345678-abcd-abcd-0123-456789abcdef"
 SCHEMA = "app_data_prod"
-
-
-def _cursor(existing_key=None):
-    cur = MagicMock()
-    cur.fetchone.return_value = (existing_key,) if existing_key else (KEY,)
-    return cur
-
-
-class TestMigrateEncryptionKey:
-    def test_fresh_migration_creates_seeds_and_grants(self):
-        cur = _cursor(existing_key=KEY)
-        _migrate_encryption_key_to_lakebase(cur, SCHEMA, CLIENT_ID, KEY)
-
-        sql = [str(c.args[0]) for c in cur.execute.call_args_list]
-        assert any("CREATE TABLE IF NOT EXISTS" in s and "encryption_keys" in s for s in sql)
-        assert any("INSERT INTO" in s and "ON CONFLICT (id) DO NOTHING" in s for s in sql)
-        assert any(
-            "GRANT SELECT, INSERT" in s and f'TO "{CLIENT_ID}"' in s for s in sql
-        )
-
-    def test_rerun_with_same_key_is_noop(self):
-        cur = _cursor(existing_key=KEY)
-        # Must not raise: INSERT no-ops, read-back equals the app.yaml key.
-        _migrate_encryption_key_to_lakebase(cur, SCHEMA, CLIENT_ID, KEY)
-
-    def test_mismatched_existing_key_hard_fails_before_grant(self):
-        cur = _cursor(existing_key=OTHER_KEY)
-        # match is case-sensitive re.search; the message says "DIFFERENT key"
-        with pytest.raises(DeploymentError, match="DIFFERENT key"):
-            _migrate_encryption_key_to_lakebase(cur, SCHEMA, CLIENT_ID, KEY)
-        sql = [str(c.args[0]) for c in cur.execute.call_args_list]
-        assert not any("GRANT" in s for s in sql)
-
-    def test_missing_client_id_seeds_but_skips_grant(self):
-        cur = _cursor(existing_key=KEY)
-        _migrate_encryption_key_to_lakebase(cur, SCHEMA, None, KEY)
-        sql = [str(c.args[0]) for c in cur.execute.call_args_list]
-        assert any("INSERT INTO" in s for s in sql)
-        assert not any("GRANT" in s for s in sql)
-
-    def test_bad_schema_rejected_before_any_ddl(self):
-        cur = MagicMock()
-        with pytest.raises(ValueError):
-            _migrate_encryption_key_to_lakebase(
-                cur, 'x"; DROP SCHEMA y; --', CLIENT_ID, KEY
-            )
-        cur.execute.assert_not_called()
-
-    def test_bad_client_id_rejected_before_grant(self):
-        cur = _cursor(existing_key=KEY)
-        with pytest.raises(ValueError):
-            _migrate_encryption_key_to_lakebase(cur, SCHEMA, '"; GRANT ALL --', KEY)
 
 
 class TestReadExistingEncryptionKeyStrict:
@@ -96,57 +43,17 @@ class TestReadExistingEncryptionKeyStrict:
             _read_existing_encryption_key(ws, "/Workspace/x")
 
 
-class TestUpdateDatabricksWiring:
+class TestUpdateDatabricksCarryForward:
     @patch("databricks_tellr.deploy._get_workspace_client")
     @patch("databricks_tellr.deploy._get_or_create_lakebase")
     @patch("databricks_tellr.deploy._check_breaking_migrations")
     @patch("databricks_tellr.deploy._read_existing_encryption_key", return_value=KEY)
-    @patch("databricks_tellr.deploy._get_lakebase_connection")
-    @patch("databricks_tellr.deploy._migrate_encryption_key_to_lakebase")
     @patch("databricks_tellr.deploy._write_requirements")
     @patch("databricks_tellr.deploy._write_app_yaml")
     @patch("databricks_tellr.deploy._upload_files")
-    def test_migration_runs_before_upload_and_key_not_passed_to_app_yaml(
-        self, mock_upload, mock_yaml, mock_reqs, mock_migrate,
-        mock_conn, mock_read, mock_check, mock_lakebase, mock_ws_factory,
-    ):
-        from databricks_tellr.deploy import _update_databricks
-
-        ws = MagicMock()
-        mock_ws_factory.return_value = ws
-        mock_lakebase.return_value = {"type": "provisioned", "name": "lb"}
-        conn = MagicMock()
-        mock_conn.return_value = (conn, "me@x.com")
-        ws.apps.get.return_value = MagicMock(
-            service_principal_client_id=CLIENT_ID, url="https://app"
-        )
-
-        manager = MagicMock()
-        manager.attach_mock(mock_migrate, "migrate")
-        manager.attach_mock(mock_upload, "upload")
-
-        _update_databricks(
-            app_name="app", app_file_workspace_path="/Workspace/x",
-            lakebase_name="lb", schema_name=SCHEMA,
-        )
-
-        # migration strictly precedes upload (order is load-bearing)
-        names = [c[0] for c in manager.mock_calls if c[0] in ("migrate", "upload")]
-        assert names.index("migrate") < names.index("upload")
-        # app.yaml writer no longer receives a key
-        assert "encryption_key" not in mock_yaml.call_args.kwargs
-
-    @patch("databricks_tellr.deploy._get_workspace_client")
-    @patch("databricks_tellr.deploy._get_or_create_lakebase")
-    @patch("databricks_tellr.deploy._check_breaking_migrations")
-    @patch("databricks_tellr.deploy._read_existing_encryption_key", return_value=None)
-    @patch("databricks_tellr.deploy._migrate_encryption_key_to_lakebase")
-    @patch("databricks_tellr.deploy._write_requirements")
-    @patch("databricks_tellr.deploy._write_app_yaml")
-    @patch("databricks_tellr.deploy._upload_files")
-    def test_no_key_in_deployed_yaml_skips_migration(
-        self, mock_upload, mock_yaml, mock_reqs, mock_migrate,
-        mock_read, mock_check, mock_lakebase, mock_ws_factory,
+    def test_legacy_key_is_carried_into_app_yaml(
+        self, mock_upload, mock_yaml, mock_reqs, mock_read,
+        mock_check, mock_lakebase, mock_ws_factory,
     ):
         from databricks_tellr.deploy import _update_databricks
 
@@ -159,7 +66,38 @@ class TestUpdateDatabricksWiring:
             app_name="app", app_file_workspace_path="/Workspace/x",
             lakebase_name="lb", schema_name=SCHEMA,
         )
-        mock_migrate.assert_not_called()
+        # key is carried forward into the regenerated app.yaml
+        assert mock_yaml.call_args.kwargs.get("encryption_key") == KEY
+
+    @patch("databricks_tellr.deploy._get_workspace_client")
+    @patch("databricks_tellr.deploy._get_or_create_lakebase")
+    @patch("databricks_tellr.deploy._check_breaking_migrations")
+    @patch("databricks_tellr.deploy._read_existing_encryption_key", return_value=None)
+    @patch("databricks_tellr.deploy._write_requirements")
+    @patch("databricks_tellr.deploy._write_app_yaml")
+    @patch("databricks_tellr.deploy._upload_files")
+    def test_no_legacy_key_writes_keyless(
+        self, mock_upload, mock_yaml, mock_reqs, mock_read,
+        mock_check, mock_lakebase, mock_ws_factory,
+    ):
+        from databricks_tellr.deploy import _update_databricks
+
+        ws = MagicMock()
+        mock_ws_factory.return_value = ws
+        mock_lakebase.return_value = {"type": "provisioned", "name": "lb"}
+        ws.apps.get.return_value = MagicMock(url="https://app")
+
+        _update_databricks(
+            app_name="app", app_file_workspace_path="/Workspace/x",
+            lakebase_name="lb", schema_name=SCHEMA,
+        )
+        # keyless: encryption_key is None (or absent)
+        assert not mock_yaml.call_args.kwargs.get("encryption_key")
+
+    def test_migrate_function_is_removed(self):
+        """The deploy-time DDL relocation is gone; boot owns migration now."""
+        import databricks_tellr.deploy as d
+        assert not hasattr(d, "_migrate_encryption_key_to_lakebase")
 
 
 class TestWriteAppYamlKeyBlock:

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -1,8 +1,10 @@
 """Tests for the Lakebase-backed Fernet encryption utility (SDR-4437 CRITICAL-3)."""
 
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 import pytest
+import yaml
 from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
@@ -43,6 +45,7 @@ def db(tmp_path, monkeypatch):
 
     monkeypatch.setattr("src.core.database.get_db_session", _session)
     monkeypatch.setattr("src.core.encryption._KEY_FILE", tmp_path / ".encryption_key")
+    monkeypatch.delenv("GOOGLE_OAUTH_ENCRYPTION_KEY", raising=False)
     get_encryption_key.cache_clear()
     yield engine, _session
     get_encryption_key.cache_clear()
@@ -250,3 +253,94 @@ def test_init_database_exits_1_when_key_seed_fails(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         run.init_database()
     assert exc.value.code == 1
+
+
+def _app_yaml_bytes(with_key: str | None) -> bytes:
+    env = [{"name": "ENVIRONMENT", "value": "production"}]
+    if with_key is not None:
+        env.append({"name": "GOOGLE_OAUTH_ENCRYPTION_KEY", "value": with_key})
+    return yaml.safe_dump({"name": "tellr", "env": env}).encode()
+
+
+def _mock_ws_with_app_yaml(content_bytes: bytes, source_path="/Workspace/x"):
+    ws = MagicMock()
+    ws.apps.get.return_value = MagicMock(default_source_code_path=source_path)
+    resp = MagicMock()
+    resp.read.return_value = content_bytes
+    ws.workspace.download.return_value = resp
+    return ws
+
+
+def test_scrub_noop_when_app_name_unset(db, monkeypatch):
+    """Local/SQLite/tests have no DATABRICKS_APP_NAME → scrub is a no-op."""
+    from src.core.encryption import _scrub_app_yaml_key
+    monkeypatch.delenv("DATABRICKS_APP_NAME", raising=False)
+    called = []
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client",
+        lambda *a, **k: called.append(1),
+    )
+    _scrub_app_yaml_key()
+    assert called == []  # never even built a client
+
+
+def test_scrub_removes_entry_on_value_match(db, monkeypatch):
+    from src.core.encryption import _scrub_app_yaml_key
+    # Seed the table so get_encryption_key returns a known key.
+    key = get_encryption_key().decode()
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = _mock_ws_with_app_yaml(_app_yaml_bytes(with_key=key))
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()
+    # uploaded content must no longer contain the key entry
+    uploaded = ws.workspace.upload.call_args
+    assert uploaded is not None
+    body = uploaded.args[1] if len(uploaded.args) > 1 else uploaded.kwargs["content"]
+    text_body = body.decode() if isinstance(body, bytes) else (
+        body.read().decode() if hasattr(body, "read") else str(body)
+    )
+    assert "GOOGLE_OAUTH_ENCRYPTION_KEY" not in text_body
+
+
+def test_scrub_leaves_entry_on_value_mismatch(db, monkeypatch):
+    """A divergent key must NOT be removed — it might be the only copy of a
+    different key. Log and leave it."""
+    from src.core.encryption import _scrub_app_yaml_key
+    get_encryption_key()  # seed table
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = _mock_ws_with_app_yaml(_app_yaml_bytes(with_key="a-different-key"))
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()
+    ws.workspace.upload.assert_not_called()
+
+
+def test_scrub_noop_when_no_key_entry(db, monkeypatch):
+    """Already-scrubbed app.yaml → nothing to do, no upload (idempotent)."""
+    from src.core.encryption import _scrub_app_yaml_key
+    get_encryption_key()
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = _mock_ws_with_app_yaml(_app_yaml_bytes(with_key=None))
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()
+    ws.workspace.upload.assert_not_called()
+
+
+def test_scrub_swallows_download_failure(db, monkeypatch):
+    """Any failure (no ACL, download error) is caught — scrub never raises."""
+    from src.core.encryption import _scrub_app_yaml_key
+    get_encryption_key()
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "tellr")
+    ws = MagicMock()
+    ws.apps.get.return_value = MagicMock(default_source_code_path="/Workspace/x")
+    ws.workspace.download.side_effect = OSError("no read ACL")
+    monkeypatch.setattr(
+        "src.core.databricks_client.get_system_client", lambda *a, **k: ws
+    )
+    _scrub_app_yaml_key()  # must NOT raise
+    ws.workspace.upload.assert_not_called()

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -90,6 +90,44 @@ def test_legacy_key_file_seeds_empty_table(db, tmp_path):
     assert _stored_key(engine) == legacy
 
 
+def test_env_var_seeds_empty_table(db, monkeypatch):
+    """SDR-4437: the one-time legacy→table migration. An empty table plus a
+    GOOGLE_OAUTH_ENCRYPTION_KEY env var seeds the table from that env value."""
+    engine, _ = db
+    legacy = Fernet.generate_key().decode()
+    monkeypatch.setenv("GOOGLE_OAUTH_ENCRYPTION_KEY", legacy)
+    assert get_encryption_key() == legacy.encode()
+    assert _stored_key(engine) == legacy
+
+
+def test_env_var_takes_priority_over_key_file(db, tmp_path, monkeypatch):
+    """When both are present on an empty table, the env var (migration source)
+    wins over the legacy key file."""
+    engine, _ = db
+    env_key = Fernet.generate_key().decode()
+    file_key = Fernet.generate_key().decode()
+    (tmp_path / ".encryption_key").write_text(file_key)
+    monkeypatch.setenv("GOOGLE_OAUTH_ENCRYPTION_KEY", env_key)
+    assert get_encryption_key() == env_key.encode()
+    assert _stored_key(engine) == env_key
+
+
+def test_existing_row_ignores_env_var(db, monkeypatch):
+    """One-time cutover: once the row exists, the env var is never consulted."""
+    engine, session = db
+    existing = Fernet.generate_key().decode()
+    with session() as s:
+        s.execute(
+            text(
+                "INSERT INTO encryption_keys (id, key_value, created_at) "
+                "VALUES (1, :k, CURRENT_TIMESTAMP)"
+            ),
+            {"k": existing},
+        )
+    monkeypatch.setenv("GOOGLE_OAUTH_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    assert get_encryption_key() == existing.encode()
+
+
 def test_concurrent_seed_converges_on_winner(db, monkeypatch):
     """If another worker inserts between our SELECT and INSERT, read-back wins."""
     engine, session = db

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -255,6 +255,43 @@ def test_init_database_exits_1_when_key_seed_fails(monkeypatch):
     assert exc.value.code == 1
 
 
+def test_init_database_invokes_scrub_after_key_hook(monkeypatch):
+    """run.py::init_database calls _scrub_app_yaml_key after ensure_encryption_key."""
+    run = _load_run_module()
+    order = []
+    monkeypatch.setattr("src.core.database.init_db", lambda: None)
+    monkeypatch.setattr(
+        "src.core.init_default_profile.seed_defaults",
+        lambda include_databricks: None,
+    )
+    monkeypatch.setattr(
+        "src.core.encryption.ensure_encryption_key", lambda: order.append("ensure")
+    )
+    monkeypatch.setattr(
+        "src.core.encryption._scrub_app_yaml_key", lambda: order.append("scrub")
+    )
+    run.init_database()
+    assert order == ["ensure", "scrub"]
+
+
+def test_init_database_survives_scrub_failure(monkeypatch):
+    """A scrub failure must NOT abort boot (it is best-effort)."""
+    run = _load_run_module()
+    monkeypatch.setattr("src.core.database.init_db", lambda: None)
+    monkeypatch.setattr(
+        "src.core.init_default_profile.seed_defaults",
+        lambda include_databricks: None,
+    )
+    monkeypatch.setattr("src.core.encryption.ensure_encryption_key", lambda: None)
+
+    def _boom():
+        raise RuntimeError("scrub blew up")
+
+    monkeypatch.setattr("src.core.encryption._scrub_app_yaml_key", _boom)
+    # Must return normally — NO SystemExit.
+    run.init_database()
+
+
 def _app_yaml_bytes(with_key: str | None) -> bytes:
     env = [{"name": "ENVIRONMENT", "value": "production"}]
     if with_key is not None:


### PR DESCRIPTION
## Summary

Fixes the silent data-loss bug from SDR-4437 CRITICAL-3 where any upgrade **not** run through the deploy tool — most importantly the Databricks Apps **UI "Deploy" button** — booted the new keyless code, found `encryption_keys` empty, ignored the `GOOGLE_OAUTH_ENCRYPTION_KEY` env var still sitting in app.yaml, and generated a **fresh** key. Every existing encrypted Google credential/token became undecryptable (and was self-deleted on read). Root cause: the key migration lived in the deploy tool instead of being self-contained in the artifact.

## The fix — three units, boot owns migration on every path

1. **Boot-time seed (correctness).** `src/core/encryption.py::_seed_value()` now reads `GOOGLE_OAUTH_ENCRYPTION_KEY` first when the table is empty. Because `get_encryption_key()` is SELECT-first, this is a **one-time cutover** that migrates the legacy key on the first boot of the new code, then never consults the env var again.
2. **Boot-time self-scrub (SDR hygiene).** New `_scrub_app_yaml_key()` best-effort removes the plaintext key from the deployed workspace app.yaml — but **only** after validating the table holds the matching valid key, so it can never orphan ciphertext. Never raises; wired into `run.py::init_database()` as a **separate** exception-swallowing block after `ensure_encryption_key()` (which `SystemExit`s), so a scrub failure can never abort boot. No-op outside a Databricks Apps runtime.
3. **Deploy-tool carry-forward.** `tellr.update` and `deploy_local update` now re-emit any existing key into the regenerated app.yaml (new `$ENCRYPTION_KEY_BLOCK` template placeholder + `_write_app_yaml(encryption_key=...)`) so boot can migrate it, instead of a deploy-time DDL relocation. `_migrate_encryption_key_to_lakebase` is deleted.

The **fork/branching preflight's legacy-key rejection is deliberately KEPT**: carry-forward does not run on the fork path (the fork inherits the key by copy-on-write of the table), so the source env must be migrated once before it can be forked.

## Why this is safe

- **No data loss on any path**: SELECT-first means an already-migrated install never re-reads env; the scrub validates the table key before removing anything and only deletes an exact-match redundant copy; the kept fork precondition blocks forking an unmigrated source.
- **Dev == prod**: all three upgrade paths converge on the identical boot-time migrator, eliminating the dev/prod divergence that let CRITICAL-3 pass in dev but lose data in prod.

## Known limitation (documented)

If the app SP lacks write ACL on its own source folder, boot-scrub cannot land — and because Unit 3 is *carry-forward* (it re-emits a present key, it does not drop it), **boot-scrub is the only automated remover** of a still-present app.yaml key. In that regime a failed scrub leaves the plaintext key until removed manually. Data safety is unaffected (SELECT-first makes the lingering key inert). Resolving the write-ACL probe on a deployed instance is the open item for SDR sign-off.

## Testing

- Full unit suite: **zero net-new failures** vs `main` (the 19 failures are the known pre-existing baseline: SVG/cairo, mlflow-tracing, autoscaling-mock). All branch-touched tests pass.
- TDD throughout: env-seed order, SELECT-first cutover, scrub match-only/never-raise/no-op-off-runtime, carry-forward keyless-vs-key, function deletion, fork precondition retained.
- **Live verification (deployed legacy→new upgrade) is PENDING** — published as `0.3.13.dev17` for manual two-lifecycle testing; the write-ACL probe is answered there.

Spec: `docs/superpowers/specs/2026-07-20-fernet-key-boot-migration-design.md`
Plan: `docs/superpowers/plans/2026-07-20-fernet-key-boot-migration.md`

This pull request and its description were written by Isaac.
