### PR TITLE
fix(gslides): keep absolutely-positioned pills in place on export

### DIFF
--- a/docs/technical/google-slides-integration.md
+++ b/docs/technical/google-slides-integration.md
@@ -1,25 +1,32 @@
 # Google Slides Integration
 
-**One-Line Summary:** Global, user-scoped Google OAuth2 flow with encrypted credential storage and LLM-powered HTML-to-Google-Slides conversion.
+**One-Line Summary:** Global, user-scoped Google OAuth2 flow with encrypted credential storage; export renders the deck HTML to a PPTX and uploads it to Drive, which auto-converts it to native editable Google Slides.
 
 ---
 
 ## 1. Overview
 
-The Google Slides integration allows users to export their AI-generated slide decks directly to Google Slides presentations. It extends the existing PPTX export with a cloud-native alternative that produces editable Google Slides.
+The Google Slides integration allows users to export their AI-generated slide decks directly to Google Slides presentations. It shares the deck's rendered HTML with the PPTX export path and produces editable Google Slides via a Drive round-trip.
 
 Key design decisions:
 - **Global credentials** — A single `credentials.json` is stored app-wide in the `google_global_credentials` table, encrypted at rest. Admins upload via the `/admin` page.
 - **Per-user tokens** — OAuth tokens are scoped to `user_identity` only. Each user authorizes once; tokens are stored in `google_oauth_tokens`.
 - **DB-backed storage** — No files on disk; all secrets live in PostgreSQL/Lakebase, encrypted with Fernet symmetric encryption.
-- **LLM code-gen approach** — Same architecture as PPTX export: an LLM generates Python code that calls the Google Slides API, which is then executed server-side.
+- **HTML → PPTX → Drive auto-convert** — The export does **not** call the Google Slides API to build slides object-by-object. It renders the deck's HTML to a `.pptx` and uploads that file to Drive with `mimeType=application/vnd.google-apps.presentation`, so Google converts it to a native Slides presentation. This gives coordinate-faithful layout (positions come straight from the rendered DOM) for free.
+
+> **Historical note.** An earlier design used an LLM to generate Python that
+> called `slides.batchUpdate()` object-by-object (`src/services/html_to_google_slides.py`,
+> `google_slides_prompts_defaults.py`, and the `POST /api/export/google-slides`
+> + `/poll/{job_id}` async-job routes). That path is **superseded** by the
+> HTML→PPTX→Drive pipeline below and is no longer the route the UI calls. The
+> code still exists but should be treated as legacy.
 
 ---
 
 ## 2. Architecture
 
 ```
-Frontend (Admin page → GoogleSlidesAuthForm)
+Frontend (Admin page → GoogleSlidesAuthForm)   ← one-time setup
   │
   ├─ Upload credentials.json ──► POST /api/admin/google-credentials
   │                                 └─ validates → encrypts → stores in google_global_credentials
@@ -28,18 +35,29 @@ Frontend (Admin page → GoogleSlidesAuthForm)
   │                                 └─ builds Flow from decrypted creds → returns consent URL
   │   Google consent ──────────► GET /api/export/google-slides/auth/callback
   │                                 └─ exchanges code → encrypts token → stores in google_oauth_tokens
+
+Frontend (SlidePanel → "Export to Google Slides")   ← the export
   │
-  └─ Export ───────────────────► POST /api/export/google-slides
-  │                                 └─ validates auth → fetches slides → enqueues async job → returns job_id
-  └─ Poll ────────────────────► GET /api/export/google-slides/poll/{job_id}
-                                    └─ returns progress, status, and presentation URL on completion
+  ├─ POST /api/export/google-slides/from-huashu     (primary path)
+  │      └─ backend fetches deck HTML from session storage
+  │      └─ build_pptx_huashu() → spawns Node sidecar (emit_deck.mjs)
+  │            └─ per slide: Playwright renders HTML in Chromium (1280×720)
+  │                          → preprocess.mjs mutates DOM → html2pptx.js walks
+  │                            the rendered DOM → pptxgenjs assembles one .pptx
+  │      └─ upload_pptx_as_slides()  → Drive upload, mimeType=…google-apps.presentation
+  │                          → Google auto-converts PPTX → native Slides
+  │      └─ returns { presentation_id, presentation_url }   (synchronous, no polling)
+  │
+  └─ POST /api/export/google-slides/from-records    (fallback, only on 503)
+         └─ client-side DOM walker (domWalker.ts) → records → pptxgenjs → same Drive upload
 ```
 
 ### Data Flow
 
 1. **Admin** uploads `credentials.json` via the Google Slides tab on the `/admin` page.
 2. **Each user** clicks "Authorize" to complete the OAuth consent flow in a popup. The resulting token is encrypted and stored per-user (by `user_identity`).
-3. **Export** validates auth, fetches slides, and enqueues an async background job. The frontend polls for progress until the job completes with `presentation_id` and `presentation_url`.
+3. **Export** (`exportToGoogleSlides` in `frontend/src/services/api.ts`) POSTs to `/from-huashu`. The backend builds the PPTX server-side and uploads it to Drive in a single synchronous round-trip — there is **no** job/poll cycle on this path.
+4. If the huashu pipeline is unavailable on the deployment (HTTP 503 — e.g. Chromium not bootstrapped), the frontend transparently falls back to `/from-records`, walking the deck DOM client-side and POSTing the extracted records.
 
 ---
 
@@ -132,45 +150,46 @@ python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().d
 
 ### Export (`/api/export/google-slides`)
 
+All export routes live in `src/api/routes/google_slides.py`.
+
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/export/google-slides` | Starts an async Google Slides export job. Returns `{job_id, status, total_slides}`. |
-| `GET` | `/api/export/google-slides/poll/{job_id}` | Polls export progress. Returns `{job_id, status, progress, total_slides}`. When `status` is `completed`, also includes `presentation_id` and `presentation_url`. |
+| `POST` | `/api/export/google-slides/from-huashu` | **Primary.** Backend fetches the deck HTML from session storage, renders it to a PPTX via the huashu (Playwright + Chromium) pipeline, and uploads it to Drive. Synchronous — returns `{presentation_id, presentation_url}` directly. |
+| `POST` | `/api/export/google-slides/from-records` | **Fallback** (frontend uses it only when `/from-huashu` returns 503). Accepts DOM-walker records extracted client-side, builds a PPTX with pptxgenjs, and uploads it the same way. |
+| `POST` | `/api/export/google-slides` | **Legacy** async LLM-batchUpdate job. Returns `{job_id, status, total_slides}`. Not called by the current UI — see the historical note in §1. |
+| `GET` | `/api/export/google-slides/poll/{job_id}` | **Legacy** poll for the async job above. |
 
-Export is **asynchronous**. The `POST` validates auth, fetches slides, builds HTML, and enqueues a background job for the slow LLM conversion. The frontend polls the `GET` endpoint until `status` reaches `completed` or `error`.
+Both live paths are **synchronous** — a single request builds the PPTX and completes the Drive upload before responding, so there is no job/poll cycle.
 
-**Re-export:** If a session has already been exported to Google Slides, the endpoint looks up the `existing_presentation_id` via the session manager and overwrites the existing presentation instead of creating a new one.
+The `/from-huashu` route sets `bypass_validation=True` so every slide ships even if it violates huashu's design-rule checks (overflow, text-near-bottom-edge, etc.) — otherwise a failing slide would be silently dropped and slide numbering would shift on Drive.
 
-**Request body:**
+**Re-export:** If a session already has a presentation, the route looks up the `existing_presentation_id` via the session manager and calls `replace_presentation()` (delete + re-upload) instead of creating a new one.
+
+**Request body (`/from-huashu`):**
+```json
+{ "session_id": "abc123" }
+```
+No client-side images or records are needed — the backend assembles complete slide HTML server-side (`_build_slide_html`, which delegates to `export.py::build_slide_html`) and substitutes `{{image:ID}}` placeholders with base64 data URIs.
+
+**Request body (`/from-records`):**
 ```json
 {
   "session_id": "abc123",
-  "chart_images": [[{"canvas_id": "chart_0", "base64_data": "data:image/png;base64,..."}]]
+  "title": "Presentation",
+  "slides": [ /* SlideExtract[] from domWalker.ts */ ],
+  "font_mode": "google_slides"
 }
 ```
 
-**Response body (POST):**
+**Response body (both live paths):**
 ```json
 {
-  "job_id": "abc-123",
-  "status": "pending",
-  "total_slides": 5
-}
-```
-
-**Response body (GET poll, completed):**
-```json
-{
-  "job_id": "abc-123",
-  "status": "completed",
-  "progress": 5,
-  "total_slides": 5,
   "presentation_id": "1A2B3C...",
   "presentation_url": "https://docs.google.com/presentation/d/1A2B3C.../edit"
 }
 ```
 
-Auth uses global credentials and user-scoped token.
+Auth uses global credentials and the user-scoped token.
 
 ---
 
@@ -191,26 +210,52 @@ Key methods:
 - `authorize(code, redirect_uri)` — Exchanges code for tokens, persists.
 - `build_slides_service()` / `build_drive_service()` — Returns authenticated Google API clients.
 
-### HtmlToGoogleSlidesConverter (`src/services/html_to_google_slides.py`)
+### Huashu PPTX pipeline (`src/services/pptx_from_html_huashu.py`)
 
-LLM-powered converter following the same pattern as `HtmlToPptxConverterV3`:
+The primary path. `build_pptx_huashu(title, slides_html, bypass_validation=…)`
+JSON-encodes the deck and spawns the Node sidecar
+`services/pptx-emit-huashu/emit_deck.mjs`, which for each slide:
 
-1. Creates a blank Google Slides presentation via the API.
-2. Extracts base64-embedded content images from HTML, converting SVGs to PNG via `_svg_to_png()` (`svgpathtools` + `Pillow`).
-3. For each slide, sends the HTML to the LLM with a detailed system prompt.
-4. LLM generates Python code that calls `slides_service.presentations().batchUpdate()`.
-5. Content images are uploaded to Google Drive and embedded via `createImage` requests.
-6. Code is executed server-side with sanitization (smart quote replacement, function wrapping, import injection).
-7. On failure, retries once with error context. Falls back to a placeholder text box.
+1. Launches headless Chromium via Playwright and loads the slide's complete HTML doc (sized to 1280×720 px = 13.333"×7.5", `LAYOUT_WIDE`).
+2. Runs `preprocess.mjs` (`PREPROCESS_SOURCE`) as an in-page `page.evaluate()` DOM-mutation pass to bring Tellr's HTML into compliance with huashu's rules — wrap bare `<div>` text in `<p>`, flatten `<table>`s to positioned divs, rasterize `<canvas>`, transfer slide-root backgrounds to `<body>`, promote inline-background pills, etc.
+3. Walks the rendered DOM in `html2pptx.js`, reading each element's `getBoundingClientRect()` and converting px→inches at 96 px/in, and emits the corresponding pptxgenjs shapes/text/images.
+4. `pptxgenjs` assembles all slides into a single `.pptx`, returned as bytes.
 
-### Prompts (`src/services/google_slides_prompts_defaults.py`)
+**Availability / local-only.** The sidecar needs Chromium (via Playwright),
+which Databricks Apps containers lack by default. `is_available()` gates on
+`HUASHU_PIPELINE_ENABLED=1` (or `ENVIRONMENT=development`) plus node,
+`playwright`, `pptxgenjs`, and an installed Chromium. When it can't run, the
+route returns 503 and the frontend falls back to `/from-records`.
 
-Shared rules cover:
-- Slide dimensions (16:9 widescreen, 10" x 5.625")
-- Overflow prevention with strict bounds
-- Font size maximums per element type
-- Metric card, table, chart, and layout patterns
-- Google Slides API patterns (batchUpdate nesting, textRange, shapeProperties)
+**Positioning is coordinate-faithful.** Element positions are measured from the
+rendered DOM, not inferred — an absolutely-positioned corner element lands in
+that corner in the PPTX (and therefore in Slides). The one place this was
+historically broken: `preprocess.mjs::emitInlineBackgrounds()` re-centers
+inline-background pills (`span`/`mark`/`kbd`) so table-cell badges sit centered
+in their cell. It now branches on `position` — author-positioned
+(`absolute`/`fixed`) pills keep their measured position (fixing corner
+"eyebrow"/"cadence" tags that used to drift to the slide center on export),
+while normal-flow badges are still centered.
+
+### Records PPTX pipeline (`src/services/pptx_from_records.py`)
+
+The fallback path. `build_pptx(...)` takes the `SlideExtract[]` records that
+`frontend/src/services/domWalker.ts` produced by walking the deck DOM
+client-side (in a hidden iframe in the user's browser) and emits a PPTX with
+pptxgenjs — no server-side Chromium required. Lower fidelity than huashu but
+works on any deployment.
+
+### Drive uploader (`src/services/drive_uploader.py`)
+
+- `upload_pptx_as_slides(auth, pptx_bytes, title)` — uploads the PPTX to Drive with `mimeType=application/vnd.google-apps.presentation`, which triggers Google's server-side conversion to a native editable Slides presentation. Returns `(presentation_id, web_view_url)`. The file is created with the requesting user's OAuth credentials, so it lives in *their* Drive with owner access (no extra sharing — the earlier "anyone-with-link" grant was removed after DoControl flagged it).
+- `replace_presentation(auth, old_id, pptx_bytes, title)` — best-effort delete of the old file, then a fresh upload. Used on re-export.
+
+### Legacy: HtmlToGoogleSlidesConverter (`src/services/html_to_google_slides.py`)
+
+The superseded LLM code-gen converter (+ `google_slides_prompts_defaults.py`).
+It creates a blank presentation via the API, prompts an LLM to emit Python that
+returns `batchUpdate` request dicts, then validates/executes them host-side.
+Retained for reference but not on the live export path — see §1.
 
 ---
 
@@ -228,12 +273,13 @@ Rendered on the `/admin` page. Provides:
 
 ### SlidePanel (`frontend/src/components/SlidePanel/SlidePanel.tsx`)
 
-`handleExportGoogleSlides` calls `exportToGoogleSlides(sessionId, chartImages)` to export the current session's deck.
+`handleExportGoogleSlides` calls `exportToGoogleSlides(sessionId, slideDeck, onProgress)`, which POSTs to `/from-huashu` and, on 503, extracts records via `domWalker.ts` and retries against `/from-records`.
 
 ### API Services
 
 - `frontend/src/api/config.ts` — `uploadGoogleCredentials()`, `getGoogleCredentialsStatus()`, `deleteGoogleCredentials()` (admin endpoints)
-- `frontend/src/services/api.ts` — `checkGoogleSlidesAuth()`, `getGoogleSlidesAuthUrl()`, `exportToGoogleSlides(sessionId, chartImages)`
+- `frontend/src/services/api.ts` — `checkGoogleSlidesAuth()`, `getGoogleSlidesAuthUrl()`, `exportToGoogleSlides(sessionId, slideDeck, onProgress)`
+- `frontend/src/services/domWalker.ts` — `extractSlideRecordsForExport(deck, fontMode)`, the client-side DOM walker used only for the `/from-records` fallback
 
 ---
 

--- a/services/pptx-emit-huashu/preprocess.mjs
+++ b/services/pptx-emit-huashu/preprocess.mjs
@@ -480,18 +480,36 @@ export const PREPROCESS_SOURCE = `
       const borderRight = parseFloat(acs.borderRightWidth) || 0;
       const borderTop = parseFloat(acs.borderTopWidth) || 0;
       const borderBottom = parseFloat(acs.borderBottomWidth) || 0;
-      // Center the pill within the cell's content area, both horizontally
-      // and vertically. Place it directly at the geometric middle of the
-      // cell's content area (cell height minus padding/border) instead of
-      // inheriting the span's measured position — that way the pill sits
-      // at the same y-baseline as the row label and the plain-text cells
-      // (which are also flex-centered in their cell-divs).
+      // Where to place the standalone pill depends on how the ORIGINAL inline
+      // element was positioned:
+      //
+      //   * Author-positioned (position: absolute / fixed) — e.g. a corner
+      //     "eyebrow" / "cadence" tag anchored top-left / top-right of the
+      //     slide. Preserve its measured position. Recentering these yanks
+      //     them to the geometric middle of their (slide-sized) ancestor —
+      //     the "corner pills drift to the centre on Google/PPTX export" bug.
+      //
+      //   * Normal flow (static / relative) — e.g. a badge inside a flattened
+      //     table cell. Centre it in the ancestor's content area so it sits on
+      //     the same baseline as the row label and the flex-centred plain-text
+      //     cells. This is the case emitInlineBackgrounds was written for.
       const contentWidth =
         ancestorRect.width - padLeft - padRight - borderLeft - borderRight;
       const contentHeight =
         ancestorRect.height - padTop - padBottom - borderTop - borderBottom;
-      const x = Math.max(0, (contentWidth - elRect.width) / 2);
-      const y = Math.max(0, (contentHeight - elRect.height) / 2);
+      const isAuthorPositioned = cs.position === 'absolute' || cs.position === 'fixed';
+      let x, y;
+      if (isAuthorPositioned) {
+        // Offset from the ancestor's padding box (where absolute children
+        // anchor) = measured position, so the pill lands exactly where the
+        // author placed it. ancestor is promoted to a positioned context
+        // below, so the pill resolves against it rather than a higher one.
+        x = elRect.left - (ancestorRect.left + borderLeft);
+        y = elRect.top - (ancestorRect.top + borderTop);
+      } else {
+        x = Math.max(0, (contentWidth - elRect.width) / 2);
+        y = Math.max(0, (contentHeight - elRect.height) / 2);
+      }
 
       // Build the standalone pill: a positioned <div> with the bg,
       // border-radius, and same dims as the span, containing a <p>


### PR DESCRIPTION
## Problem

When a deck is exported to Google Slides, absolutely-positioned corner elements — e.g. `.tag-eyebrow` (top-left) and `.tag-cadence` (top-right) "pill" tags — drift into the **middle** of the slide instead of staying in their corners.

## Root cause

Google Slides export runs through the huashu pipeline: **HTML → PPTX (Playwright + Chromium DOM walk) → Drive upload → auto-convert to Slides**. Positioning is coordinate-faithful (each element's `getBoundingClientRect()` → inches), *except* for one preprocess step.

`preprocess.mjs::emitInlineBackgrounds()` rebuilds every inline-background `<span>`/`<mark>`/`<kbd>` as a standalone positioned `<div>` (so huashu emits the background) and **unconditionally re-centers it** inside its ancestor. That centering is correct for badges inside flattened table cells, but for an author-positioned corner tag (`position: absolute`) the ancestor is the whole slide root — so the pill gets yanked to the geometric middle of the slide.

## Fix

Branch on the original element's `position`:
- **Author-positioned** (`absolute`/`fixed`) pills keep their measured position — fixes the corner drift.
- **Normal-flow** pills (table-cell badges) are still centered, as before.

## Verification

Reproduced and verified end-to-end through the real Playwright + Chromium sidecar (`emit_deck.mjs` → `html2pptx.js` → pptxgenjs):

- **Before fix:** corner pills measured at `(20,20)` / `(1155,20)` px pre-preprocess, both at `(~550,310)` — dead center — after.
- **After fix:** a corner-pill slide emits shapes at `0.21"×0.21"` (top-left) and `12.18"×0.21"` (top-right) of the 13.33" slide.
- **Regression guard:** a badge inside a flattened table cell still centers within its cell row (not the slide).

## Docs

Also refreshes `docs/technical/google-slides-integration.md`, which described a stale LLM-`batchUpdate` design. The doc now documents the live HTML→PPTX→Drive pipeline, the `/from-huashu` (primary) and `/from-records` (fallback) routes, the Drive uploader, and marks the LLM converter as legacy.

## Notes for reviewers

- The change is in the bundled huashu Node sidecar (`preprocess.mjs`), which ships in the wheel under `_assets/sidecars/pptx-emit-huashu/` — the `tellr-code-review` checklist flags this bundling chain as fragile, worth a look.
- The huashu path is local-dev / opt-in only (`HUASHU_PIPELINE_ENABLED=1`; needs Chromium), so the fix is exercised via the sidecar, not the Apps container.

This pull request and its description were written by Isaac.