### PR TITLE
chore(release): bump version 0.4.0 -> 0.4.1

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.4.0"
+version = "0.4.1"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.4.0"
+version = "0.4.1"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps both packages `0.4.0` -> `0.4.1` for the patch release carrying the
Google Slides corner-pill positioning fix (#232, already merged to `main`).

The bump was originally committed on the #232 branch but that PR merged
before the bump landed, so `main` still reads `0.4.0`. This carries just the
two version lines.

Both `databricks-tellr` and `databricks-tellr-app` must share the version —
`publish.yml` validates the `v*` release tag against both `pyproject.toml`
files, so they have to be in lockstep before tagging `v0.4.1`.

After merge, cut the release with:

    git tag v0.4.1 && git push origin v0.4.1

This pull request and its description were written by Isaac.