### PR TITLE
security(SDR-4437 F-CR-3): OAuth state-nonce binding + explicit postMessage origin

### DIFF
--- a/frontend/src/hooks/useGoogleOAuthPopup.ts
+++ b/frontend/src/hooks/useGoogleOAuthPopup.ts
@@ -17,6 +17,9 @@ export function useGoogleOAuthPopup() {
       const popup = window.open(url, 'google-slides-auth', 'width=600,height=700,popup=yes');
 
       const handleMessage = (event: MessageEvent) => {
+        // F-CR-3 (SDR-4437): only trust the callback popup, which is same-origin.
+        // Reject spoofed messages posted from any other origin.
+        if (event.origin !== window.location.origin) return;
         if (event.data?.type === 'google-slides-auth') {
           cleanup();
           resolve(event.data.success === true);

--- a/src/api/routes/google_slides.py
+++ b/src/api/routes/google_slides.py
@@ -10,9 +10,10 @@ user tokens are stored per-user in the ``google_oauth_tokens`` table.
 import json
 import logging
 import os
+import secrets
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -32,6 +33,12 @@ from src.services.pptx_from_records import EmitError, build_pptx
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/export/google-slides", tags=["google-slides"])
+
+# F-CR-3 (SDR-4437): the OAuth "state" carries an unguessable nonce that is also
+# stored in this short-lived cookie; the callback requires them to match before
+# exchanging the authorization code (anti-CSRF / anti-login-CSRF double-submit).
+_OAUTH_STATE_COOKIE = "g_oauth_state"
+_OAUTH_COOKIE_PATH = "/api/export/google-slides"
 
 
 # -------------------------------------------------------------------------
@@ -98,32 +105,76 @@ class AuthUrlResponse(BaseModel):
 # -------------------------------------------------------------------------
 
 
-def _build_redirect_uri(request: Request) -> str:
-    """Build the OAuth callback redirect URI from the current request.
-
-    Google requires redirect URIs to match *exactly* what's registered in GCP,
-    with no query parameters.
+def _build_app_origin(request: Request) -> str:
+    """Return the public origin (``scheme://host``) serving the app.
 
     Behind a reverse proxy (e.g. Databricks Apps), ``request.base_url``
     returns the internal address (``http://localhost:8000``).  We use the
     ``X-Forwarded-Host`` / ``X-Forwarded-Proto`` headers set by the proxy
-    to reconstruct the public URL instead.
-
-    For localhost, Google only allows ``http``.
+    to reconstruct the public URL instead. For localhost, force ``http``.
     """
     forwarded_host = request.headers.get("x-forwarded-host")
     forwarded_proto = request.headers.get("x-forwarded-proto")
 
     if forwarded_host:
         scheme = forwarded_proto or "https"
-        base = f"{scheme}://{forwarded_host.split(',')[0].strip()}"
-    else:
-        base = str(request.base_url).rstrip("/")
-        # Force http for localhost (Google rejects https://localhost)
-        if "://localhost" in base or "://127.0.0.1" in base:
-            base = base.replace("https://", "http://")
+        return f"{scheme}://{forwarded_host.split(',')[0].strip()}"
 
-    return f"{base}/api/export/google-slides/auth/callback"
+    base = str(request.base_url).rstrip("/")
+    if "://localhost" in base or "://127.0.0.1" in base:
+        base = base.replace("https://", "http://")
+    return base
+
+
+def _build_redirect_uri(request: Request) -> str:
+    """Build the OAuth callback redirect URI from the current request.
+
+    Google requires redirect URIs to match *exactly* what's registered in GCP,
+    with no query parameters.
+    """
+    return f"{_build_app_origin(request)}/api/export/google-slides/auth/callback"
+
+
+# Callback page template. The JS object braces are intentionally literal; the
+# %TOKENS% are substituted below so the postMessage targets the explicit app
+# origin (F-CR-3) instead of the wildcard '*'.
+_CALLBACK_TEMPLATE = """
+<html><body>
+    <h2>%TITLE%</h2>
+    <p>%MESSAGE%</p>
+    <script>
+        if (window.opener) {
+            window.opener.postMessage({ type: 'google-slides-auth', success: %SUCCESS% }, %ORIGIN%);
+        }
+        setTimeout(() => window.close(), %DELAY%);
+    </script>
+</body></html>
+"""
+
+
+def _callback_response(app_origin: str, *, success: bool) -> HTMLResponse:
+    """Render the popup callback page and clear the anti-CSRF state cookie.
+
+    ``postMessage`` targets ``app_origin`` explicitly (F-CR-3); ``json.dumps``
+    yields a safely-quoted JS string literal for the origin.
+    """
+    if success:
+        title, message, delay = "Authorization Successful", "You can close this window.", "1500"
+    else:
+        title = "Authorization Failed"
+        message = "Authorization could not be completed. Please close this window and try again."
+        delay = "3000"
+    body = (
+        _CALLBACK_TEMPLATE
+        .replace("%TITLE%", title)
+        .replace("%MESSAGE%", message)
+        .replace("%SUCCESS%", "true" if success else "false")
+        .replace("%ORIGIN%", json.dumps(app_origin))
+        .replace("%DELAY%", delay)
+    )
+    resp = HTMLResponse(content=body, status_code=200)
+    resp.delete_cookie(_OAUTH_STATE_COOKIE, path=_OAUTH_COOKIE_PATH)
+    return resp
 
 
 @router.get("/auth/status", response_model=AuthStatusResponse)
@@ -141,6 +192,7 @@ async def auth_status(db: Session = Depends(get_db)):
 @router.get("/auth/url", response_model=AuthUrlResponse)
 async def auth_url(
     request: Request,
+    response: Response,
     db: Session = Depends(get_db),
 ):
     """Generate the Google OAuth consent URL.
@@ -149,13 +201,26 @@ async def auth_url(
     passed via the OAuth ``state`` parameter so the callback can persist the
     token for the correct user — the redirect URI itself stays clean
     (no query params) to satisfy Google's exact-match requirement.
+
+    F-CR-3: an unguessable nonce is bound into both the ``state`` and a
+    short-lived cookie; the callback requires them to match.
     """
     try:
         auth = _get_auth(db)
         redirect_uri = _build_redirect_uri(request)
-        state = json.dumps({"user": _get_user_identity()})
+        nonce = secrets.token_urlsafe(32)
+        state = json.dumps({"user": _get_user_identity(), "nonce": nonce})
         url = auth.get_auth_url(redirect_uri=redirect_uri, state=state)
 
+        response.set_cookie(
+            key=_OAUTH_STATE_COOKIE,
+            value=nonce,
+            max_age=600,
+            httponly=True,
+            secure=True,
+            samesite="lax",  # sent on Google's top-level redirect back to us
+            path=_OAUTH_COOKIE_PATH,
+        )
         return AuthUrlResponse(url=url)
     except GoogleSlidesAuthError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -184,11 +249,21 @@ async def auth_callback(
     them in the ``google_oauth_tokens`` table.  Returns a small HTML page
     that notifies the opener window and closes itself.
     """
+    app_origin = _build_app_origin(request)
+    cookie_nonce = request.cookies.get(_OAUTH_STATE_COOKIE)
     try:
         state_data = json.loads(state) if state else {}
         user = state_data.get("user")
         if not user:
             raise ValueError("Missing user in OAuth state")
+
+        # F-CR-3: verify the anti-CSRF nonce BEFORE exchanging the code. The
+        # state nonce must match the cookie set when the auth URL was issued.
+        state_nonce = state_data.get("nonce")
+        if not cookie_nonce or not state_nonce or not secrets.compare_digest(
+            str(cookie_nonce), str(state_nonce)
+        ):
+            raise ValueError("OAuth state nonce mismatch")
 
         auth = _get_auth(db)
         redirect_uri = _build_redirect_uri(request)
@@ -202,37 +277,9 @@ async def auth_callback(
         # F-CR-2 (SDR-4437): never reflect the raw exception into the HTML page —
         # it is logged server-side above. Show a static, generic failure message.
         logger.error("OAuth callback failed", exc_info=True)
-        return HTMLResponse(
-            content="""
-            <html><body>
-                <h2>Authorization Failed</h2>
-                <p>Authorization could not be completed. Please close this window and try again.</p>
-                <script>
-                    if (window.opener) {
-                        window.opener.postMessage({ type: 'google-slides-auth', success: false }, '*');
-                    }
-                    setTimeout(() => window.close(), 3000);
-                </script>
-            </body></html>
-            """,
-            status_code=200,
-        )
+        return _callback_response(app_origin, success=False)
 
-    return HTMLResponse(
-        content="""
-        <html><body>
-            <h2>Authorization Successful</h2>
-            <p>You can close this window.</p>
-            <script>
-                if (window.opener) {
-                    window.opener.postMessage({ type: 'google-slides-auth', success: true }, '*');
-                }
-                setTimeout(() => window.close(), 1500);
-            </script>
-        </body></html>
-        """,
-        status_code=200,
-    )
+    return _callback_response(app_origin, success=True)
 
 
 # -------------------------------------------------------------------------

--- a/tests/unit/test_google_slides_routes.py
+++ b/tests/unit/test_google_slides_routes.py
@@ -255,6 +255,78 @@ class TestAuthCallback:
 
 
 # ---------------------------------------------------------------------------
+# OAuth CSRF (F-CR-3): state-nonce binding + explicit postMessage origin
+# ---------------------------------------------------------------------------
+
+class TestOAuthCsrf:
+    def _state_from_url(self, url: str) -> dict:
+        import urllib.parse
+
+        query = urllib.parse.urlparse(url).query
+        raw_state = urllib.parse.parse_qs(query)["state"][0]
+        return json.loads(raw_state)
+
+    def test_auth_url_sets_nonce_cookie_matching_state(self, test_client, session_factory):
+        """auth_url must bind an unguessable nonce into both state and a cookie."""
+        _seed_global_credentials(session_factory)
+        resp = test_client.get("/api/export/google-slides/auth/url")
+        assert resp.status_code == 200
+        state = self._state_from_url(resp.json()["url"])
+        assert len(state.get("nonce", "")) >= 20
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "g_oauth_state=" in set_cookie
+        assert state["nonce"] in set_cookie
+        low = set_cookie.lower()
+        assert "httponly" in low
+        assert "samesite=lax" in low
+        test_client.cookies.clear()
+
+    def test_callback_rejects_nonce_mismatch_without_token_exchange(self, test_client, monkeypatch):
+        """A callback whose state nonce does not match the cookie must be rejected
+        BEFORE any token exchange (login-CSRF defense)."""
+        fake_get_auth = MagicMock()
+        monkeypatch.setattr("src.api.routes.google_slides._get_auth", fake_get_auth)
+        test_client.cookies.clear()
+        state = json.dumps({"user": "local_dev", "nonce": "STATE_NONCE_BBBBBBBBBBBB"})
+        resp = test_client.get(
+            "/api/export/google-slides/auth/callback",
+            params={"code": "x", "state": state},
+            headers={"Cookie": "g_oauth_state=COOKIE_NONCE_AAAAAAAAAAAA"},
+        )
+        assert resp.status_code == 200
+        assert "Authorization Failed" in resp.text
+        assert fake_get_auth.call_count == 0  # token exchange never reached
+
+    def test_callback_accepts_matching_nonce(self, test_client, monkeypatch):
+        """Matching state nonce + cookie proceeds to the token exchange."""
+        fake_auth = MagicMock()
+        monkeypatch.setattr("src.api.routes.google_slides._get_auth", lambda db: fake_auth)
+        test_client.cookies.clear()
+        nonce = "NONCE_MATCH_1234567890AB"
+        state = json.dumps({"user": "local_dev", "nonce": nonce})
+        resp = test_client.get(
+            "/api/export/google-slides/auth/callback",
+            params={"code": "x", "state": state},
+            headers={"Cookie": f"g_oauth_state={nonce}"},
+        )
+        assert resp.status_code == 200
+        assert "Authorization Successful" in resp.text
+        fake_auth.authorize.assert_called_once()
+
+    def test_callback_postmessage_targets_app_origin_not_wildcard(self, test_client):
+        """postMessage must target the explicit app origin, never '*'."""
+        test_client.cookies.clear()
+        resp = test_client.get(
+            "/api/export/google-slides/auth/callback",
+            params={"code": "x", "state": json.dumps({"user": "local_dev", "nonce": "z"})},
+            headers={"x-forwarded-host": "myapp.example.com", "x-forwarded-proto": "https"},
+        )
+        assert "postMessage" in resp.text
+        assert "https://myapp.example.com" in resp.text
+        assert "'*'" not in resp.text
+
+
+# ---------------------------------------------------------------------------
 # Export endpoint
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## SDR-4437 remediation (round 2) — finding **F-CR-3** (MEDIUM)

> **Stacked on #239** (F-CR-2) — both modify the same OAuth callback handler, so this branch is based on `security/sdr4437-reflected-exceptions` to avoid a guaranteed merge conflict. Merge #239 first (GitHub will retarget this to `main`).

### Problem
The Google OAuth flow put only `{"user": ...}` in the `state` parameter (no unguessable value), and the callback popup posted its result with `postMessage(..., '*')`:
- a forged callback / login-CSRF could complete the flow, and
- any origin could read the auth result.

### Fix
- **`auth_url`**: mint `secrets.token_urlsafe(32)`, embed it in `state`, and set it in a short-lived **HttpOnly / Secure / SameSite=Lax** cookie (`g_oauth_state`), path-scoped to the endpoint.
- **`auth_callback`**: require `state.nonce == cookie` (constant-time `compare_digest`) **before** exchanging the authorization code; clear the cookie afterward.
- **postMessage**: now targets the explicit app origin (shared `_build_app_origin` helper) instead of `'*'`, on both the success and failure pages.
- **Frontend** (`useGoogleOAuthPopup`): the popup-message receiver now rejects any `event.origin` that isn't the app's own origin — the receiving-end half of the same concern.

### Tests
- `auth_url` sets the nonce cookie (HttpOnly, SameSite=Lax) matching the `state` nonce.
- callback with a **mismatched** nonce is rejected **without** reaching the token exchange.
- callback with a **matching** nonce proceeds.
- callback `postMessage` targets the app origin, never `'*'`.

Full suite: no new failures (same 20 pre-existing). Frontend `tsc -b` clean (only the pre-existing `recharts` missing-dep error).

This pull request and its description were written by Isaac.