### PR TITLE
chore(release): bump version 0.4.1 -> 0.4.2

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.4.1"
+version = "0.4.2"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.4.1"
+version = "0.4.2"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps both packages `0.4.1` -> `0.4.2` — the release bump for the
design-system library work merged in #243.

Carries just the two version lines:

- `packages/databricks-tellr/pyproject.toml`
- `packages/databricks-tellr-app/pyproject.toml`

Both must share the version — `publish.yml` extracts the version from the
release tag and validates it against **both** `pyproject.toml` files, hard-failing
if either disagrees. The root `pyproject.toml` is untouched (it uses
`setuptools-scm` dynamic versioning and is never published).

After this merges, cut the release by pushing the tag:

    git tag v0.4.2 && git push origin v0.4.2

No tag is created by this PR — tagging is the publish trigger.

This pull request and its description were written by Isaac.
