### PR TITLE
security(SDR-4437 / F-CR-3): make MCP agent tools OBO-only by construction

### DIFF
--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -16,19 +16,22 @@ Accepts three identity sources, evaluated in priority order:
    identity headers. The receiving app (tellr) trusts those headers
    because the same proxy sets them, strips any caller-supplied versions,
    and cannot be bypassed by external traffic. This path has no user
-   token, so downstream Databricks API calls use tellr's own service
-   principal credentials; attribution (``created_by`` on decks, etc.)
-   remains the real user via ``user_name``.
+   token, so the user-client ContextVar is left **unset**: agent tools
+   that resolve their client via ``get_user_client()`` fail closed rather
+   than silently running as tellr's service principal (SDR-4437 / F-CR-3).
+   Code that legitimately needs SP credentials on this path must call
+   ``get_system_client()`` explicitly. Attribution (``created_by`` on
+   decks, etc.) remains the real user via ``user_name``.
 
 The priority-3 path is gated on ``TELLR_TRUST_FORWARDED_IDENTITY=true``
 so the behaviour is explicit at deploy time. Production Databricks Apps
 deployments enable it; local dev does not.
 
 The resolved identity is bound into the same request-scoped ContextVars
-the browser flow uses (``set_current_user``, ``set_user_client``,
-``set_permission_context``), so downstream services (session manager,
-permission service, MLflow, Google OAuth) see the caller's identity
-without any MCP-specific plumbing.
+the browser flow uses (``set_current_user``, ``set_permission_context``,
+and — only when a user token is present — ``set_user_client``), so
+downstream services (session manager, permission service, MLflow, Google
+OAuth) see the caller's identity without any MCP-specific plumbing.
 """
 
 from __future__ import annotations
@@ -43,7 +46,6 @@ from fastapi import Request
 
 from src.core.databricks_client import (
     get_or_create_user_client,
-    get_system_client,
     set_user_client,
 )
 from src.core.permission_context import (
@@ -150,27 +152,23 @@ def extract_mcp_identity(request: Request) -> MCPIdentity:
 def mcp_auth_scope(request: Request) -> Iterator[MCPIdentity]:
     """Authenticate an MCP request and bind identity ContextVars for the block.
 
-    On entry: resolves identity, binds ``current_user``, ``user_client``,
-    and ``permission_context``.
+    On entry: resolves identity and binds ``current_user`` and
+    ``permission_context``. The ``user_client`` ContextVar is bound only when
+    a real user token is present (priority 1/2); on the token-less priority-3
+    app-to-app path it is deliberately left unset.
 
     On exit: clears all three ContextVars, even if the wrapped block raised.
 
-    When the identity was resolved via priority 3 (no user token), the
-    bound ``user_client`` is tellr's service-principal client — downstream
-    services still function, but any SDK calls are made with SP credentials
-    rather than the user's own. Attribution (``created_by``) is unaffected:
-    it uses ``user_name`` from the forwarded identity headers, which the
-    proxy attests.
+    Leaving ``user_client`` unset on priority 3 makes it true by construction
+    that agent tools (which resolve their client via ``get_user_client()``)
+    can never execute as tellr's service principal on the app-to-app path —
+    they fail closed with ``UserClientRequiredError`` in production
+    (SDR-4437 / F-CR-3). Code that legitimately needs SP credentials must call
+    ``get_system_client()`` explicitly. Attribution (``created_by``) is
+    unaffected: it uses ``user_name`` from the forwarded identity headers,
+    which the proxy attests.
     """
     identity = extract_mcp_identity(request)
-
-    if identity.token is not None:
-        user_client = get_or_create_user_client(identity.token)
-    else:
-        # Priority-3 path: no user token, so downstream Databricks API
-        # calls use tellr's service principal. Safe because the app-to-app
-        # model explicitly delegates credentialing to the receiving app.
-        user_client = get_system_client()
 
     permission_ctx = build_permission_context(
         user_id=identity.user_id,
@@ -179,8 +177,21 @@ def mcp_auth_scope(request: Request) -> Iterator[MCPIdentity]:
     )
 
     set_current_user(identity.user_name)
-    set_user_client(user_client)
     set_permission_context(permission_ctx)
+
+    if identity.token is not None:
+        # Priority 1/2: a real user token is present. Bind the OBO client so
+        # downstream services (agent tools included) act as the user.
+        set_user_client(get_or_create_user_client(identity.token))
+    else:
+        # Priority-3 (app-to-app) path: no user token is available. Do NOT
+        # bind any client into the user-client ContextVar. Leaving it unset
+        # makes it true by construction that agent tools — which resolve their
+        # client via get_user_client() — can never run as the app service
+        # principal on this path: they fail closed with UserClientRequiredError
+        # in production (SDR-4437 / F-CR-3). Anything that legitimately needs
+        # the SP here must call get_system_client() explicitly.
+        set_user_client(None)
 
     logger.debug(
         "MCP auth scope entered",

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -226,8 +226,15 @@ def test_scope_clears_context_even_on_exception(fake_user_client):
         assert set_perm.call_args_list[-1].args[0] is None
 
 
-def test_scope_uses_system_client_for_forwarded_identity(monkeypatch):
-    """Priority 3 path binds tellr's SP client (no user token available)."""
+def test_scope_leaves_user_client_unset_for_forwarded_identity(monkeypatch):
+    """Priority 3 (app-to-app, no user token) must NOT bind any client into the
+    user-client ContextVar.
+
+    Leaving it unset is what makes get_user_client() fail closed for agent
+    tools, so a tool can never run as the app service principal on this path
+    (SDR-4437 / F-CR-3). current_user and permission_context ARE still bound on
+    entry (and cleared on exit) so attribution and authz keep working.
+    """
     monkeypatch.setenv("TELLR_TRUST_FORWARDED_IDENTITY", "true")
     req = _FakeRequest(
         headers={
@@ -235,24 +242,58 @@ def test_scope_uses_system_client_for_forwarded_identity(monkeypatch):
             "x-forwarded-user": "12345@99999",
         }
     )
-    sp_client = MagicMock(name="sp_client")
 
-    with patch("src.api.mcp_auth.get_system_client", return_value=sp_client), \
-         patch("src.api.mcp_auth.get_or_create_user_client") as user_client_factory, \
-         patch("src.api.mcp_auth.set_user_client") as set_client:
+    with patch("src.api.mcp_auth.get_or_create_user_client") as user_client_factory, \
+         patch("src.api.mcp_auth.set_current_user") as set_user, \
+         patch("src.api.mcp_auth.set_user_client") as set_client, \
+         patch("src.api.mcp_auth.set_permission_context") as set_perm:
 
         with mcp_auth_scope(req) as identity:
             assert identity.source == "x-forwarded-identity"
             assert identity.token is None
 
-        # User-client factory should never be touched (no token to pass)
-        user_client_factory.assert_not_called()
-        # SP client was bound on entry
-        bound_clients = [
-            call.args[0] for call in set_client.call_args_list
-            if call.args[0] is not None
-        ]
-        assert bound_clients == [sp_client]
+    # No user token -> the OBO client factory is never called.
+    user_client_factory.assert_not_called()
+
+    # The user-client ContextVar is NEVER bound to a real client on this path:
+    # every set_user_client call is with None (the else-branch guard on entry
+    # plus the finally cleanup).
+    assert set_client.call_args_list, "set_user_client should have been called"
+    assert all(
+        call.args[0] is None for call in set_client.call_args_list
+    ), set_client.call_args_list
+
+    # Identity + permission context ARE set on entry and cleared on exit.
+    assert set_user.call_args_list[0].args[0] == "alice@example.com"
+    assert set_user.call_args_list[-1].args[0] is None
+    non_none_perm = [
+        c.args[0] for c in set_perm.call_args_list if c.args[0] is not None
+    ]
+    assert len(non_none_perm) == 1
+    assert set_perm.call_args_list[-1].args[0] is None
+
+
+def test_tool_client_resolution_fails_closed_on_forwarded_identity(monkeypatch):
+    """End-to-end invariant: under the priority-3 scope in production, a tool
+    that resolves its client via get_user_client() fails closed instead of
+    silently receiving the app service principal (SDR-4437 / F-CR-3)."""
+    from src.core.databricks_client import (
+        UserClientRequiredError,
+        get_user_client,
+    )
+
+    monkeypatch.setenv("TELLR_TRUST_FORWARDED_IDENTITY", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    req = _FakeRequest(
+        headers={
+            "x-forwarded-email": "alice@example.com",
+            "x-forwarded-user": "12345@99999",
+        }
+    )
+
+    with mcp_auth_scope(req):
+        with pytest.raises(UserClientRequiredError):
+            get_user_client()
 
 
 def test_mcp_identity_repr_does_not_leak_token():


### PR DESCRIPTION
## Problem

On the token-less priority-3 ("app-to-app") MCP path, `mcp_auth_scope` bound the app service principal (SP) into the user-client ContextVar (`set_user_client(get_system_client())`). Every agent tool resolves its client via `get_user_client()`, which returns whatever is bound — so a tool invoked on that path would have executed as the **SP**, with the SP's (broader) Unity Catalog grants rather than the caller's. The "tools are OBO-only" invariant held only because the MCP agent currently ships with `tools=[]`; registering any tool would silently reactivate the SP path. (SDR-4437 / F-CR-3.)

## Fix

Leave the user-client ContextVar **unset** on priority 3. Agent tools then hit the existing `UserClientRequiredError` fail-closed in production (mapped to 401), so the SP can never be the tool-execution client on the app-to-app path — enforced **by construction**, not by the current absence of tools. `current_user` and `permission_context` are still bound, so attribution (`created_by`) and authz are unchanged. The now-unused `get_system_client` import is dropped.

## Blast radius

- **Browser / OBO path (`main.py`) unchanged** — it only binds a client when a user token is present.
- **MCP deck tools** (`create_deck`/`edit_deck`/`get_deck`/`get_deck_status`) and their services (session_manager, permission_service, enqueue job) don't call `get_user_client()` — unaffected.
- The only non-tool `get_user_client()` caller reachable on this path is **background title generation**; it now fails closed and degrades gracefully (its existing `try/except` logs and continues, deck still created). **Follow-up:** give title-gen an explicit `get_system_client()` fallback so app-to-app decks keep auto-titles. Deferred here to keep the diff isolated — `chat_service.py` has unrelated in-flight changes.

## Tests

- Rewrote `test_scope_uses_system_client_for_forwarded_identity` → `test_scope_leaves_user_client_unset_for_forwarded_identity` (asserts no client is bound on priority 3, while `current_user`/`permission_context` still are).
- Added `test_tool_client_resolution_fails_closed_on_forwarded_identity` — end-to-end invariant: under the priority-3 scope in production, `get_user_client()` raises `UserClientRequiredError`.
- `tests/unit/test_mcp_auth.py` + `tests/unit/test_user_client_fail_closed.py` (25) and `tests/integration/test_mcp_endpoint.py` (6) pass; ruff clean.

This pull request and its description were written by Isaac.
