### PR TITLE
chore(release): set version to 0.4.3, and report it honestly in /api/health

### DIFF
--- a/packages/databricks-tellr-app/pyproject.toml
+++ b/packages/databricks-tellr-app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr-app"
-version = "0.4.4"
+version = "0.4.3"
 description = "Tellr application package for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/databricks-tellr/pyproject.toml
+++ b/packages/databricks-tellr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "databricks-tellr"
-version = "0.4.4"
+version = "0.4.3"
 description = "Tellr deployment tooling for Databricks Apps"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -494,13 +494,17 @@ async def health():
     ``encryption_key_source`` is load-bearing for deployment: ``tellr.update``
     polls it to confirm a relocated app is reading the secret before it deletes
     the Lakebase key row. Reports the source only — never the key.
+
+    ``version`` comes from the installed wheel's metadata, so it tracks the
+    deployed release; it reads "unknown" from a source checkout.
     """
+    from src.api.routes.version import get_installed_version
     from src.core.encryption import key_source
 
     return {
         "status": "healthy",
         "environment": ENVIRONMENT,
-        "version": "0.3.0",
+        "version": get_installed_version(),
         "encryption_key_source": key_source(),
     }
 

--- a/src/api/routes/version.py
+++ b/src/api/routes/version.py
@@ -39,8 +39,12 @@ class VersionCheckResponse(BaseModel):
     package_name: str
 
 
-def _get_installed_version() -> str:
+def get_installed_version() -> str:
     """Get the installed version of databricks-tellr-app.
+
+    Shared with the ``/api/health`` handler in ``src.api.main``, which reports
+    the same value. Returns "unknown" when running from a source checkout
+    rather than an installed wheel.
 
     Returns:
         Version string or "unknown" if not installed
@@ -129,7 +133,7 @@ async def check_version() -> VersionCheckResponse:
     - update_available: Whether an update is available
     - update_type: "patch" (redeploy) or "major" (run tellr.update())
     """
-    installed = _get_installed_version()
+    installed = get_installed_version()
     latest = _get_latest_version_from_pypi()
 
     update_available = False

--- a/tests/unit/test_health_key_source.py
+++ b/tests/unit/test_health_key_source.py
@@ -24,6 +24,15 @@ def test_health_reports_secret_when_injected(client, monkeypatch):
     assert body["encryption_key_source"] == "secret"
 
 
+def test_health_version_comes_from_package_metadata(client, monkeypatch):
+    """Guards against re-hardcoding the version, which had drifted to 0.3.0."""
+    import src.api.routes.version as version_mod
+
+    monkeypatch.setattr(version_mod, "get_installed_version", lambda: "9.9.9")
+    body = client.get("/api/health").json()
+    assert body["version"] == "9.9.9"
+
+
 def test_health_never_exposes_the_key(client, monkeypatch):
     key = Fernet.generate_key().decode()
     monkeypatch.setenv("TELLR_ENCRYPTION_KEY", key)


### PR DESCRIPTION
Two related version-correctness fixes, both needed before the next PyPI publish.

## 1. Release version back to `0.4.3`

Sets both packages to `0.4.3` (from `0.4.4`):

- `packages/databricks-tellr/pyproject.toml`
- `packages/databricks-tellr-app/pyproject.toml`

PyPI's highest published **final** for `databricks-tellr-app` is `0.4.2`, so the next patch release is `0.4.3`. Publishing `0.4.4` would silently skip a version.

The `0.4.4` stamp is leftover from walking back an earlier `0.5.0` bump — the version went `0.4.2` → `0.5.0` (e4305c3c1) → `0.4.4` (92845d7cd), overshooting the correct patch by one.

This also realigns the release with the dev stream: every dev build for this line has been `0.4.3.devN` (currently `0.4.3.dev15`), because `publish-dev.yml` derives its base from the same "highest final + 1" rule. Releasing `0.4.3` means the final lands directly above its own pre-releases, which is what `pip` expects.

## 2. `/api/health` reported a hardcoded `0.3.0`

`src/api/main.py` returned a literal `"version": "0.3.0"` — several releases stale. A live deploy of `0.4.3.dev15` confirmed it:

```json
{"status":"healthy","environment":"production",
 "version":"0.3.0","encryption_key_source":"lakebase"}
```

It now reports the installed wheel's metadata version, reusing the resolver `/api/version` already had — `_get_installed_version` is promoted to a shared public `get_installed_version`, its only two call sites updated.

From a source checkout (no wheel installed) this reads `"unknown"`. That is deliberate: honest beats a stale literal, and nothing consumes the field programmatically — the load-bearing field for `tellr.update` is `encryption_key_source`, which is untouched.

Adds `test_health_version_comes_from_package_metadata`, which monkeypatches the helper and asserts the response follows it, so the value cannot regress to a hardcoded string.

## Risk

Low. No behavioural change to any code path a user hits — version metadata and one reported field. `pip` continues to ignore `.devN` pre-releases by default, so `pip install databricks-tellr-app` resolves to the highest final either way.

## Verification

- `tests/unit/test_health_key_source.py` (4 tests, incl. the new one), `test_local_version.py`, `test_usage_event_capture.py` — 15 passed locally.
- `0.4.3.dev15`, built from `main` at 3ce0abeb3 and containing both #247 and #248, was deployed to a throwaway devloop app on its own Lakebase branch. App reached RUNNING, migrations ran clean on the fork, and `/api/health` returned 200 with `encryption_key_source: lakebase`. That deploy is what surfaced the stale `0.3.0`.

This pull request and its description were written by Isaac.