### PR TITLE
security(SDR-4437 / F-CR-16): remove unauthenticated POST /api/sessions/cleanup endpoint

### DIFF
--- a/docs/technical/api-routes-tests.md
+++ b/docs/technical/api-routes-tests.md
@@ -148,9 +148,9 @@ tests/integration/test_api_routes.py::TestSessionEndpoints
 | `test_get_session_messages_not_found` | GET `/api/sessions/{id}/messages` | Invalid id | 404 |
 | `test_get_session_slides_success` | GET `/api/sessions/{id}/slides` | Get slides | 200 |
 | `test_get_session_slides_not_found` | GET `/api/sessions/{id}/slides` | Invalid id | 404 |
-| `test_cleanup_expired_sessions` | POST `/api/sessions/cleanup` | Cleanup | 200 |
-| `test_export_session_success` | POST `/api/sessions/{id}/export` | Export | 200 |
-| `test_export_session_not_found` | POST `/api/sessions/{id}/export` | Invalid id | 404 |
+
+The `test_cleanup_expired_sessions` and `test_export_session_*` rows were removed
+with their endpoints by SDR-4437 (F-CR-16 and F-CR-10 respectively).
 
 **Limit Validation:** `limit` parameter must be between 1 and 100. Session listing filters by authenticated user via `created_by`.
 

--- a/docs/technical/backend-overview.md
+++ b/docs/technical/backend-overview.md
@@ -56,8 +56,11 @@ Frontend fetch -> FastAPI router ->   │ ChatService            │
 | `DELETE` | `/api/sessions/{id}` | Delete session | `routes/sessions.delete_session` |
 | `GET` | `/api/sessions/{id}/slides` | Get slide deck for session | `routes/sessions.get_session_slides` |
 | `POST` | `/api/sessions/{id}/contribute` | Get or create contributor session for shared deck | `routes/sessions.get_or_create_contributor_session` |
-| `POST` | `/api/sessions/cleanup` | Clean up expired sessions | `routes/sessions.cleanup_expired_sessions` |
-| `POST` | `/api/sessions/{id}/export` | Export full session data to JSON for debugging | `routes/sessions.export_session` |
+
+Two session routes were removed by SDR-4437 and are intentionally absent from the
+table above: `POST /api/sessions/cleanup` (F-CR-16 — unauthenticated cascading
+delete of all users' expired sessions) and `POST /api/sessions/{id}/export`
+(F-CR-10 — dumped full session data to disk). Neither had a caller.
 
 ### Session Messages Endpoints
 

--- a/docs/technical/usage-analytics.md
+++ b/docs/technical/usage-analytics.md
@@ -291,18 +291,30 @@ yet).
 
 ## Operational Notes
 
-### `user_sessions` is durable history — never schedule session cleanup
+### `user_sessions` is durable history — there is no session-cleanup path
 
 Pre-boundary metrics (and parts of retention, heatmap, top-users, and active-user
-counts) depend on `user_sessions` rows surviving forever. The TTL cleanup
-(`SessionManager.cleanup_expired_sessions`) is intentionally reachable **only** via the
-manual `POST /api/sessions/cleanup` endpoint; nothing schedules it.
+counts) depend on `user_sessions` rows surviving forever. **No TTL cleanup exists
+any more:** both `POST /api/sessions/cleanup` and
+`SessionManager.cleanup_expired_sessions` were removed in SDR-4437 (F-CR-16), so
+nothing in the app deletes session history.
 
-> **Warning:** do **not** wire `POST /api/sessions/cleanup` (or
-> `cleanup_expired_sessions`) to any scheduler or cron. Doing so would permanently
-> destroy the session history that the `/admin` usage dashboard's pre-event-log
-> aggregations rely on. The method's docstring in
-> `src/api/services/session_manager.py` carries the same warning.
+Previously the cleanup was reachable only via that manual endpoint, and the
+endpoint had **no authorization check** — any CAN_USE workspace user could call it
+and permanently delete every user's sessions whose `last_activity` was older than
+`session_ttl_hours` (24 by default), cascading to slide decks, chat messages, deck
+versions, chat requests, deck contributors and child contributor sessions. Nothing
+called it: no frontend caller, no scheduler, no script. It was deleted rather than
+gated, because an endpoint with no callers has nothing to gain from a gate.
+
+> **Warning:** do **not** reintroduce a session-cleanup path — endpoint, method,
+> scheduled job or migration — without an explicit authorization gate and a
+> decision about this dashboard. Doing so would permanently destroy the session
+> history that the `/admin` usage dashboard's pre-event-log aggregations rely on.
+> If a retention requirement ever makes a purge necessary, it belongs behind
+> `require_admin` (or outside the HTTP surface entirely) and should record who
+> triggered it — the removed endpoint logged only a row count, so a deletion would
+> have been unattributable in the very history it destroyed.
 
 ### Write-path guarantees
 

--- a/src/api/routes/sessions.py
+++ b/src/api/routes/sessions.py
@@ -743,28 +743,11 @@ async def get_session_slides(session_id: str):
         ) from e
 
 
-@router.post("/cleanup")
-async def cleanup_expired_sessions():
-    """Clean up expired sessions.
-
-    Returns:
-        Number of sessions deleted
-    """
-    try:
-        session_manager = get_session_manager()
-        count = await asyncio.to_thread(session_manager.cleanup_expired_sessions)
-
-        logger.info("Session cleanup completed", extra={"deleted_count": count})
-
-        return {"status": "completed", "deleted_count": count}
-
-    except Exception as e:
-        logger.error(f"Failed to cleanup sessions: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail="Cleanup failed",
-        ) from e
-
+# F-CR-16 (SDR-4437): the POST /cleanup endpoint was removed — it had no
+# authorization check and allowed any authenticated CAN_USE user to delete all
+# sessions older than 24h (cascading to decks, chat history, etc.). The endpoint
+# was unused (no frontend caller, no scheduler, no script), so removal was safer
+# than gating. See SDR-4437 for details.
 
 # F-CR-10 (SDR-4437): the debug-only POST /{session_id}/export endpoint was
 # removed — it was unused by the frontend and dumped full session data (all chat

--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -2073,41 +2073,6 @@ class SessionManager:
 
             return count
 
-    # Cleanup operations
-    def cleanup_expired_sessions(self) -> int:
-        """Delete sessions that have exceeded TTL.
-
-        WARNING: user_sessions is the app's durable usage history. This
-        method is intentionally NOT scheduled anywhere — it is only
-        reachable via the manual POST /api/sessions/cleanup endpoint.
-        Do not wire it to a scheduler; doing so would destroy the
-        history that the /admin usage dashboard's pre-event-log
-        aggregations rely on.
-
-        Returns:
-            Number of sessions deleted
-        """
-        cutoff = datetime.utcnow() - timedelta(hours=self.session_ttl_hours)
-
-        with get_db_session() as db:
-            expired = (
-                db.query(UserSession)
-                .filter(UserSession.last_activity < cutoff)
-                .all()
-            )
-
-            count = len(expired)
-            for session in expired:
-                db.delete(session)
-
-            if count > 0:
-                logger.info(
-                    "Cleaned up expired sessions",
-                    extra={"count": count, "cutoff": cutoff.isoformat()},
-                )
-
-            return count
-
     def _get_session_or_raise(self, db: Session, session_id: str) -> UserSession:
         """Get session by ID or raise error.
 

--- a/tests/integration/test_api_routes.py
+++ b/tests/integration/test_api_routes.py
@@ -959,15 +959,8 @@ class TestSessionEndpoints:
         response = client.get("/api/sessions/nonexistent/slides")
         assert response.status_code == 404
 
-    def test_cleanup_expired_sessions(self, client, mock_session_manager):
-        """POST /api/sessions/cleanup cleans up expired sessions."""
-        mock_session_manager.cleanup_expired_sessions.return_value = 5
-
-        response = client.post("/api/sessions/cleanup")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "completed"
-        assert data["deleted_count"] == 5
+    # (POST /api/sessions/cleanup tests removed — endpoint deleted as unused
+    #  and unauthenticated in SDR-4437 F-CR-16.)
 
     # (POST /api/sessions/{id}/export tests removed — endpoint deleted as unused
     #  dead code in SDR-4437 F-CR-10.)


### PR DESCRIPTION
## Summary

**Finding:** SDR-4437 / F-CR-16 — the `POST /api/sessions/cleanup` endpoint has no authorization check and permits any authenticated CAN_USE user to delete all sessions older than 24 hours.

**Blast radius:** Sessions cascade deletes to UserSessionMessages, SlideDeck, DeckVersion, ChatRequest, DeckContributor, and child UserSessions. With a 24-hour TTL, every authenticated user can permanently destroy every other user's decks and chat history older than 24h with a single request.

**Evidence of non-use:**
- No frontend caller anywhere in `frontend/src`
- No scheduler / cron / APScheduler / Celery wiring
- No script invocation
- No CI reference (checked `.github/workflows/`)
- Only a test exercised it — no production path
- Service method docstring explicitly warns: "intentionally NOT scheduled anywhere"

**Resolution:** Deleted the endpoint outright rather than adding authorization gates. Removal is safer and more maintainable:
- Nothing calls it, so removal has zero downstream impact
- Leaving a destructive, unauthenticated method invites future misuse
- Deletion aligns with defense-in-depth: remove the footgun entirely

**Changes:**
- Removed `@router.post("/cleanup")` handler from `src/api/routes/sessions.py` (was lines 746–766)
- Removed `SessionManager.cleanup_expired_sessions()` method from `src/api/services/session_manager.py` (was lines 2077–2109) — confirmed via repo-wide grep to have zero remaining callers
- Removed `test_cleanup_expired_sessions` from `tests/integration/test_api_routes.py`
- Left brief comments recording each removal in the style of prior F-CR-10 removal

**Test results:** All 79 integration tests in `test_api_routes.py` pass; no other tests reference the removed symbols.

This pull request and its description were written by Isaac.