### PR TITLE
security(SDR-4437): bound the lifetime of anyone:reader Drive image assets

### DIFF
--- a/src/services/html_to_google_slides.py
+++ b/src/services/html_to_google_slides.py
@@ -494,52 +494,55 @@ class HtmlToGoogleSlidesConverter:
             _shutil.rmtree(job_dir, ignore_errors=True)
         by_index = {e["index"]: e for e in emitted}
 
-        # ── Phase 2c: execute per slide on the host (validate, upload, chunked)
-        for i, (code, (html_str, chart_files, content_files, assets_dir)) in enumerate(
-            zip(codes, slide_inputs), 1,
-        ):
-            page_id = page_ids[i - 1]
-            if page_id is None:
-                continue
-            entry = by_index.get(i - 1)
-            requests = entry.get("requests") if entry else None
+        try:
+            # ── Phase 2c: execute per slide on the host (validate, upload, chunked)
+            for i, (code, (html_str, chart_files, content_files, assets_dir)) in enumerate(
+                zip(codes, slide_inputs), 1,
+            ):
+                page_id = page_ids[i - 1]
+                if page_id is None:
+                    continue
+                entry = by_index.get(i - 1)
+                requests = entry.get("requests") if entry else None
 
-            if requests is None:
-                logger.warning("Slide %d: no emitted requests, adding fallback", i)
-                self._add_fallback(slides_service, pres_id, page_id, i)
-            else:
-                err = self._execute_slide_requests(
-                    requests, slides_service, drive_service, pres_id, page_id,
-                    assets_dir, i,
-                )
-                if err is not None:
-                    fixed = await self._retry_with_error(
-                        code, err, html_str, chart_files, content_files,
+                if requests is None:
+                    logger.warning("Slide %d: no emitted requests, adding fallback", i)
+                    self._add_fallback(slides_service, pres_id, page_id, i)
+                else:
+                    err = self._execute_slide_requests(
+                        requests, slides_service, drive_service, pres_id, page_id,
+                        assets_dir, i,
                     )
-                    retry_err = "no-retry-code"
-                    if fixed:
-                        retry_requests = self._emit_single_slide(fixed, html_str, assets_dir, page_id)
-                        if retry_requests is not None:
-                            retry_err = self._execute_slide_requests(
-                                retry_requests, slides_service, drive_service,
-                                pres_id, page_id, assets_dir, i,
-                            )
-                    if retry_err is not None:
-                        logger.warning("Slide %d: all attempts failed, fallback", i)
-                        self._add_fallback(slides_service, pres_id, page_id, i)
+                    if err is not None:
+                        fixed = await self._retry_with_error(
+                            code, err, html_str, chart_files, content_files,
+                        )
+                        retry_err = "no-retry-code"
+                        if fixed:
+                            retry_requests = self._emit_single_slide(fixed, html_str, assets_dir, page_id)
+                            if retry_requests is not None:
+                                retry_err = self._execute_slide_requests(
+                                    retry_requests, slides_service, drive_service,
+                                    pres_id, page_id, assets_dir, i,
+                                )
+                        if retry_err is not None:
+                            logger.warning("Slide %d: all attempts failed, fallback", i)
+                            self._add_fallback(slides_service, pres_id, page_id, i)
 
-            if progress_callback:
-                try:
-                    progress_callback(i, total, f"Building slide {i}/{total}…")
-                except Exception:
-                    pass
-
-        # Best-effort Drive cleanup of uploaded asset files (generated code never did this).
-        for file_id in getattr(self, "_uploaded_file_ids", []):
-            try:
-                drive_service.files().delete(fileId=file_id).execute()
-            except Exception:
-                logger.debug("Asset cleanup failed for %s", file_id, exc_info=True)
+                if progress_callback:
+                    try:
+                        progress_callback(i, total, f"Building slide {i}/{total}…")
+                    except Exception:
+                        pass
+        finally:
+            # SDR-4437: a guaranteed sweep. Per-slide deletion in
+            # _execute_slide_requests handles the normal path; this catches
+            # anything whose delete failed there, and runs even when the
+            # export raises part-way, so a failed export cannot leave an
+            # anyone:reader asset behind.
+            self._delete_drive_assets(
+                drive_service, list(getattr(self, "_uploaded_file_ids", [])),
+            )
 
         print(f"[GSLIDES_CONVERTER] Done: {url}")
         return {"presentation_id": pres_id, "presentation_url": url}
@@ -1187,7 +1190,36 @@ class HtmlToGoogleSlidesConverter:
                     )
         return requests
 
-    def _upload_and_substitute_assets(self, requests, drive_service, assets_dir):
+    def _delete_drive_assets(self, drive_service, file_ids) -> None:
+        """Delete transient Drive image assets and drop them from the pending list.
+
+        SDR-4437: ``createImage`` requires a URL Google's own servers can fetch,
+        and the app's endpoints sit behind the gateway, so each asset is uploaded
+        to the user's Drive as ``anyone:reader`` for the duration of one
+        ``batchUpdate``. Google copies the image into the presentation during
+        that call, so the Drive copy is redundant the moment it returns — and it
+        is world-readable, so it must not outlive the call.
+
+        IDs that fail to delete stay on ``_uploaded_file_ids`` for the
+        end-of-export sweep to retry. Failures log at WARNING, not DEBUG: a
+        leaked asset is publicly readable, and the app runs at INFO, so a DEBUG
+        line would make the one case worth knowing about invisible.
+        """
+        pending = getattr(self, "_uploaded_file_ids", None)
+        for file_id in list(file_ids):
+            try:
+                drive_service.files().delete(fileId=file_id).execute()
+            except Exception:
+                logger.warning(
+                    "Drive asset cleanup failed for %s - it remains anyone:reader",
+                    file_id, exc_info=True,
+                )
+                continue
+            if pending is not None and file_id in pending:
+                pending.remove(file_id)
+
+    def _upload_and_substitute_assets(self, requests, drive_service, assets_dir,
+                                      uploaded_ids=None):
         """Upload each tellr-asset:// referenced file to Drive and substitute
         the real URL. Records uploaded file IDs on self._uploaded_file_ids.
 
@@ -1237,6 +1269,8 @@ class HtmlToGoogleSlidesConverter:
                     label=f"Share {filename}",
                 )
                 self._uploaded_file_ids.append(file_id)
+                if uploaded_ids is not None:
+                    uploaded_ids.append(file_id)
                 cache[filename] = f"https://drive.google.com/uc?id={file_id}"
             req["createImage"]["url"] = cache[filename]
         return requests
@@ -1244,11 +1278,19 @@ class HtmlToGoogleSlidesConverter:
     def _execute_slide_requests(self, requests, slides_service, drive_service,
                                 pres_id, page_id, assets_dir, slide_num):
         """Validate → upload+substitute → execute through _ChunkedSlidesService.
-        Returns None on success, error string on failure."""
+        Returns None on success, error string on failure.
+
+        SDR-4437: assets uploaded for this slide are deleted in the ``finally``,
+        so a publicly readable Drive copy never outlives the single
+        ``batchUpdate`` that consumes it. This runs on the failure path too — the
+        substitution cache is per-call, so a retry uploads its own copies and
+        shares nothing with the attempt that failed.
+        """
+        slide_asset_ids: List[str] = []
         try:
             self._validate_requests(requests)
             requests = self._upload_and_substitute_assets(
-                requests, drive_service, assets_dir,
+                requests, drive_service, assets_dir, slide_asset_ids,
             )
             wrapped = _ChunkedSlidesService(
                 slides_service, chunk_size=4, slide_num=slide_num,
@@ -1260,6 +1302,8 @@ class HtmlToGoogleSlidesConverter:
         except Exception as exc:
             logger.warning("Slide %d host execution failed", slide_num, exc_info=True)
             return str(exc)
+        finally:
+            self._delete_drive_assets(drive_service, slide_asset_ids)
 
     def _build_gslides_job_dir(self, codes, slide_inputs, page_ids) -> str:
         """Write the jail job dir: manifest + per-slide code/html/assets, with

--- a/tests/unit/test_gslides_host_executor.py
+++ b/tests/unit/test_gslides_host_executor.py
@@ -171,3 +171,86 @@ class TestExecuteThroughChunkedService:
         )
         assert err is None
         assert calls["n"] >= 2  # retried after the 429
+
+
+class TestDriveAssetLifetime:
+    """SDR-4437: a Drive image asset is uploaded anyone:reader so Google's
+    servers can fetch it for createImage. It must not outlive the batchUpdate
+    that consumes it, on the success path or the failure path."""
+
+    @staticmethod
+    def _drive(tmp_path, file_id="FILEID"):
+        from unittest.mock import MagicMock
+        (tmp_path / "chart_0.png").write_bytes(b"\x89PNG\r\n")
+        drive = MagicMock()
+        drive.files().create().execute.return_value = {"id": file_id}
+        drive.permissions().create().execute.return_value = {}
+        return drive
+
+    @staticmethod
+    def _reqs():
+        return [{"createImage": {"objectId": "i", "url": "tellr-asset://chart_0.png"}}]
+
+    def test_uploader_reports_ids_for_this_call(self, tmp_path):
+        drive = self._drive(tmp_path)
+        got = []
+        _conv()._upload_and_substitute_assets(
+            self._reqs(), drive, str(tmp_path), got,
+        )
+        assert got == ["FILEID"]
+
+    def test_asset_deleted_after_successful_slide(self, tmp_path):
+        from unittest.mock import MagicMock
+        drive = self._drive(tmp_path)
+        conv = _conv()
+        assert conv._execute_slide_requests(
+            self._reqs(), MagicMock(), drive, "PRES", "PAGE", str(tmp_path), 1,
+        ) is None
+        drive.files().delete.assert_called_with(fileId="FILEID")
+        assert conv._uploaded_file_ids == []
+
+    def test_asset_deleted_when_the_slide_fails(self, tmp_path, monkeypatch):
+        """The failure path is the one that used to orphan assets.
+
+        Patch the chunked service itself rather than mocking a 429 on
+        batchUpdate: the chunker deliberately retries a failed chunk request by
+        request, so a mock failure there is absorbed and the slide still
+        succeeds. Raising from the wrapper is what makes execution genuinely
+        fail after the upload has happened.
+        """
+        from unittest.mock import MagicMock
+
+        import src.services.html_to_google_slides as g
+
+        def _explode(*a, **k):
+            raise Exception("batchUpdate exploded")
+
+        monkeypatch.setattr(g, "_ChunkedSlidesService", _explode)
+        drive = self._drive(tmp_path)
+        conv = _conv()
+        err = conv._execute_slide_requests(
+            self._reqs(), MagicMock(), drive, "PRES", "PAGE", str(tmp_path), 1,
+        )
+        assert err is not None
+        drive.files().delete.assert_called_with(fileId="FILEID")
+        assert conv._uploaded_file_ids == []
+
+    def test_failed_delete_stays_pending_for_the_sweep(self, tmp_path):
+        """A delete that errors must leave the id pending, not silently drop it."""
+        from unittest.mock import MagicMock
+        drive = self._drive(tmp_path)
+        drive.files().delete().execute.side_effect = Exception("503")
+        conv = _conv()
+        conv._execute_slide_requests(
+            self._reqs(), MagicMock(), drive, "PRES", "PAGE", str(tmp_path), 1,
+        )
+        assert conv._uploaded_file_ids == ["FILEID"]
+
+    def test_sweep_retries_pending_ids(self, tmp_path):
+        from unittest.mock import MagicMock
+        drive = MagicMock()
+        conv = _conv()
+        conv._uploaded_file_ids = ["A", "B"]
+        conv._delete_drive_assets(drive, list(conv._uploaded_file_ids))
+        assert conv._uploaded_file_ids == []
+        assert drive.files().delete.call_count == 2


### PR DESCRIPTION
Tightens the Google Slides export path so a publicly readable Drive image asset cannot outlive the single API call that needs it.

## Why the public grant exists at all

Slides' `createImage` accepts a **URL that Google's own servers must fetch** — not image bytes. Tellr's image endpoints sit behind the Databricks Apps gateway, which requires workspace auth, so Google cannot reach them. So each chart/diagram is uploaded to the user's Drive, granted `{"type": "anyone", "role": "reader"}`, handed to Slides as a `drive.google.com/uc?id=…` URL, and deleted afterwards. Google copies the image into the presentation during `batchUpdate`, so the Drive copy is redundant the moment that call returns.

That design is sound. The gap was cleanup reliability.

## The gap

Cleanup existed, but sat **inline on the success path**, immediately before the `return` — not in a `finally`:

```python
        # Best-effort Drive cleanup of uploaded asset files
        for file_id in getattr(self, "_uploaded_file_ids", []):
            ...
        print(f"[GSLIDES_CONVERTER] Done: {url}")
        return {...}
```

Any exception escaping `convert_slide_deck` before it skipped cleanup entirely — a raise in `_add_fallback`, a network error in `_retry_with_error`, asyncio cancellation from a job timeout or worker shutdown, an OOM or container restart. The per-slide handling is defensive (errors become return values, not raises), so this was not the common path, but process death guaranteed it.

The result was world-readable imagery from account-plan / QBR decks left in the user's Drive indefinitely. Two aggravating details: cleanup failures logged at `DEBUG` while the app runs at `INFO`, so the one case worth knowing about was invisible; and `_uploaded_file_ids` was created with `if not hasattr(...)` and never reset, so it accumulated across exports.

## Changes

**1. Per-slide deletion.** `_execute_slide_requests` now deletes the assets it uploaded in a `finally`, so a public copy never outlives the one `batchUpdate` that consumes it. This covers the failure path too — the substitution cache is per-call, so a retry uploads its own copies and shares nothing with the attempt that failed. Window drops from whole-deck to per-slide.

**2. Guaranteed sweep.** Phase 2c is wrapped in `try/finally`, so anything whose per-slide delete failed is retried even when the export raises part-way. Successful deletes are dropped from `_uploaded_file_ids`, which also fixes the never-reset accumulation.

Failures now log at `WARNING` and state explicitly that the asset remains `anyone:reader`.

## What this is not

Not an SDR finding — it isn't F-CR-anything. Found while confirming the Drive sharing posture for the ESI registration, and disclosed in that ticket rather than left to be discovered.

Deliberately **not** a background janitor/TTL reaper, which was the other option on the table. A reaper would need per-user background use of stored refresh tokens with no user present, expanding the credential posture the ESI has to cover, plus multi-worker leader election — to solve a narrower problem than these two changes solve. If a guarantee against process death is ever wanted, the right shape is a durable orphan ledger reaped on that user's *next* export, in-request under their own consent — not offline token use.

The presentation itself is not shared publicly; an earlier `anyone-with-link` **writer** grant on the deck was removed separately in 0.3.8 (`00d35f030`). Only these transient image assets carried a public grant.

## Testing

New `TestDriveAssetLifetime` — 5 cases: uploader reports its ids; asset deleted after a successful slide; **asset deleted when the slide fails** (the path that used to orphan); a failed delete stays pending rather than being silently dropped; the sweep retries pending ids.

One note on the failure-path test: it patches `_ChunkedSlidesService` rather than mocking a `batchUpdate` error, because the chunker deliberately retries a failed chunk request-by-request and absorbs a mock failure — the slide then succeeds and the test proves nothing. My first version of it made exactly that mistake.

`tests/unit`: **3734 passed**, 107 skipped. The two `test_deploy_autoscaling.py::TestGetOrCreateLakebase` failures are pre-existing and local-only — they fail identically on the base commit and passed in CI on #252.

This pull request and its description were written by Isaac.
