### PR TITLE
feat(slide-styles): visual preview for slide styles (generated sample deck)

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -166,6 +166,33 @@ export interface SlideStyleListResponse {
   total: number;
 }
 
+// Slide-style generated preview (a cached, model-generated sample deck).
+export type SlideStylePreviewStatus =
+  | 'ready'
+  | 'stale'
+  | 'queued'
+  | 'generating'
+  | 'failed'
+  | 'missing';
+
+export interface SlideStylePreviewAsset {
+  type: string;
+  token?: string;
+}
+
+export interface SlideStylePreview {
+  style_id: number;
+  status: SlideStylePreviewStatus;
+  fingerprint?: string | null;
+  /** Per-slide sanitized HTML fragments (kept separate for the mini-deck pager). */
+  slides?: string[] | null;
+  css?: string | null;
+  assets?: SlideStylePreviewAsset[] | null;
+  generated_at?: string | null;
+  error_code?: string | null;
+  stale?: boolean;
+}
+
 // Design System Library types (Phase 4).
 // Mirrors the backend schemas in src/api/routes/settings/design_systems.py.
 
@@ -550,6 +577,22 @@ export const configApi = {
   
   getSlideStyle: (styleId: number): Promise<SlideStyle> =>
     fetchJson(`${API_BASE}/slide-styles/${styleId}`),
+
+  // Read-only preview fetch. Never triggers generation directly; the backend
+  // enqueues a deduplicated background job when the cached preview is missing or
+  // stale. Pass an AbortSignal to cancel in-flight polls when the selection
+  // changes.
+  getSlideStylePreview: (
+    styleId: number,
+    signal?: AbortSignal,
+  ): Promise<SlideStylePreview> =>
+    fetchJson(`${API_BASE}/slide-styles/${styleId}/preview`, { signal }),
+
+  // Admin-only explicit regeneration.
+  regenerateSlideStylePreview: (styleId: number): Promise<SlideStylePreview> =>
+    fetchJson(`${API_BASE}/slide-styles/${styleId}/preview/regenerate`, {
+      method: 'POST',
+    }),
   
   createSlideStyle: (data: SlideStyleCreate): Promise<SlideStyle> =>
     fetchJson(`${API_BASE}/slide-styles`, {

--- a/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
+++ b/frontend/src/components/AgentConfigBar/AgentConfigBar.tsx
@@ -22,6 +22,7 @@ import { ToolPicker } from './ToolPicker';
 import GenieDetailPanel from './GenieDetailPanel';
 import ToolDetailPanel from './ToolDetailPanel';
 import type { ToolPreviewData } from './ToolDetailPanel';
+import { SlideStylePreviewThumbnail } from '../config/SlideStylePreviewFrame';
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -804,6 +805,22 @@ export const AgentConfigBar: React.FC = () => {
                   <option key={s.id} value={s.id}>{s.name}</option>
                 ))}
               </select>
+
+              {/* Visual preview of the SETTLED slide-style selection. Shown only
+                  when a slide style is active AND no design system is selected
+                  (they are mutually exclusive; a design system carries its own
+                  template previews). Fetches after the selection commits and
+                  cancels on change (handled inside the thumbnail hook). */}
+              {agentConfig.slide_style_id != null &&
+                agentConfig.design_system_id == null && (
+                  <SlideStylePreviewThumbnail
+                    key={agentConfig.slide_style_id}
+                    styleId={agentConfig.slide_style_id}
+                    name={selectedStyleName ?? 'Slide style'}
+                    enabled
+                    className="mt-2"
+                  />
+                )}
             </div>
 
             {/* Deck prompt selector */}

--- a/frontend/src/components/config/SlideStyleList.tsx
+++ b/frontend/src/components/config/SlideStyleList.tsx
@@ -15,6 +15,7 @@ import { configApi } from '../../api/config';
 import type { SlideStyle, SlideStyleCreate, SlideStyleUpdate } from '../../api/config';
 import { SlideStyleForm } from './SlideStyleForm';
 import { ConfirmDialog } from './ConfirmDialog';
+import { LazySlideStylePreview } from './SlideStylePreviewFrame';
 
 export const SlideStyleList: React.FC = () => {
   const [styles, setStyles] = useState<SlideStyle[]>([]);
@@ -25,6 +26,9 @@ export const SlideStyleList: React.FC = () => {
   const [editingStyle, setEditingStyle] = useState<SlideStyle | null>(null);
   const [actionLoading, setActionLoading] = useState<number | null>(null);
   const [expandedStyleId, setExpandedStyleId] = useState<number | null>(null);
+  // Raw style-text visibility is independent of the visual preview so a user can
+  // read the prose guidance whether or not the generated preview succeeded.
+  const [showRawStyleId, setShowRawStyleId] = useState<number | null>(null);
   const [userDefaultStyleId, setUserDefaultStyleId] = useState<number | null>(() => {
     const stored = localStorage.getItem('userDefaultSlideStyleId');
     return stored ? Number(stored) : null;
@@ -274,15 +278,35 @@ export const SlideStyleList: React.FC = () => {
                     </div>
                   </div>
 
-                  {/* Expanded Content */}
+                  {/* Expanded Content: rendered visual preview + optional raw text */}
                   {expandedStyleId === style.id && (
                     <div className="mt-3 rounded-md border border-border bg-muted/30 p-3">
-                      <label className="text-xs font-medium uppercase text-muted-foreground">
-                        Style Content
-                      </label>
-                      <pre className="mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap rounded-md border border-border bg-background p-3 font-mono text-xs text-foreground">
-                        {style.style_content}
-                      </pre>
+                      <div className="flex items-center justify-between">
+                        <label className="text-xs font-medium uppercase text-muted-foreground">
+                          Style Preview
+                        </label>
+                        <button
+                          type="button"
+                          className="rounded px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                          onClick={() =>
+                            setShowRawStyleId(showRawStyleId === style.id ? null : style.id)
+                          }
+                          data-testid="slide-style-raw-toggle"
+                        >
+                          {showRawStyleId === style.id ? 'Hide style text' : 'Show style text'}
+                        </button>
+                      </div>
+                      <LazySlideStylePreview
+                        styleId={style.id}
+                        name={style.name}
+                        canRegenerate={!style.is_system}
+                        className="mt-2 max-w-md"
+                      />
+                      {showRawStyleId === style.id && (
+                        <pre className="mt-3 max-h-64 overflow-y-auto whitespace-pre-wrap rounded-md border border-border bg-background p-3 font-mono text-xs text-foreground">
+                          {style.style_content}
+                        </pre>
+                      )}
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/config/SlideStylePreviewFrame.tsx
+++ b/frontend/src/components/config/SlideStylePreviewFrame.tsx
@@ -1,0 +1,460 @@
+/**
+ * Visual preview for a slide style.
+ *
+ * A slide style is prose the model interprets, not deterministic CSS, so the
+ * only faithful "what will my slides look like" preview is a model-generated
+ * sample deck. The backend generates/caches that deck in a background job; this
+ * component READS it (never triggers generation directly) and renders it.
+ *
+ * SECURITY: the sample HTML/CSS is MODEL OUTPUT and is treated as hostile. It is
+ * rendered exactly like uploaded template previews — a fully-sandboxed iframe
+ * (`sandbox=""`: no scripts, no same-origin) whose srcDoc carries the strict,
+ * network-blocked slide CSP (see slideDocument.ts). Scripts were already
+ * stripped server-side; the empty sandbox is the real guarantee they never run.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { AlertTriangle, ChevronLeft, ChevronRight, Eye, Loader2, RefreshCw, X } from 'lucide-react';
+import { configApi } from '../../api/config';
+import type { SlideStylePreview, SlideStylePreviewStatus } from '../../api/config';
+import {
+  buildSlideDocument,
+  SLIDE_FRAME_H,
+  SLIDE_FRAME_W,
+  SLIDE_PREVIEW_RESET_STYLE,
+} from '../../services/slideDocument';
+import { LazyMount } from './TemplateThumbnail';
+
+// ---------------------------------------------------------------------------
+// Query cache + polling hook
+// ---------------------------------------------------------------------------
+// Cache the latest response per style so re-selecting a style shows its preview
+// instantly instead of re-fetching. Keyed by styleId; the value carries the
+// fingerprint so a stale entry is visibly marked while a refresh runs.
+const previewCache = new Map<number, SlideStylePreview>();
+
+const POLL_START_MS = 1000;
+// Cap the backoff low so a finished generation surfaces promptly (a completed
+// deck is otherwise invisible until the next poll fires).
+const POLL_MAX_MS = 3000;
+// Statuses that mean "a fresh result may still arrive" — keep polling.
+const POLLING_STATUSES: SlideStylePreviewStatus[] = ['queued', 'generating', 'stale'];
+
+interface UseSlideStylePreviewResult {
+  preview: SlideStylePreview | null;
+  loading: boolean;
+  error: string | null;
+  regenerate: () => void;
+}
+
+/**
+ * Fetch (and, while in flight, poll) the cached preview for a style.
+ *
+ * - Never fetches when `enabled` is false or `styleId` is null.
+ * - Cancels the in-flight request and stops polling when the style changes or
+ *   the component unmounts (AbortController) — so rapid selection changes in the
+ *   picker never fan out or race.
+ * - Backs off polling while the preview is queued/generating/stale.
+ */
+export function useSlideStylePreview(
+  styleId: number | null,
+  enabled: boolean,
+): UseSlideStylePreviewResult {
+  const [preview, setPreview] = useState<SlideStylePreview | null>(
+    styleId != null ? previewCache.get(styleId) ?? null : null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped by regenerate() to force a fresh poll cycle.
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    if (styleId == null || !enabled) {
+      return;
+    }
+    // Show the cached copy immediately (may be stale; polling will refresh it).
+    setPreview(previewCache.get(styleId) ?? null);
+    setError(null);
+
+    let cancelled = false;
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let delay = POLL_START_MS;
+
+    const poll = async () => {
+      setLoading(true);
+      try {
+        const res = await configApi.getSlideStylePreview(styleId, controller.signal);
+        if (cancelled) return;
+        previewCache.set(styleId, res);
+        setPreview(res);
+        setError(null);
+        if (POLLING_STATUSES.includes(res.status)) {
+          delay = Math.min(delay * 1.5, POLL_MAX_MS);
+          timer = setTimeout(poll, delay);
+        }
+      } catch (e) {
+        if (cancelled || controller.signal.aborted) return;
+        // A fetch error must never break the picker; surface it non-blockingly.
+        setError(e instanceof Error ? e.message : 'Failed to load preview');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    poll();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer) clearTimeout(timer);
+    };
+  }, [styleId, enabled, nonce]);
+
+  const regenerate = useCallback(() => {
+    if (styleId == null) return;
+    // Fire-and-forget the admin regenerate, then restart polling.
+    configApi
+      .regenerateSlideStylePreview(styleId)
+      .catch(() => {
+        /* surfaced via the next poll's status; ignore here */
+      })
+      .finally(() => setNonce((n) => n + 1));
+  }, [styleId]);
+
+  return { preview, loading, error, regenerate };
+}
+
+// ---------------------------------------------------------------------------
+// Single scaled slide frame (sandboxed)
+// ---------------------------------------------------------------------------
+/** Render one preview slide into a scaled, clipped, fully-sandboxed iframe. */
+const SlideFrame: React.FC<{
+  slideHtml: string;
+  css: string;
+  name: string;
+  /** Set on the modal (content the user reads) to expose it to assistive tech. */
+  exposeToA11y?: boolean;
+  testId?: string;
+}> = ({ slideHtml, css, name, exposeToA11y, testId }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(0);
+
+  const doc = React.useMemo(
+    () =>
+      buildSlideDocument(slideHtml, {
+        css,
+        extraHeadStyle: SLIDE_PREVIEW_RESET_STYLE,
+      }),
+    [slideHtml, css],
+  );
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      // A zero measurement is transient (pre-layout / display:none ancestor);
+      // keep the last good scale rather than tearing the iframe down.
+      if (!el.offsetWidth) return;
+      setScale(el.offsetWidth / SLIDE_FRAME_W);
+    };
+    update();
+    const observer =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(update) : null;
+    observer?.observe(el);
+    window.addEventListener('resize', update);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 overflow-hidden">
+      {scale === 0 ? null : (
+        <iframe
+          srcDoc={doc}
+          title={`${name} style preview`}
+          sandbox=""
+          scrolling="no"
+          tabIndex={-1}
+          aria-hidden={exposeToA11y ? undefined : true}
+          data-testid={testId}
+          className="border-0"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: `${SLIDE_FRAME_W}px`,
+            height: `${SLIDE_FRAME_H}px`,
+            transform: `scale(${scale})`,
+            transformOrigin: 'top left',
+            pointerEvents: 'none',
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Status overlay helpers
+// ---------------------------------------------------------------------------
+const StatusOverlay: React.FC<{ children: React.ReactNode; tone?: 'info' | 'error' }> = ({
+  children,
+  tone = 'info',
+}) => (
+  <div
+    className={`absolute inset-0 flex flex-col items-center justify-center gap-1 p-2 text-center text-xs ${
+      tone === 'error' ? 'text-destructive' : 'text-muted-foreground'
+    } bg-background/70`}
+  >
+    {children}
+  </div>
+);
+
+function hasRenderableSlides(preview: SlideStylePreview | null): boolean {
+  return !!preview && Array.isArray(preview.slides) && preview.slides.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Mini-deck modal
+// ---------------------------------------------------------------------------
+const SlideStylePreviewModal: React.FC<{
+  name: string;
+  preview: SlideStylePreview;
+  onClose: () => void;
+}> = ({ name, preview, onClose }) => {
+  const slides = preview.slides ?? [];
+  const pageCount = Math.max(1, slides.length);
+  const [index, setIndex] = useState(0);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  const goPrev = useCallback(
+    () => setIndex((i) => (i - 1 + pageCount) % pageCount),
+    [pageCount],
+  );
+  const goNext = useCallback(() => setIndex((i) => (i + 1) % pageCount), [pageCount]);
+
+  useEffect(() => {
+    // Focus the close button on open (focus trap entry) and restore on unmount.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    closeRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+      else if (event.key === 'ArrowLeft') goPrev();
+      else if (event.key === 'ArrowRight') goNext();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [onClose, goPrev, goNext]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${name} style preview`}
+      data-testid="slide-style-preview-modal"
+    >
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} data-testid="slide-style-preview-backdrop" />
+      <div className="relative flex max-h-full w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-border bg-background shadow-xl">
+        <div className="flex items-start justify-between gap-4 border-b border-border px-4 py-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-medium text-foreground">{name}</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Sample deck generated from this style{preview.stale ? ' (refreshing…)' : ''}
+            </p>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close style preview"
+            data-testid="slide-style-preview-close"
+            className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="relative aspect-video w-full overflow-hidden bg-muted/30">
+          <SlideFrame
+            slideHtml={slides[index] ?? ''}
+            css={preview.css ?? ''}
+            name={name}
+            exposeToA11y
+            testId="slide-style-preview-modal-frame"
+          />
+        </div>
+
+        {pageCount > 1 && (
+          <div className="flex items-center justify-center gap-3 border-t border-border px-4 py-2">
+            <button
+              type="button"
+              onClick={goPrev}
+              aria-label="Previous slide"
+              data-testid="slide-style-preview-prev"
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+            <span className="text-xs text-muted-foreground" data-testid="slide-style-preview-counter">
+              Slide {index + 1} of {pageCount}
+            </span>
+            <button
+              type="button"
+              onClick={goNext}
+              aria-label="Next slide"
+              data-testid="slide-style-preview-next"
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ChevronRight className="size-4" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Public: preview thumbnail + opener
+// ---------------------------------------------------------------------------
+/**
+ * Hero-slide thumbnail for a slide style, with an accessible opener to the
+ * mini-deck modal. Renders EVERY status state non-blockingly: a fetch error or
+ * an in-flight generation never blocks selecting or generating with the style.
+ */
+export const SlideStylePreviewThumbnail: React.FC<{
+  styleId: number;
+  name: string;
+  /** Gate fetching (e.g. only for the settled selection / on-screen cards). */
+  enabled?: boolean;
+  className?: string;
+  /** Show a regenerate control (admins). */
+  canRegenerate?: boolean;
+}> = ({ styleId, name, enabled = true, className, canRegenerate }) => {
+  const { preview, loading, error, regenerate } = useSlideStylePreview(styleId, enabled);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const status = preview?.status ?? (loading ? 'queued' : 'missing');
+  const renderable = hasRenderableSlides(preview);
+  const hero = renderable && preview ? preview.slides![0] : null;
+
+  const overlay = (() => {
+    if (renderable && preview) {
+      // A usable copy exists. Only overlay a small "refreshing" hint if stale.
+      if (preview.stale || status === 'generating' || status === 'queued') {
+        return (
+          <div className="absolute right-1 top-1 flex items-center gap-1 rounded bg-background/80 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            <Loader2 className="size-3 animate-spin" /> updating
+          </div>
+        );
+      }
+      return null;
+    }
+    if (error) {
+      return (
+        <StatusOverlay tone="error">
+          <AlertTriangle className="size-4" />
+          <span>Preview unavailable</span>
+        </StatusOverlay>
+      );
+    }
+    if (status === 'failed') {
+      return (
+        <StatusOverlay tone="error">
+          <AlertTriangle className="size-4" />
+          <span>Preview failed{preview?.error_code ? ` (${preview.error_code})` : ''}</span>
+        </StatusOverlay>
+      );
+    }
+    if (status === 'queued' || status === 'generating') {
+      return (
+        <StatusOverlay>
+          <Loader2 className="size-4 animate-spin" />
+          <span>Generating preview…</span>
+        </StatusOverlay>
+      );
+    }
+    return (
+      <StatusOverlay>
+        <Eye className="size-4" />
+        <span>Preview will generate on selection</span>
+      </StatusOverlay>
+    );
+  })();
+
+  return (
+    <div className={className} data-testid="slide-style-preview" data-preview-status={status}>
+      <div className="relative aspect-video w-full overflow-hidden rounded-md border border-border bg-muted/30">
+        {hero != null && (
+          <SlideFrame slideHtml={hero} css={preview?.css ?? ''} name={name} />
+        )}
+        {overlay}
+        {/* A real button opener — keyboard reachable, labeled. Only clickable
+            when there is a renderable deck to open. */}
+        {renderable && (
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            aria-label={`Preview slide style: ${name}`}
+            data-testid="slide-style-preview-open"
+            className="absolute inset-0 cursor-zoom-in bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        )}
+      </div>
+
+      {(canRegenerate || error || status === 'failed') && (
+        <div className="mt-1 flex items-center justify-end">
+          {canRegenerate && (
+            <button
+              type="button"
+              onClick={regenerate}
+              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              data-testid="slide-style-preview-regenerate"
+            >
+              <RefreshCw className="size-3" /> Regenerate
+            </button>
+          )}
+        </div>
+      )}
+
+      {modalOpen && renderable && preview && (
+        <SlideStylePreviewModal
+          name={name}
+          preview={preview}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+/**
+ * List/card wrapper: lazily mounts the thumbnail so a library of many styles
+ * does not fan out a preview fetch for every card at initial render.
+ */
+export const LazySlideStylePreview: React.FC<{
+  styleId: number;
+  name: string;
+  canRegenerate?: boolean;
+  className?: string;
+}> = ({ styleId, name, canRegenerate, className }) => (
+  <LazyMount className={className} rootMargin="0px">
+    <SlideStylePreviewThumbnail
+      styleId={styleId}
+      name={name}
+      enabled
+      canRegenerate={canRegenerate}
+    />
+  </LazyMount>
+);

--- a/frontend/tests/e2e/slide-style-preview.spec.ts
+++ b/frontend/tests/e2e/slide-style-preview.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, Page } from '@playwright/test';
+import {
+  mockProfileSummaries,
+  mockDeckPrompts,
+  mockSlideStyles,
+  mockSessions,
+} from '../fixtures/mocks';
+
+/**
+ * Slide Style Visual Preview UI tests (mocked).
+ *
+ * Covers the properties the design depends on:
+ * - no per-card preview fan-out at initial render (lazy + settled),
+ * - every status state renders non-blockingly (ready/generating/failed),
+ * - the raw style-text toggle is independent of preview success,
+ * - the mini-deck modal opens from an accessible control and closes on Escape.
+ */
+
+type PreviewBody = Record<string, unknown>;
+
+const READY_PREVIEW: PreviewBody = {
+  status: 'ready',
+  fingerprint: 'fp-1',
+  slides: ["<div class='slide'>Cover</div>", "<div class='slide'>Content</div>"],
+  css: '.slide{color:navy}',
+  assets: [],
+  generated_at: '2026-01-01T00:00:00Z',
+  stale: false,
+};
+
+/** Base app mocks + a configurable /preview handler that records call count. */
+async function setupMocks(page: Page, previewBody: () => PreviewBody) {
+  const state = { previewCalls: 0 };
+
+  await page.route('**/api/setup/status', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ configured: true }) }),
+  );
+  await page.route(/\/api\/settings\/slide-styles$/, (r, req) => {
+    if (req.method() === 'GET') {
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockSlideStyles) });
+    } else {
+      r.continue();
+    }
+  });
+  // The preview endpoint — counts calls so we can assert no fan-out.
+  await page.route(/\/api\/settings\/slide-styles\/(\d+)\/preview$/, (r, req) => {
+    const id = parseInt(req.url().match(/slide-styles\/(\d+)\/preview/)?.[1] || '1');
+    state.previewCalls += 1;
+    r.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ style_id: id, ...previewBody() }),
+    });
+  });
+  await page.route(/\/api\/settings\/slide-styles\/\d+$/, (r, req) => {
+    if (req.method() === 'GET') {
+      const id = parseInt(req.url().split('/').pop() || '1');
+      const style = mockSlideStyles.styles.find((s) => s.id === id) || mockSlideStyles.styles[0];
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(style) });
+    } else {
+      r.continue();
+    }
+  });
+  await page.route(/\/api\/profiles$/, (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockProfileSummaries) }),
+  );
+  await page.route('**/api/tools/available', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ tools: [] }) }),
+  );
+  await page.route('**/api/settings/deck-prompts', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockDeckPrompts) }),
+  );
+  await page.route('**/api/sessions**', (r, req) => {
+    if (req.method() === 'POST' || req.method() === 'DELETE') {
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ session_id: 'mock', title: 'New', user_id: null, created_at: '2026-01-01T00:00:00Z' }) });
+      return;
+    }
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockSessions) });
+  });
+  await page.route('**/api/genie/spaces', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ spaces: [], total: 0 }) }),
+  );
+  await page.route('**/api/version**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ version: '0.1.21', latest: '0.1.21' }) }),
+  );
+
+  return state;
+}
+
+async function goToSlideStyles(page: Page) {
+  await page.goto('/slide-styles');
+  await expect(page.getByRole('heading', { name: 'Slide Style Library' })).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Slide style preview', () => {
+  test('does not fetch previews for every card at initial render', async ({ page }) => {
+    const state = await setupMocks(page, () => READY_PREVIEW);
+    await goToSlideStyles(page);
+    // Give any errant fan-out a chance to fire.
+    await page.waitForTimeout(500);
+    expect(state.previewCalls).toBe(0);
+
+    // Expanding one card fetches only THAT card's preview — never one per card.
+    // (There are 3 styles; a fan-out bug would fire >=3. React StrictMode may
+    // double-invoke the effect in dev, so allow up to 2 for the single card.)
+    await page.getByRole('button', { name: 'Preview' }).first().click();
+    await expect(page.getByTestId('slide-style-preview').first()).toBeVisible();
+    expect(state.previewCalls).toBeGreaterThan(0);
+    expect(state.previewCalls).toBeLessThan(mockSlideStyles.styles.length);
+  });
+
+  test('ready preview renders a sandboxed frame and opens a modal', async ({ page }) => {
+    await setupMocks(page, () => READY_PREVIEW);
+    await goToSlideStyles(page);
+    await page.getByRole('button', { name: 'Preview' }).first().click();
+
+    const preview = page.getByTestId('slide-style-preview').first();
+    await expect(preview).toBeVisible();
+    await expect(preview).toHaveAttribute('data-preview-status', 'ready');
+
+    // Accessible opener → modal → Escape closes, focus-managed.
+    await preview.getByTestId('slide-style-preview-open').click();
+    await expect(page.getByTestId('slide-style-preview-modal')).toBeVisible();
+    await expect(page.getByTestId('slide-style-preview-counter')).toHaveText(/Slide 1 of 2/);
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('slide-style-preview-modal')).not.toBeVisible();
+  });
+
+  test('generating state shows a non-blocking spinner', async ({ page }) => {
+    await setupMocks(page, () => ({ status: 'generating' }));
+    await goToSlideStyles(page);
+    await page.getByRole('button', { name: 'Preview' }).first().click();
+
+    const preview = page.getByTestId('slide-style-preview').first();
+    await expect(preview).toHaveAttribute('data-preview-status', 'generating');
+    await expect(page.getByText('Generating preview…')).toBeVisible();
+    // Raw text is still reachable even without a rendered preview.
+    await page.getByTestId('slide-style-raw-toggle').first().click();
+    await expect(page.locator('pre').first()).toBeVisible();
+  });
+
+  test('failed state shows an error without breaking the page', async ({ page }) => {
+    await setupMocks(page, () => ({ status: 'failed', error_code: 'too_large' }));
+    await goToSlideStyles(page);
+    await page.getByRole('button', { name: 'Preview' }).first().click();
+
+    const preview = page.getByTestId('slide-style-preview').first();
+    await expect(preview).toHaveAttribute('data-preview-status', 'failed');
+    await expect(page.getByText(/Preview failed/)).toBeVisible();
+    // The list still works: other actions remain usable.
+    await expect(page.getByRole('button', { name: 'New Style' })).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/slide-styles-integration.spec.ts
+++ b/frontend/tests/e2e/slide-styles-integration.spec.ts
@@ -703,11 +703,13 @@ test.describe('Slide Style Edge Cases', () => {
       // Find the style card (use .first() to avoid matching nested divs)
       const styleCard = page.locator('div.border.rounded-lg').filter({ hasText: styleName }).first();
 
-      // Click Preview
+      // Click Preview to expand
       await styleCard.getByRole('button', { name: 'Preview' }).first().click();
 
-      // Should show content
-      await expect(page.getByText('Style Content').first()).toBeVisible();
+      // Expanded panel shows the visual preview by default; raw style text is
+      // behind a toggle (the panel no longer dumps the CSS inline).
+      await expect(page.getByText('Style Preview').first()).toBeVisible();
+      await styleCard.getByTestId('slide-style-raw-toggle').first().click();
       await expect(page.locator('pre').filter({ hasText: 'E2E test CSS' })).toBeVisible();
 
       // Button should now say Hide

--- a/frontend/tests/e2e/slide-styles-ui.spec.ts
+++ b/frontend/tests/e2e/slide-styles-ui.spec.ts
@@ -61,6 +61,28 @@ async function setupMocks(page: Page) {
     }
   });
 
+  // Mock the read-only preview endpoint (any style id) → a ready 2-slide deck.
+  await page.route(/\/api\/settings\/slide-styles\/\d+\/preview$/, (route, request) => {
+    const id = parseInt(request.url().split('/').slice(-2)[0] || '1');
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        style_id: id,
+        status: 'ready',
+        fingerprint: 'fp-mock',
+        slides: [
+          "<div class='slide'>Cover</div>",
+          "<div class='slide'>Content</div>",
+        ],
+        css: '.slide{color:navy}',
+        assets: [],
+        generated_at: new Date().toISOString(),
+        stale: false,
+      }),
+    });
+  });
+
   // Mock individual slide style endpoints
   await page.route(/http:\/\/127.0.0.1:8000\/api\/settings\/slide-styles\/\d+$/, (route, request) => {
     if (request.method() === 'DELETE') {
@@ -227,15 +249,20 @@ test.describe('SlideStyleList', () => {
     await expect(page.getByRole('button', { name: 'Hide' }).first()).toBeVisible();
   });
 
-  test('expanded view shows style content', async ({ page }) => {
+  test('expanded view shows visual preview and toggles raw style content', async ({ page }) => {
     await goToSlideStyles(page);
 
     // Click Preview on System Default
     const systemCard = page.locator('div.border.rounded-lg').filter({ hasText: 'System Default' }).filter({ hasText: 'Protected system style' });
     await systemCard.getByRole('button', { name: 'Preview' }).click();
 
-    // Should show Style Content label and content
-    await expect(page.getByText('Style Content')).toBeVisible();
+    // The expanded panel now leads with a rendered visual preview.
+    await expect(page.getByText('Style Preview')).toBeVisible();
+    await expect(systemCard.getByTestId('slide-style-preview')).toBeVisible();
+
+    // Raw style text is behind an independent toggle.
+    await expect(page.locator('pre').filter({ hasText: '/* System default CSS */' })).not.toBeVisible();
+    await systemCard.getByTestId('slide-style-raw-toggle').click();
     await expect(page.locator('pre').filter({ hasText: '/* System default CSS */' })).toBeVisible();
   });
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -33,6 +33,7 @@ from src.api.routes.settings import (
 )
 from src.api.services.export_job_queue import start_export_worker
 from src.api.services.job_queue import recover_stuck_requests, start_worker
+from src.api.services.slide_style_preview_queue import start_preview_worker
 from src.core.database import (
     is_lakebase_environment,
     start_token_refresh,
@@ -49,6 +50,7 @@ IS_TESTING = ENVIRONMENT == "test"
 # Worker task references for cleanup
 _worker_task = None
 _export_worker_task = None
+_preview_worker_task = None
 _cleanup_task = None
 _timeout_task = None
 _frontend_assets_stack: ExitStack | None = None
@@ -57,7 +59,7 @@ _frontend_assets_stack: ExitStack | None = None
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup/shutdown events."""
-    global _worker_task, _export_worker_task, _cleanup_task, _timeout_task, _frontend_assets_stack
+    global _worker_task, _export_worker_task, _preview_worker_task, _cleanup_task, _timeout_task, _frontend_assets_stack
 
     # Startup
     logger.info(f"Starting AI Slide Generator API (environment: {ENVIRONMENT})")
@@ -124,6 +126,20 @@ async def lifespan(app: FastAPI):
         _export_worker_task = await start_export_worker()
         logger.info("Export job queue worker started")
 
+        # Start the slide-style preview generation worker
+        _preview_worker_task = await start_preview_worker()
+        logger.info("Slide-style preview worker started")
+
+        # Pre-warm previews for active styles so viewers hit a warm cache instead
+        # of a cold LLM generation. Bounded + deduplicated; runs off the event loop.
+        try:
+            from src.api.services.slide_style_preview_queue import warm_missing_previews
+
+            warmed = await asyncio.to_thread(warm_missing_previews)
+            logger.info("Slide-style preview warm backfill enqueued", extra={"enqueued": warmed})
+        except Exception:  # noqa: BLE001 — warming must never block startup
+            logger.warning("Slide-style preview warm backfill failed", exc_info=True)
+
         # Start the MCP job timeout sweeper
         from src.api.services.job_queue import mark_timed_out_jobs_loop
         _timeout_task = asyncio.create_task(mark_timed_out_jobs_loop())
@@ -168,6 +184,14 @@ async def lifespan(app: FastAPI):
         except asyncio.CancelledError:
             pass
         logger.info("Export job queue worker stopped")
+
+    if _preview_worker_task:
+        _preview_worker_task.cancel()
+        try:
+            await _preview_worker_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("Slide-style preview worker stopped")
 
     if _cleanup_task:
         _cleanup_task.cancel()

--- a/src/api/routes/settings/slide_styles.py
+++ b/src/api/routes/settings/slide_styles.py
@@ -16,8 +16,13 @@ from sqlalchemy.orm import Session
 from src.api.routes._authz import require_admin
 from src.core.database import get_db, get_db_session
 from src.database.models import SlideStyleLibrary
+from src.services import slide_style_preview_fixture as preview_fixture
+from src.services import slide_style_preview_storage as preview_storage
 
 logger = logging.getLogger(__name__)
+
+# Fields whose change invalidates a generated preview (see cache-invalidation).
+_PREVIEW_AFFECTING_FIELDS = ("style_content", "image_guidelines")
 
 router = APIRouter(prefix="/slide-styles", tags=["slide-styles"])
 
@@ -66,6 +71,26 @@ class SlideStyleListResponse(BaseModel):
     """Response for listing slide styles."""
     styles: List[SlideStyleResponse]
     total: int
+
+
+class SlideStylePreviewResponse(BaseModel):
+    """Read-only preview state for a slide style.
+
+    ``status`` drives the client: ``ready`` (current), ``stale`` (a usable but
+    out-of-date copy while regeneration runs), ``queued``/``generating`` (in
+    flight), ``failed`` (with optional last-known-good copy), ``missing`` (never
+    generated). HTTP is always 200; the client polls on ``status`` rather than
+    on status codes.
+    """
+    style_id: int
+    status: str
+    fingerprint: Optional[str] = None
+    slides: Optional[List[str]] = None
+    css: Optional[str] = None
+    assets: Optional[List[dict]] = None
+    generated_at: Optional[str] = None
+    error_code: Optional[str] = None
+    stale: bool = False
 
 
 # API endpoints
@@ -238,6 +263,15 @@ def create_slide_style(
         db.refresh(style)
         
         logger.info(f"Created slide style: {style.name} (id={style.id})")
+
+        # Warm the visual preview immediately so the first viewer gets a cache
+        # hit instead of waiting on a cold generation. Deduplicated + best-effort.
+        try:
+            from src.api.services.slide_style_preview_queue import try_enqueue
+
+            try_enqueue(style.id)
+        except Exception:  # noqa: BLE001 — warming must never fail the create
+            logger.warning("Preview warm-on-create failed", exc_info=True)
         
         return SlideStyleResponse(
             id=style.id,
@@ -321,10 +355,37 @@ def update_slide_style(
             style.description = request.description
         if request.category is not None:
             style.category = request.category
+
+        # Detect preview-affecting changes BEFORE mutating, so we can invalidate
+        # the cached preview in the SAME transaction as the edit (cache-invalidation).
+        preview_affected = False
+        if request.style_content is not None and request.style_content != style.style_content:
+            preview_affected = True
+        if (
+            request.image_guidelines is not None
+            and request.image_guidelines != style.image_guidelines
+        ):
+            preview_affected = True
+
         if request.style_content is not None:
             style.style_content = request.style_content
         if request.image_guidelines is not None:
             style.image_guidelines = request.image_guidelines
+
+        if preview_affected:
+            # Bump the revision (the generation write-back guard) and reset the
+            # cached preview to 'missing' so it regenerates. The last-known-good
+            # payload row is left in storage until the next successful prune.
+            style.style_revision = (style.style_revision or 0) + 1
+            style.preview_status = "missing"
+            style.preview_fingerprint = None
+            style.preview_payload_id = None
+            style.preview_error_code = None
+            style.preview_error_message = None
+            logger.info(
+                "Invalidated slide-style preview after edit",
+                extra={"style_id": style.id, "style_revision": style.style_revision},
+            )
 
         # Update the user (skip Databricks call in test/dev to avoid network timeout)
         if os.getenv("ENVIRONMENT") in ("development", "test"):
@@ -344,6 +405,16 @@ def update_slide_style(
         db.refresh(style)
         
         logger.info(f"Updated slide style: {style.name} (id={style.id})")
+
+        # If the edit invalidated the preview, warm it right away (against the
+        # now-committed new revision) so viewers don't hit a cold regeneration.
+        if preview_affected:
+            try:
+                from src.api.services.slide_style_preview_queue import try_enqueue
+
+                try_enqueue(style.id)
+            except Exception:  # noqa: BLE001 — warming must never fail the update
+                logger.warning("Preview warm-on-update failed", exc_info=True)
         
         return SlideStyleResponse(
             id=style.id,
@@ -510,3 +581,123 @@ def set_default_slide_style(style_id: int):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to set default slide style",
         )
+
+
+@router.get("/{style_id}/preview", response_model=SlideStylePreviewResponse)
+def get_slide_style_preview(
+    style_id: int,
+    db: Session = Depends(get_db),
+):
+    """Read the cached visual preview for a slide style. NEVER generates inline.
+
+    Visibility mirrors ``GET /{style_id}`` (404 parity). When the cached preview
+    is missing or stale relative to the current generation fingerprint, this
+    enqueues a deduplicated background job and returns the current state (with a
+    stale copy if one exists) so the UI stays fast and crawlers/prefetch/scroll
+    never trigger LLM cost.
+    """
+    from src.api.services.slide_style_preview_queue import try_enqueue
+
+    style = db.query(SlideStyleLibrary).filter(SlideStyleLibrary.id == style_id).first()
+    if not style:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Slide style {style_id} not found",
+        )
+
+    current_fp = preview_fixture.compute_fingerprint(
+        style.style_content, style.image_guidelines
+    )
+    status_val = style.preview_status or "missing"
+
+    # Load any stored payload (ready OR last-known-good) once.
+    payload = None
+    if style.preview_payload_id:
+        payload = preview_storage.load_payload(db, style.preview_payload_id)
+
+    def _resp(status_str: str, *, include_payload: bool, stale: bool = False):
+        has = include_payload and payload
+        return SlideStylePreviewResponse(
+            style_id=style_id,
+            status=status_str,
+            fingerprint=style.preview_fingerprint if include_payload else None,
+            slides=(payload or {}).get("slides") if has else None,
+            css=(payload or {}).get("css") if has else None,
+            assets=(payload or {}).get("assets") if has else None,
+            generated_at=style.preview_generated_at.isoformat()
+            if (has and style.preview_generated_at)
+            else None,
+            error_code=style.preview_error_code,
+            stale=stale,
+        )
+
+    # Ready and current (cache hit).
+    if status_val == "ready" and style.preview_fingerprint == current_fp and payload:
+        logger.info(
+            "slide_style_preview.cache_hit",
+            extra={"style_id": style_id, "status": "ready"},
+        )
+        return _resp("ready", include_payload=True)
+
+    # Ready but stale (fingerprint moved). Serve the stale copy, kick a refresh.
+    if status_val == "ready" and payload:
+        age_s = None
+        if style.preview_generated_at:
+            from datetime import datetime as _dt
+
+            age_s = (_dt.utcnow() - style.preview_generated_at).total_seconds()
+        logger.info(
+            "slide_style_preview.cache_stale",
+            extra={"style_id": style_id, "stale_age_s": age_s},
+        )
+        try_enqueue(style_id)
+        return _resp("stale", include_payload=True, stale=True)
+
+    # In flight. Serve stale copy underneath if present.
+    if status_val in ("queued", "generating"):
+        return _resp(status_val, include_payload=bool(payload), stale=bool(payload))
+
+    # Failed. Return last-known-good if we have one; otherwise just the error.
+    if status_val == "failed":
+        return _resp("failed", include_payload=bool(payload), stale=bool(payload))
+
+    # Missing (or unknown): enqueue and report queued.
+    try_enqueue(style_id)
+    # Re-read status: try_enqueue may have transitioned it to 'queued'.
+    return SlideStylePreviewResponse(style_id=style_id, status="queued")
+
+
+# SDR-4437 HIGH-3: workspace-global library writes are admin-only.
+@router.post(
+    "/{style_id}/preview/regenerate",
+    response_model=SlideStylePreviewResponse,
+    dependencies=[Depends(require_admin)],
+)
+def regenerate_slide_style_preview(
+    style_id: int,
+    db: Session = Depends(get_db),
+):
+    """Explicitly (re)generate a slide-style preview. Admin-only, deduplicated.
+
+    Enqueues a background job against the current style snapshot. Idempotent: if
+    a generation is already in flight this is a no-op that returns the in-flight
+    status.
+    """
+    from src.api.services.slide_style_preview_queue import try_enqueue
+
+    style = db.query(SlideStyleLibrary).filter(SlideStyleLibrary.id == style_id).first()
+    if not style:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Slide style {style_id} not found",
+        )
+
+    # Force a re-attempt even from a 'failed'/'ready' terminal state by clearing
+    # to 'missing' first (in its own committed txn), then enqueue.
+    db.query(SlideStyleLibrary).filter(SlideStyleLibrary.id == style_id).update(
+        {"preview_status": "missing"}, synchronize_session=False
+    )
+    db.commit()
+
+    try_enqueue(style_id)
+    return SlideStylePreviewResponse(style_id=style_id, status="queued")

--- a/src/api/services/slide_style_preview_queue.py
+++ b/src/api/services/slide_style_preview_queue.py
@@ -1,0 +1,440 @@
+"""DB-backed, deduplicated background generation of slide-style previews.
+
+Mirrors the ``export_job_queue`` pattern: a process-local ``asyncio.Queue``
+dispatches to a background worker that runs the blocking LLM generation in a
+thread. Unlike exports there is no separate job table — the ``slide_style_library``
+row IS the job record (``preview_status`` + fingerprint + timestamps), which makes
+dedup and cache reads a single row read.
+
+Correctness properties:
+- Dedup: enqueue performs a CONDITIONAL status transition
+  (missing/failed/ready-but-stale -> queued) and only dispatches if it won the
+  transition, so N concurrent readers produce exactly one generation.
+- Revision guard: the worker snapshots ``style_revision`` before generating and
+  only writes the result back IF the revision is unchanged, so a slow generation
+  cannot clobber a style the admin edited meanwhile.
+- Last-known-good: a validation/provider failure sets ``failed`` but never clears
+  the previously-ready ``preview_payload_id``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime
+from typing import Any, Optional
+
+from src.core.database import get_db_session
+from src.database.models.slide_style_library import SlideStyleLibrary
+from src.services import slide_style_preview_fixture as fixture
+from src.services import slide_style_preview_storage as storage
+
+logger = logging.getLogger(__name__)
+
+# Process-local dispatch queue (cross-worker state lives in the DB row).
+preview_queue: "asyncio.Queue[int]" = asyncio.Queue()
+
+# Validation / safety caps.
+PREVIEW_MAX_BYTES = 3_000_000      # reject runaway payloads
+PREVIEW_MAX_ASSETS = 24            # referenced-asset ceiling
+PREVIEW_MAX_RETRIES = 2            # transient provider errors
+
+# Statuses a preview can be re-queued from.
+_REQUEUEABLE = ("missing", "failed", "ready", "stale", None)
+
+_IMAGE_TOKEN_RE = re.compile(r"\{\{image:([A-Za-z0-9_\-]+)\}\}")
+_SCRIPT_TAG_RE = re.compile(r"<script\b[^>]*>.*?</script>", re.IGNORECASE | re.DOTALL)
+_EXTERNAL_URL_RE = re.compile(r"""(?:src|href)\s*=\s*['"]https?://""", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Enqueue (dedup via conditional transition)
+# ---------------------------------------------------------------------------
+def try_enqueue(style_id: int) -> bool:
+    """Conditionally move a style's preview to 'queued' and dispatch it.
+
+    Returns True if THIS caller won the transition and dispatched a job; False if
+    a generation is already queued/generating (dedup) or the style is missing.
+    Safe to call from any request handler.
+    """
+    with get_db_session() as db:
+        style = (
+            db.query(SlideStyleLibrary)
+            .filter(SlideStyleLibrary.id == style_id)
+            .first()
+        )
+        if style is None:
+            return False
+        current_fp = fixture.compute_fingerprint(style.style_content, style.image_guidelines)
+
+        # Already in-flight? Never double-dispatch.
+        if style.preview_status in ("queued", "generating"):
+            logger.debug(
+                "slide_style_preview.dedup_suppressed",
+                extra={"style_id": style_id, "status": style.preview_status},
+            )
+            return False
+        # Already ready AND current? Nothing to do.
+        if style.preview_status == "ready" and style.preview_fingerprint == current_fp:
+            return False
+
+        # Win the transition with a guarded UPDATE (atomic across workers).
+        updated = (
+            db.query(SlideStyleLibrary)
+            .filter(
+                SlideStyleLibrary.id == style_id,
+                SlideStyleLibrary.preview_status.in_(
+                    [s for s in _REQUEUEABLE if s is not None]
+                )
+                | SlideStyleLibrary.preview_status.is_(None),
+            )
+            .update(
+                {
+                    "preview_status": "queued",
+                    "preview_attempted_at": datetime.utcnow(),
+                },
+                synchronize_session=False,
+            )
+        )
+        if not updated:
+            return False  # lost the race
+
+    _dispatch(style_id)
+    logger.info("Enqueued slide-style preview generation", extra={"style_id": style_id})
+    return True
+
+
+def _dispatch(style_id: int) -> None:
+    """Put the job on the process-local queue if a loop/worker is available.
+
+    If no running loop (e.g. sync test context), the DB row stays 'queued' and a
+    later worker/cron can pick it up; we don't crash the request path.
+    """
+    try:
+        preview_queue.put_nowait(style_id)
+    except RuntimeError:
+        logger.debug("No running loop to dispatch preview job; left queued", extra={"style_id": style_id})
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+def _generate_deck(style_id: int) -> dict[str, Any]:
+    """Run the real generation pipeline against a fixed brief for one style.
+
+    Creates an ephemeral, non-user-visible session whose agent_config selects the
+    target slide style (design system explicitly off), generates the canonical
+    preview brief through the same ``send_message`` path real decks use, then
+    deletes the session. Returns the parsed slide_deck dict.
+    """
+    from src.api.services.chat_service import get_chat_service
+    from src.api.services.session_manager import get_session_manager
+
+    session_id = f"__preview__{style_id}__{datetime.utcnow().timestamp()}"
+    session_manager = get_session_manager()
+    session_manager.create_session(
+        session_id=session_id,
+        created_by="__preview__",
+        title="(slide-style preview)",
+        agent_config={"slide_style_id": style_id, "design_system_id": None, "tools": []},
+    )
+    # Cap max_tokens for this generation only (same model, smaller thinking
+    # budget). The agent's model factory reads this context-var at creation time;
+    # reset in finally so nothing else inherits the cap.
+    token = fixture.preview_max_tokens_override.set(fixture.PREVIEW_MAX_TOKENS)
+    try:
+        chat_service = get_chat_service()
+        result = chat_service.send_message(session_id, fixture.PREVIEW_BRIEF)
+        deck = result.get("slide_deck") or {}
+        deck["_metadata"] = result.get("metadata") or {}
+        return deck
+    finally:
+        fixture.preview_max_tokens_override.reset(token)
+        try:
+            session_manager.delete_session(session_id)
+        except Exception:  # noqa: BLE001 — cleanup best-effort
+            logger.warning("Failed to delete ephemeral preview session %s", session_id, exc_info=True)
+
+
+def _sanitize_and_validate(
+    deck: dict[str, Any]
+) -> tuple[list[str], str, list[dict[str, Any]]]:
+    """Treat model output as hostile. Returns (slides_html, css, asset_manifest).
+
+    Slides are kept as a list (the UI pages a mini-deck; concatenating would stack
+    the ``position:absolute`` slide roots). Raises ValueError(code) on rejection so
+    the caller can record error_code and preserve last-known-good.
+    """
+    raw_slides = deck.get("slides") or []
+    css = _SCRIPT_TAG_RE.sub("", deck.get("css") or "")
+
+    # Strip scripts (preview renders in a script-less sandbox, so any <script> is
+    # dead weight and a risk vector). Drop empty fragments.
+    slides = [
+        _SCRIPT_TAG_RE.sub("", s.get("html") or "").strip()
+        for s in raw_slides
+    ]
+    slides = [s for s in slides if s]
+
+    if not (fixture.PREVIEW_MIN_SLIDES <= len(slides) <= fixture.PREVIEW_MAX_SLIDES):
+        raise ValueError("bad_slide_count")
+
+    combined = "\n".join(slides)
+    if not combined.strip():
+        raise ValueError("empty_html")
+
+    # No external/transient asset references — the iframe CSP forbids them and a
+    # third-party URL could rot. Library images use {{image:token}} placeholders.
+    if _EXTERNAL_URL_RE.search(combined) or _EXTERNAL_URL_RE.search(css):
+        raise ValueError("external_asset")
+
+    total_bytes = len(combined.encode("utf-8")) + len(css.encode("utf-8"))
+    if total_bytes > PREVIEW_MAX_BYTES:
+        raise ValueError("too_large")
+
+    tokens = set(_IMAGE_TOKEN_RE.findall(combined)) | set(_IMAGE_TOKEN_RE.findall(css))
+    if len(tokens) > PREVIEW_MAX_ASSETS:
+        raise ValueError("too_many_assets")
+    manifest = [{"type": "image", "token": t} for t in sorted(tokens)]
+
+    return slides, css, manifest
+
+
+def process_preview_job(style_id: int) -> None:
+    """Generate, validate, and cache a preview for one style (blocking).
+
+    Idempotent and revision-guarded; safe to run from a worker thread.
+    """
+    # Snapshot the style + revision we are generating against.
+    with get_db_session() as db:
+        style = db.query(SlideStyleLibrary).filter(SlideStyleLibrary.id == style_id).first()
+        if style is None:
+            return
+        snap_revision = style.style_revision or 0
+        style_content = style.style_content
+        image_guidelines = style.image_guidelines
+        fingerprint = fixture.compute_fingerprint(style_content, image_guidelines)
+        content_hash = fixture.compute_content_hash(style_content, image_guidelines)
+        # queued -> generating (guarded; bail if someone superseded us).
+        moved = (
+            db.query(SlideStyleLibrary)
+            .filter(
+                SlideStyleLibrary.id == style_id,
+                SlideStyleLibrary.preview_status.in_(["queued", "generating"]),
+            )
+            .update({"preview_status": "generating"}, synchronize_session=False)
+        )
+        if not moved:
+            return
+
+    started = datetime.utcnow()
+    last_err = "unknown"
+    for attempt in range(1, PREVIEW_MAX_RETRIES + 2):  # 1 + retries
+        try:
+            deck = _generate_deck(style_id)
+            slides, css, manifest = _sanitize_and_validate(deck)
+            persisted = _persist_success(
+                style_id, snap_revision, fingerprint, content_hash, slides, css, manifest,
+            )
+            latency = (datetime.utcnow() - started).total_seconds()
+            logger.info(
+                "slide_style_preview.generated" if persisted
+                else "slide_style_preview.generated_but_discarded",
+                extra={
+                    "style_id": style_id,
+                    "attempt": attempt,
+                    "persisted": persisted,
+                    "latency_s": round(latency, 2),
+                    "slides": len(slides),
+                    "bytes": sum(len(s) for s in slides) + len(css),
+                    "assets": len(manifest),
+                    "tokens": (deck.get("_metadata") or {}).get("total_tokens"),
+                },
+            )
+            return
+        except ValueError as ve:  # validation rejection — not retryable
+            last_err = str(ve)
+            logger.warning(
+                "slide_style_preview.rejected",
+                extra={"style_id": style_id, "error_code": last_err, "attempt": attempt},
+            )
+            break
+        except Exception as e:  # noqa: BLE001 — transient provider/runtime error
+            last_err = "generation_error"
+            logger.warning(
+                "slide_style_preview.attempt_failed",
+                extra={"style_id": style_id, "attempt": attempt, "error": str(e)[:200]},
+            )
+            continue
+
+    _persist_failure(style_id, last_err)
+
+
+def _persist_success(
+    style_id: int,
+    snap_revision: int,
+    fingerprint: str,
+    content_hash: str,
+    slides: list[str],
+    css: str,
+    manifest: list[dict[str, Any]],
+) -> bool:
+    """Store payload + write pointer back, guarded on style_revision.
+
+    Returns True if the pointer was written (preview promoted to ready), False if
+    the write was discarded because the style was edited mid-generation.
+    """
+    from sqlalchemy import or_
+
+    with get_db_session() as db:
+        payload_id, total_bytes = storage.store_payload(
+            db, style_id, fingerprint, slides, css, manifest
+        )
+        # Conditional write-back: only if the style wasn't edited mid-generation.
+        # NULL-safe: rows inherited via a Lakebase branch have style_revision=NULL
+        # (the migration adds the column without a backfill on already-populated
+        # forks), and `NULL == 0` is never true in SQL — so a plain equality check
+        # would discard EVERY generation on a fork. When we snapshotted revision 0,
+        # treat NULL as 0 so those inherited rows can be promoted to ready.
+        revision_guard = SlideStyleLibrary.style_revision == snap_revision
+        if snap_revision == 0:
+            revision_guard = or_(revision_guard, SlideStyleLibrary.style_revision.is_(None))
+        updated = (
+            db.query(SlideStyleLibrary)
+            .filter(
+                SlideStyleLibrary.id == style_id,
+                revision_guard,
+            )
+            .update(
+                {
+                    "preview_status": "ready",
+                    "preview_fingerprint": fingerprint,
+                    "preview_content_hash": content_hash,
+                    "preview_payload_id": payload_id,
+                    "preview_asset_manifest": manifest,
+                    "preview_total_bytes": total_bytes,
+                    "preview_error_code": None,
+                    "preview_error_message": None,
+                    "preview_generated_at": datetime.utcnow(),
+                },
+                synchronize_session=False,
+            )
+        )
+        if not updated:
+            # Style changed under us: discard. Leave status as-is (a fresh enqueue
+            # for the new revision will supersede). Prune the orphaned payload.
+            logger.info(
+                "slide_style_preview.discarded_stale_generation",
+                extra={"style_id": style_id, "snap_revision": snap_revision},
+            )
+            style = db.query(SlideStyleLibrary).filter(SlideStyleLibrary.id == style_id).first()
+            keep = {style.preview_payload_id} if style and style.preview_payload_id else set()
+            storage.prune_payloads(db, style_id, keep_ids=keep)
+            return False
+        # Success: prune stale payloads, keeping the one we just wrote.
+        storage.prune_payloads(db, style_id, keep_ids={payload_id})
+        return True
+
+
+def _persist_failure(style_id: int, error_code: str) -> None:
+    """Record failure WITHOUT clearing last-known-good payload."""
+    with get_db_session() as db:
+        db.query(SlideStyleLibrary).filter(SlideStyleLibrary.id == style_id).update(
+            {
+                "preview_status": "failed",
+                "preview_error_code": error_code,
+                "preview_error_message": f"Preview generation failed ({error_code}).",
+                "preview_failed_at": datetime.utcnow(),
+            },
+            synchronize_session=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Worker lifecycle (mirrors export_job_queue)
+# ---------------------------------------------------------------------------
+def _run_preview_job_sync(style_id: int) -> None:
+    """Thread entrypoint: run the blocking generation on its own loop."""
+    try:
+        process_preview_job(style_id)
+    except Exception:  # noqa: BLE001 — never let a job kill the worker
+        logger.error("slide_style_preview.job_crashed", extra={"style_id": style_id}, exc_info=True)
+        try:
+            _persist_failure(style_id, "worker_crash")
+        except Exception:
+            logger.error("slide_style_preview.failure_record_failed", exc_info=True)
+
+
+async def preview_worker() -> None:
+    """Background worker: drain the queue, running each job off the event loop."""
+    logger.info("Slide-style preview worker started")
+    while True:
+        try:
+            style_id = await preview_queue.get()
+            try:
+                await asyncio.to_thread(_run_preview_job_sync, style_id)
+            finally:
+                preview_queue.task_done()
+        except asyncio.CancelledError:
+            logger.info("Slide-style preview worker shutting down")
+            break
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Preview worker loop error: {e}")
+
+
+async def start_preview_worker() -> "asyncio.Task[None]":
+    """Start the background preview worker task."""
+    return asyncio.create_task(preview_worker())
+
+
+# ---------------------------------------------------------------------------
+# Startup warming (backfill)
+# ---------------------------------------------------------------------------
+# Cap how many styles we proactively warm per boot so a fresh fork (where every
+# style is 'missing') doesn't fan out an unbounded burst of Opus generations.
+# try_enqueue dedups + skips already-ready styles, so subsequent boots only warm
+# the stale/missing ones. Defaults ordered so the default + active styles warm first.
+PREVIEW_WARM_LIMIT = 25
+
+
+def warm_missing_previews(limit: int = PREVIEW_WARM_LIMIT) -> int:
+    """Proactively enqueue previews for active styles that aren't ready+current.
+
+    Runs at startup so viewers hit a warm cache instead of a cold generation.
+    Best-effort and deduplicated (``try_enqueue`` no-ops ready/in-flight styles).
+    Returns the number of styles enqueued.
+    """
+    enqueued = 0
+    try:
+        with get_db_session() as db:
+            styles = (
+                db.query(SlideStyleLibrary)
+                .filter(SlideStyleLibrary.is_active.is_(True))
+                .order_by(
+                    SlideStyleLibrary.is_default.desc(),
+                    SlideStyleLibrary.id.asc(),
+                )
+                .limit(limit)
+                .all()
+            )
+            style_ids = [s.id for s in styles]
+    except Exception:  # noqa: BLE001 — warming must never break startup
+        logger.warning("slide_style_preview.warm_query_failed", exc_info=True)
+        return 0
+
+    for style_id in style_ids:
+        try:
+            if try_enqueue(style_id):
+                enqueued += 1
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "slide_style_preview.warm_enqueue_failed",
+                extra={"style_id": style_id},
+                exc_info=True,
+            )
+    logger.info(
+        "slide_style_preview.warm_backfill",
+        extra={"candidates": len(style_ids), "enqueued": enqueued},
+    )
+    return enqueued

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -496,6 +496,9 @@ def _run_migrations(engine, schema: str | None = None):
 
         _migrate_slide_style_default(conn, inspector, schema, _qual, is_sqlite)
 
+        # --- slide-style generated-preview cache columns (payload offloaded) ---
+        _migrate_slide_style_preview_columns(conn, inspector, schema, _qual, is_sqlite)
+
         # --- permissions model: parent_session_id, locking, optimistic concurrency ---
         _migrate_permissions_columns(conn, inspector, schema, _qual, is_sqlite)
 
@@ -1686,6 +1689,73 @@ def _migrate_to_v0_2(conn, inspector, schema, _qual, is_sqlite):
         ))
 
     logger.info("Migration: v0.2 schema migration complete")
+
+
+def _migrate_slide_style_preview_columns(conn, inspector, schema, _qual, is_sqlite):
+    """Add generated-preview cache columns to slide_style_library.
+
+    Idempotent additive ALTERs (all nullable). Fresh installs get these via
+    ``create_all()``; existing/forked-prod databases need the ALTERs. The
+    ``slide_style_preview_payload`` table itself is created by ``create_all()``
+    (it creates missing tables), so only the column adds are handled here.
+    """
+    from sqlalchemy import text
+
+    table_name = "slide_style_library"
+    qualified_table = _qual(table_name)
+    try:
+        columns = {c["name"] for c in inspector.get_columns(table_name, schema=schema)}
+    except Exception:
+        return
+    if not columns:
+        return
+
+    # column name -> SQL type/default (nullable, additive-safe).
+    preview_columns = {
+        "preview_status": "VARCHAR(16) NULL",
+        "preview_fingerprint": "VARCHAR(64) NULL",
+        "preview_content_hash": "VARCHAR(64) NULL",
+        "preview_payload_id": "INTEGER NULL",
+        "preview_asset_manifest": "JSON NULL",
+        "preview_total_bytes": "INTEGER NULL",
+        "preview_error_code": "VARCHAR(64) NULL",
+        "preview_error_message": "TEXT NULL",
+        "preview_generated_at": "TIMESTAMP NULL",
+        "preview_attempted_at": "TIMESTAMP NULL",
+        "preview_failed_at": "TIMESTAMP NULL",
+        "style_revision": "INTEGER NULL",
+    }
+    added_columns = []
+    for col, ddl in preview_columns.items():
+        if col not in columns:
+            logger.info(f"Migration: adding {col} column to {table_name}")
+            conn.execute(text(f"ALTER TABLE {qualified_table} ADD COLUMN {col} {ddl}"))
+            added_columns.append(col)
+
+    # Backfill style_revision on already-populated (e.g. branch-inherited) rows.
+    # The column is added nullable with no default, so pre-existing rows are NULL.
+    # The generation write-back guard compares `style_revision == snapshot(0)`, and
+    # `NULL == 0` is never true in SQL — leaving NULL would make EVERY preview
+    # generation get discarded on a fork (never reaching 'ready'). Normalize to 0.
+    # Idempotent: only touches NULL rows, so re-runs are no-ops.
+    if "style_revision" in columns or "style_revision" in added_columns:
+        try:
+            result = conn.execute(
+                text(
+                    f"UPDATE {qualified_table} SET style_revision = 0 "
+                    f"WHERE style_revision IS NULL"
+                )
+            )
+            backfilled = getattr(result, "rowcount", 0) or 0
+            if backfilled:
+                logger.info(
+                    f"Migration: backfilled style_revision=0 on {backfilled} "
+                    f"{table_name} row(s)"
+                )
+        except Exception:
+            logger.warning(
+                "Migration: style_revision backfill failed (non-fatal)", exc_info=True
+            )
 
 
 def _migrate_slide_style_default(conn, inspector, schema, _qual, is_sqlite):

--- a/src/database/models/__init__.py
+++ b/src/database/models/__init__.py
@@ -34,6 +34,7 @@ from src.database.models.session import (
 )
 from src.database.models.slide_deck_prompt import SlideDeckPromptLibrary
 from src.database.models.slide_style_library import SlideStyleLibrary
+from src.database.models.slide_style_preview import SlideStylePreviewPayload
 from src.database.models.usage_event import UsageEvent
 from src.database.models.user_preference import UserProfilePreference
 
@@ -65,6 +66,7 @@ __all__ = [
     "SlideDeckPromptLibrary",
     "SlideDeckVersion",
     "SlideStyleLibrary",
+    "SlideStylePreviewPayload",
     "SurveyResponse",
     "UsageEvent",
     "UserProfilePreference",

--- a/src/database/models/slide_style_library.py
+++ b/src/database/models/slide_style_library.py
@@ -12,7 +12,7 @@ Slide styles control HOW slides should LOOK - the visual presentation.
 """
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, String, Text
 
 from src.core.database import Base
 
@@ -42,6 +42,38 @@ class SlideStyleLibrary(Base):
     updated_by = Column(String(255), nullable=True)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
     is_default = Column(Boolean, default=False, nullable=False)  # Which style is applied to new sessions by default
+
+    # --- Generated preview cache (see docs: slide-style visual preview) ------
+    # A slide style is prose the model interprets, so its "what will my slides
+    # look like" preview is a generated sample deck. Generation is expensive and
+    # non-deterministic, so it runs in a background job and its result is cached.
+    # The HTML/CSS PAYLOAD is offloaded to slide_style_preview_payload (bytea);
+    # only pointers + status + metadata live here so library reads stay light.
+    #
+    # preview_status lifecycle: missing -> queued -> generating -> ready|failed.
+    preview_status = Column(String(16), nullable=True, default="missing")
+    # Full generation fingerprint (style text + brief/prompt/generator/renderer/
+    # model versions). A mismatch vs the current fingerprint means the cached
+    # preview is stale and must be regenerated.
+    preview_fingerprint = Column(String(64), nullable=True)
+    # Hash of just the style-authored inputs (edit detection / diagnostics).
+    preview_content_hash = Column(String(64), nullable=True)
+    # Pointer into slide_style_preview_payload (the ready/last-known-good bundle).
+    preview_payload_id = Column(Integer, nullable=True)
+    # Non-secret manifest: referenced image ids/types + sizes (no bytes).
+    preview_asset_manifest = Column(JSON, nullable=True)
+    preview_total_bytes = Column(Integer, nullable=True)
+    # Failure diagnostics (sanitized; safe to expose to clients).
+    preview_error_code = Column(String(64), nullable=True)
+    preview_error_message = Column(Text, nullable=True)
+    preview_generated_at = Column(DateTime, nullable=True)
+    preview_attempted_at = Column(DateTime, nullable=True)
+    preview_failed_at = Column(DateTime, nullable=True)
+    # Bumped whenever a preview-affecting field (style_content/image_guidelines)
+    # changes. The generation worker only writes its result back if this value is
+    # unchanged from the snapshot it generated against — preventing a slow, stale
+    # generation from clobbering a freshly-edited style.
+    style_revision = Column(Integer, nullable=True, default=0)
 
     def __repr__(self):
         return f"<SlideStyleLibrary(id={self.id}, name='{self.name}', category='{self.category}')>"

--- a/src/database/models/slide_style_preview.py
+++ b/src/database/models/slide_style_preview.py
@@ -1,0 +1,55 @@
+"""Offloaded storage for generated slide-style previews.
+
+Slide-style previews are model-generated sample decks that can be image-heavy.
+Keeping their HTML/CSS payload inline on ``slide_style_library`` would bloat the
+frequently-queried library rows (the list endpoint reads every style). Instead
+the payload lives here, mirroring the app's existing binary-asset pattern
+(``ImageAsset.image_data`` / ``DesignSystemAsset.data`` — Postgres ``bytea``),
+while ``slide_style_library`` keeps only a pointer + manifest + status.
+
+Referenced image bytes are NOT duplicated here: previews reference images via the
+existing image library (served by its own controlled route), so this table stores
+only the gzipped HTML/CSS bundle.
+"""
+from datetime import datetime
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    LargeBinary,
+    String,
+    UniqueConstraint,
+)
+
+from src.core.database import Base
+
+
+class SlideStylePreviewPayload(Base):
+    """Gzipped HTML/CSS bundle for one (style, fingerprint) preview.
+
+    Uniqueness on ``(style_id, fingerprint)`` makes writes idempotent and lets a
+    stale-but-known-good payload survive while a newer fingerprint regenerates.
+    """
+
+    __tablename__ = "slide_style_preview_payload"
+
+    id = Column(Integer, primary_key=True)  # Internal only — never serialized.
+    style_id = Column(Integer, nullable=False, index=True)
+    fingerprint = Column(String(64), nullable=False, index=True)
+
+    # gzip(JSON) of {"html": str, "css": str, "assets": [...manifest...]}.
+    bundle_gzip = Column(LargeBinary, nullable=False)
+    total_bytes = Column(Integer, nullable=False, default=0)  # uncompressed payload size
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("style_id", "fingerprint", name="uq_slide_style_preview_fp"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<SlideStylePreviewPayload(id={self.id}, style_id={self.style_id}, "
+            f"fingerprint={self.fingerprint[:8]}…, bytes={self.total_bytes})>"
+        )

--- a/src/services/agent.py
+++ b/src/services/agent.py
@@ -445,10 +445,16 @@ class SlideGeneratorAgent:
             system_client = get_system_client()
             llm_config = DEFAULT_CONFIG["llm"]
 
+            # Slide-style preview generation caps max_tokens (same model, smaller
+            # thinking budget) via a context-var; everything else uses the full
+            # deck budget. Defaults to None so normal generation is unaffected.
+            from src.services.slide_style_preview_fixture import preview_max_tokens_override
+            max_tokens = preview_max_tokens_override.get() or llm_config["max_tokens"]
+
             model = ChatDatabricks(
                 endpoint=llm_config["endpoint"],
                 temperature=llm_config["temperature"],
-                max_tokens=llm_config["max_tokens"],
+                max_tokens=max_tokens,
                 top_p=llm_config["top_p"],
                 workspace_client=system_client,
             )
@@ -458,7 +464,8 @@ class SlideGeneratorAgent:
                 extra={
                     "endpoint": llm_config["endpoint"],
                     "temperature": llm_config["temperature"],
-                    "max_tokens": llm_config["max_tokens"],
+                    "max_tokens": max_tokens,
+                    "preview_capped": max_tokens != llm_config["max_tokens"],
                 },
             )
 

--- a/src/services/agent_factory.py
+++ b/src/services/agent_factory.py
@@ -55,10 +55,15 @@ def _create_model():
     llm_config = DEFAULT_CONFIG["llm"]
     system_client = get_system_client()
 
+    # Preview generation caps max_tokens via a context-var (same model, smaller
+    # thinking budget); None for normal generation so the full budget is used.
+    from src.services.slide_style_preview_fixture import preview_max_tokens_override
+    max_tokens = preview_max_tokens_override.get() or llm_config["max_tokens"]
+
     model = ChatDatabricks(
         endpoint=llm_config["endpoint"],
         temperature=llm_config["temperature"],
-        max_tokens=llm_config["max_tokens"],
+        max_tokens=max_tokens,
         top_p=0.95,
         workspace_client=system_client,
     )
@@ -68,7 +73,8 @@ def _create_model():
         extra={
             "endpoint": llm_config["endpoint"],
             "temperature": llm_config["temperature"],
-            "max_tokens": llm_config["max_tokens"],
+            "max_tokens": max_tokens,
+            "preview_capped": max_tokens != llm_config["max_tokens"],
         },
     )
 

--- a/src/services/slide_style_preview_fixture.py
+++ b/src/services/slide_style_preview_fixture.py
@@ -1,0 +1,119 @@
+"""Canonical preview fixture + generation fingerprint for slide-style previews.
+
+A slide style is prose the model interprets, not deterministic CSS, so the only
+faithful "what will my slides look like" preview is a generated sample. To make
+that sample (a) representative and (b) safely cacheable, this module defines:
+
+- A FIXED, versioned canonical brief that asks for a small deck spanning the
+  slide archetypes a style most differs across (cover, content/comparison, and
+  an optional data/image slide). One ambiguous slide can misrepresent a style;
+  a small canonical deck is fairer.
+- A structured GENERATION FINGERPRINT. A preview can go stale even when the
+  style text is unchanged — e.g. after a prompt-module, model, generator, or
+  renderer release. Hashing only the style text would leave those previews
+  looking valid while silently wrong. The fingerprint folds every
+  preview-affecting input plus an umbrella version so a release can invalidate
+  all previews at once without touching rows.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import hashlib
+from typing import Optional
+
+from src.core.defaults import DEFAULT_CONFIG
+
+# --- Version markers ---------------------------------------------------------
+# Bump the specific marker whose behaviour changed; bump PREVIEW_GENERATION_VERSION
+# to force-invalidate ALL previews after a cross-cutting release. Every marker is
+# folded into the fingerprint below.
+PREVIEW_BRIEF_VERSION = "1"        # the canonical brief text / slide set below
+PREVIEW_PROMPT_VERSION = "1"       # how we assemble the preview generation prompt
+PREVIEW_GENERATOR_VERSION = "2"    # bumped: preview now runs with a capped max_tokens
+PREVIEW_RENDERER_VERSION = "1"     # the frontend render contract (buildSlideDocument use)
+PREVIEW_GENERATION_VERSION = "1"   # umbrella: bump to invalidate every preview
+
+# --- Preview generation budget ----------------------------------------------
+# Previews keep the SAME model as real decks (so palette/typography/layout are
+# faithful), but cap max_tokens far below the deck default. The dominant preview
+# latency is the model's extended-THINKING budget, which scales with max_tokens;
+# a 3-slide sample needs a fraction of a full deck's budget. This is a deliberate
+# fidelity/latency trade-off: same model, less deliberation. Set high enough that
+# the canonical 3-slide brief completes without truncation (the output validator
+# fails-safe to 'failed' + last-known-good if a generation is cut short).
+PREVIEW_MAX_TOKENS = 12000
+
+# Thread/async-local override read at model-creation time (see agent model
+# factories). Set only for the duration of a preview generation; None otherwise
+# so real deck generation always uses the full DEFAULT_CONFIG budget.
+preview_max_tokens_override: "contextvars.ContextVar[Optional[int]]" = contextvars.ContextVar(
+    "preview_max_tokens_override", default=None
+)
+
+# Number of slides the canonical brief asks for. The output validator rejects a
+# generation whose slide count is not in this inclusive range (model may merge
+# or split), preventing a broken 0-slide or runaway output from being cached.
+PREVIEW_MIN_SLIDES = 2
+PREVIEW_MAX_SLIDES = 4
+
+# The fixed brief. Neutral, brandless subject matter so the preview reflects the
+# STYLE, not the topic; explicitly spans archetypes so one attractive-but-atypical
+# slide cannot give a false sense of consistency.
+PREVIEW_BRIEF = (
+    "Create a short SAMPLE slide deck that demonstrates this visual style. "
+    "Use neutral, brand-agnostic placeholder content about a fictional product "
+    "launch (call it \"Northwind\"). Produce exactly these slides in order:\n"
+    "1. A COVER/TITLE slide: a title, a subtitle, and a small metadata line.\n"
+    "2. A CONTENT slide: a section heading and 3-4 concise bullet points.\n"
+    "3. A DATA slide: a heading plus a simple chart or a 2-3 row metric layout.\n"
+    "Keep the text short. The goal is to showcase typography, color, spacing, "
+    "and layout so a viewer can judge the style before generating a real deck."
+)
+
+
+def model_config_version() -> str:
+    """A stable marker for the model configuration that affects preview output.
+
+    Reads the same fixed LLM config the agent uses (endpoint/temperature/
+    max_tokens). A change here (model swap, temperature change) legitimately
+    changes previews, so it participates in the fingerprint.
+    """
+    llm = DEFAULT_CONFIG.get("llm", {})
+    # Include the preview-specific max_tokens cap: changing it changes generation
+    # output/latency, so cached previews should regenerate when it moves.
+    return (
+        f"{llm.get('endpoint')}|{llm.get('temperature')}|{llm.get('max_tokens')}"
+        f"|preview_max_tokens={PREVIEW_MAX_TOKENS}"
+    )
+
+
+def compute_content_hash(style_content: str, image_guidelines: Optional[str]) -> str:
+    """Hash only the style-authored inputs (used to detect user edits)."""
+    h = hashlib.sha256()
+    h.update((style_content or "").encode("utf-8"))
+    h.update(b"\x00")
+    h.update((image_guidelines or "").encode("utf-8"))
+    return h.hexdigest()
+
+
+def compute_fingerprint(style_content: str, image_guidelines: Optional[str]) -> str:
+    """Full generation fingerprint: style inputs + every generation dependency.
+
+    Two previews with the same fingerprint are interchangeable; a mismatch means
+    the cached preview is stale and must be regenerated.
+    """
+    h = hashlib.sha256()
+    for part in (
+        style_content or "",
+        image_guidelines or "",
+        PREVIEW_BRIEF_VERSION,
+        PREVIEW_PROMPT_VERSION,
+        PREVIEW_GENERATOR_VERSION,
+        PREVIEW_RENDERER_VERSION,
+        model_config_version(),
+        PREVIEW_GENERATION_VERSION,
+    ):
+        h.update(part.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()

--- a/src/services/slide_style_preview_storage.py
+++ b/src/services/slide_style_preview_storage.py
@@ -1,0 +1,119 @@
+"""Object-storage backend for slide-style preview payloads.
+
+The app's durable, multi-replica-safe binary store is Postgres ``bytea`` (see
+``ImageAsset.image_data`` / ``DesignSystemAsset.data``). This module mirrors that
+pattern for preview HTML/CSS bundles: they live gzipped in
+``slide_style_preview_payload``, keyed by ``(style_id, fingerprint)``, so the
+frequently-queried ``slide_style_library`` rows stay blob-free and a stale
+last-known-good bundle can survive alongside a newer fingerprint.
+
+Referenced image bytes are NOT stored here — previews reference the existing
+image library (served by its own controlled route), so only the HTML/CSS bundle
+plus a lightweight asset manifest is persisted.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from src.database.models.slide_style_preview import SlideStylePreviewPayload
+
+logger = logging.getLogger(__name__)
+
+
+def _pack(
+    slides: list[str], css: str, assets: Optional[list[dict[str, Any]]]
+) -> tuple[bytes, int]:
+    """gzip(JSON) the bundle; return (compressed_bytes, uncompressed_size).
+
+    ``slides`` is a list of per-slide HTML fragments (kept separate so the UI can
+    page a mini-deck — slide roots are ``position:absolute`` and would stack if
+    concatenated into one document).
+    """
+    raw = json.dumps(
+        {"slides": list(slides or []), "css": css or "", "assets": assets or []},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return gzip.compress(raw), len(raw)
+
+
+def _unpack(blob: bytes) -> dict[str, Any]:
+    return json.loads(gzip.decompress(blob).decode("utf-8"))
+
+
+def store_payload(
+    db: Session,
+    style_id: int,
+    fingerprint: str,
+    slides: list[str],
+    css: str,
+    assets: Optional[list[dict[str, Any]]] = None,
+) -> tuple[int, int]:
+    """Idempotently persist a preview bundle for (style_id, fingerprint).
+
+    Returns (payload_id, total_uncompressed_bytes). If a row already exists for
+    the pair it is overwritten (a regeneration for the same fingerprint).
+    """
+    blob, total_bytes = _pack(slides, css, assets)
+    existing = (
+        db.query(SlideStylePreviewPayload)
+        .filter(
+            SlideStylePreviewPayload.style_id == style_id,
+            SlideStylePreviewPayload.fingerprint == fingerprint,
+        )
+        .first()
+    )
+    if existing:
+        existing.bundle_gzip = blob
+        existing.total_bytes = total_bytes
+        db.flush()
+        return existing.id, total_bytes
+
+    row = SlideStylePreviewPayload(
+        style_id=style_id,
+        fingerprint=fingerprint,
+        bundle_gzip=blob,
+        total_bytes=total_bytes,
+    )
+    db.add(row)
+    db.flush()  # populate row.id
+    return row.id, total_bytes
+
+
+def load_payload(db: Session, payload_id: int) -> Optional[dict[str, Any]]:
+    """Return {'slides','css','assets'} for a payload id, or None if missing."""
+    row = (
+        db.query(SlideStylePreviewPayload)
+        .filter(SlideStylePreviewPayload.id == payload_id)
+        .first()
+    )
+    if not row or not row.bundle_gzip:
+        return None
+    try:
+        return _unpack(row.bundle_gzip)
+    except Exception:  # noqa: BLE001 — corrupt payload should not 500 the read
+        logger.warning("Corrupt slide-style preview payload id=%s", payload_id, exc_info=True)
+        return None
+
+
+def prune_payloads(db: Session, style_id: int, keep_ids: set[int]) -> int:
+    """Delete stored payloads for a style except those in keep_ids. Returns count.
+
+    Keeps the current + last-known-good bundle; sweeps abandoned fingerprints.
+    """
+    rows = (
+        db.query(SlideStylePreviewPayload)
+        .filter(SlideStylePreviewPayload.style_id == style_id)
+        .all()
+    )
+    removed = 0
+    for r in rows:
+        if r.id not in keep_ids:
+            db.delete(r)
+            removed += 1
+    return removed

--- a/tests/unit/test_preview_box_model_parity.py
+++ b/tests/unit/test_preview_box_model_parity.py
@@ -191,16 +191,24 @@ def test_every_preview_surface_routes_its_frame_through_the_shared_contract(slid
     )
 
 
-def test_the_preview_reset_has_exactly_two_consumers(slide_document):
-    """Neither of them an export path, so the preview reset and the export resets
-    stay separately attributable."""
+def test_the_preview_reset_has_exactly_three_consumers(slide_document):
+    """All three are preview surfaces, none an export path, so the preview reset
+    and the export resets stay separately attributable.
+
+    SlideStylePreviewFrame.tsx (slide-style visual preview) is the third: like
+    SlideTile and VisualEditorPanel it renders a framed single slide in-app, not
+    a scrolling export document, so it correctly shares the preview reset."""
     consumers = [
         p
         for p in (_FRONTEND).rglob("*.tsx")
         if "SLIDE_PREVIEW_RESET_STYLE" in p.read_text(encoding="utf-8")
         and "extraHeadStyle: SLIDE_PREVIEW_RESET_STYLE" in p.read_text(encoding="utf-8")
     ]
-    assert {p.name for p in consumers} == {"SlideTile.tsx", "VisualEditorPanel.tsx"}
+    assert {p.name for p in consumers} == {
+        "SlideTile.tsx",
+        "VisualEditorPanel.tsx",
+        "SlideStylePreviewFrame.tsx",
+    }
 
     wrapper_start = slide_document.index("const wrapperStyle = `")
     wrapper = slide_document[wrapper_start : slide_document.index("`;", wrapper_start)]

--- a/tests/unit/test_route_authz_coverage.py
+++ b/tests/unit/test_route_authz_coverage.py
@@ -182,6 +182,12 @@ ALLOWLIST = {
         "Read-only library browse; HIGH-3 admin-gates writes only.",
     ("GET", "/api/settings/slide-styles/{style_id}"):
         "Read-only library browse; HIGH-3 admin-gates writes only.",
+    # Read-only cached visual preview; mirrors GET /{style_id} visibility (404
+    # parity, no admin gate) so any user can preview a style before picking it.
+    # It never generates inline — it enqueues a deduplicated background job — and
+    # the WRITE side (POST .../preview/regenerate) IS admin-gated (HIGH-3).
+    ("GET", "/api/settings/slide-styles/{style_id}/preview"):
+        "Read-only library browse; HIGH-3 admin-gates writes only.",
     # Design systems adapt the deck-prompt / slide-style library shape:
     # rename/delete are creator-or-admin (admin-only while the row is the org
     # default), set-default is admin-only, and — since SDR-4437 F-CR-17 —

--- a/tests/unit/test_slide_style_preview.py
+++ b/tests/unit/test_slide_style_preview.py
@@ -1,0 +1,414 @@
+"""Unit tests for the slide-style visual preview feature.
+
+Covers the correctness properties the design depends on:
+- fingerprint invalidation (style edits AND generation-version bumps),
+- deduplicated enqueue (exactly one generation for concurrent readers),
+- revision-guarded write-back (a stale generation cannot clobber a fresh edit),
+- hostile-output validation (+ last-known-good preserved on failure),
+- migration idempotency,
+- regenerate endpoint admin gating and read-visibility 404 parity.
+
+Generation is fully mocked — no real LLM call.
+"""
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import core.database BEFORE models to avoid the package's import-order cycle.
+import src.core.database as core_db
+from src.core.database import Base
+import src.database.models  # noqa: F401 — registers all tables on Base
+from src.database.models.slide_style_library import SlideStyleLibrary
+from src.services import slide_style_preview_fixture as fixture
+from src.services import slide_style_preview_storage as storage
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+# ---------------------------------------------------------------------------
+# Real in-memory DB fixtures (the queue logic is inherently DB-level)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def db_factory(tmp_path):
+    """A file-backed SQLite engine (so multiple sessions share state)."""
+    engine = create_engine(f"sqlite:///{tmp_path}/preview.db")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def patched_db(db_factory, monkeypatch):
+    """Point the queue's get_db_session at the test engine (commit-on-exit)."""
+
+    @contextlib.contextmanager
+    def _get_db_session():
+        s = db_factory()
+        try:
+            yield s
+            s.commit()
+        except Exception:
+            s.rollback()
+            raise
+        finally:
+            s.close()
+
+    monkeypatch.setattr(
+        "src.api.services.slide_style_preview_queue.get_db_session",
+        _get_db_session,
+    )
+    return db_factory
+
+
+def _make_style(db_factory, **kwargs) -> int:
+    s = db_factory()
+    style = SlideStyleLibrary(
+        name=kwargs.get("name", "Bold"),
+        style_content=kwargs.get("style_content", "Big bold headings, navy palette."),
+        image_guidelines=kwargs.get("image_guidelines"),
+        is_active=True,
+        style_revision=0,
+        preview_status="missing",
+    )
+    s.add(style)
+    s.commit()
+    style_id = style.id
+    s.close()
+    return style_id
+
+
+def _deck(slides=3, css=".slide{color:navy}"):
+    return {
+        "slides": [{"html": f"<div class='slide'>Slide {i}</div>"} for i in range(slides)],
+        "css": css,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+class TestFingerprint:
+    def test_changes_with_style_content(self):
+        a = fixture.compute_fingerprint("style A", None)
+        b = fixture.compute_fingerprint("style B", None)
+        assert a != b
+
+    def test_changes_with_image_guidelines(self):
+        a = fixture.compute_fingerprint("s", None)
+        b = fixture.compute_fingerprint("s", "prefer photos")
+        assert a != b
+
+    def test_changes_when_generation_version_bumps(self, monkeypatch):
+        before = fixture.compute_fingerprint("s", None)
+        monkeypatch.setattr(fixture, "PREVIEW_GENERATION_VERSION", "999")
+        after = fixture.compute_fingerprint("s", None)
+        assert before != after
+
+    def test_stable_for_same_inputs(self):
+        assert fixture.compute_fingerprint("s", "g") == fixture.compute_fingerprint("s", "g")
+
+    def test_changes_when_preview_max_tokens_changes(self, monkeypatch):
+        before = fixture.compute_fingerprint("s", None)
+        monkeypatch.setattr(fixture, "PREVIEW_MAX_TOKENS", fixture.PREVIEW_MAX_TOKENS + 1)
+        after = fixture.compute_fingerprint("s", None)
+        assert before != after
+
+
+# ---------------------------------------------------------------------------
+# Dedup enqueue
+# ---------------------------------------------------------------------------
+class TestEnqueueDedup:
+    def test_second_enqueue_is_suppressed(self, patched_db, db_factory):
+        from src.api.services import slide_style_preview_queue as q
+
+        style_id = _make_style(db_factory)
+        assert q.try_enqueue(style_id) is True   # wins transition -> queued
+        assert q.try_enqueue(style_id) is False  # already queued -> dedup
+
+    def test_ready_and_current_is_not_requeued(self, patched_db, db_factory):
+        from src.api.services import slide_style_preview_queue as q
+
+        style_id = _make_style(db_factory)
+        s = db_factory()
+        style = s.get(SlideStyleLibrary, style_id)
+        style.preview_status = "ready"
+        style.preview_fingerprint = fixture.compute_fingerprint(
+            style.style_content, style.image_guidelines
+        )
+        s.commit()
+        s.close()
+        assert q.try_enqueue(style_id) is False
+
+    def test_missing_style_returns_false(self, patched_db):
+        from src.api.services import slide_style_preview_queue as q
+
+        assert q.try_enqueue(999999) is False
+
+
+# ---------------------------------------------------------------------------
+# Startup warming (backfill)
+# ---------------------------------------------------------------------------
+class TestWarmBackfill:
+    def test_warms_active_styles_and_skips_ready_and_inactive(self, patched_db, db_factory):
+        from src.api.services import slide_style_preview_queue as q
+
+        # Two active styles to warm; one already ready+current (skipped); one inactive.
+        warm_a = _make_style(db_factory, name="A")
+        warm_b = _make_style(db_factory, name="B")
+        ready_id = _make_style(db_factory, name="Ready")
+        inactive_id = _make_style(db_factory, name="Inactive")
+
+        s = db_factory()
+        ready = s.get(SlideStyleLibrary, ready_id)
+        ready.preview_status = "ready"
+        ready.preview_fingerprint = fixture.compute_fingerprint(
+            ready.style_content, ready.image_guidelines
+        )
+        s.get(SlideStyleLibrary, inactive_id).is_active = False
+        s.commit()
+        s.close()
+
+        enqueued = q.warm_missing_previews()
+        assert enqueued == 2  # only the two missing active styles
+
+        s = db_factory()
+        assert s.get(SlideStyleLibrary, warm_a).preview_status == "queued"
+        assert s.get(SlideStyleLibrary, warm_b).preview_status == "queued"
+        assert s.get(SlideStyleLibrary, ready_id).preview_status == "ready"  # untouched
+        # Inactive style never enqueued.
+        assert s.get(SlideStyleLibrary, inactive_id).preview_status == "missing"
+        s.close()
+
+    def test_warm_respects_limit(self, patched_db, db_factory):
+        from src.api.services import slide_style_preview_queue as q
+
+        ids = [_make_style(db_factory, name=f"S{i}") for i in range(5)]
+        assert q.warm_missing_previews(limit=3) == 3
+        s = db_factory()
+        queued = [i for i in ids if s.get(SlideStyleLibrary, i).preview_status == "queued"]
+        s.close()
+        assert len(queued) == 3
+
+
+# ---------------------------------------------------------------------------
+# Generation + validation + persistence
+# ---------------------------------------------------------------------------
+class TestGeneration:
+    def test_generates_validates_and_caches(self, patched_db, db_factory, monkeypatch):
+        from src.api.services import slide_style_preview_queue as q
+
+        style_id = _make_style(db_factory)
+        q.try_enqueue(style_id)
+        monkeypatch.setattr(q, "_generate_deck", lambda sid: _deck(slides=3))
+        q.process_preview_job(style_id)
+
+        s = db_factory()
+        style = s.get(SlideStyleLibrary, style_id)
+        assert style.preview_status == "ready"
+        assert style.preview_payload_id is not None
+        payload = storage.load_payload(s, style.preview_payload_id)
+        assert payload is not None
+        assert len(payload["slides"]) == 3
+        s.close()
+
+    def test_null_revision_row_is_promoted(self, patched_db, db_factory, monkeypatch):
+        """Regression: rows inherited via a Lakebase branch have style_revision=NULL.
+
+        The write-back guard snapshots revision 0 (``NULL or 0``); a plain
+        ``style_revision == 0`` filter never matches NULL in SQL, so EVERY
+        generation was discarded on a fork and no preview reached 'ready'. The
+        NULL-safe guard must promote these rows.
+        """
+        from src.api.services import slide_style_preview_queue as q
+
+        style_id = _make_style(db_factory)
+        # Force the inherited-fork condition: style_revision IS NULL.
+        s = db_factory()
+        s.get(SlideStyleLibrary, style_id).style_revision = None
+        s.commit()
+        s.close()
+
+        q.try_enqueue(style_id)
+        monkeypatch.setattr(q, "_generate_deck", lambda sid: _deck(slides=2))
+        q.process_preview_job(style_id)
+
+        s = db_factory()
+        style = s.get(SlideStyleLibrary, style_id)
+        assert style.preview_status == "ready"          # promoted, not discarded
+        assert style.preview_payload_id is not None
+        s.close()
+
+    @pytest.mark.parametrize(
+        "bad_deck,code",
+        [
+            (_deck(slides=1), "bad_slide_count"),          # too few
+            (_deck(slides=9), "bad_slide_count"),          # too many
+            ({"slides": [{"html": ""}, {"html": ""}], "css": ""}, "bad_slide_count"),
+            (
+                {"slides": [{"html": "<img src='http://evil/x.png'>"}] * 2, "css": ""},
+                "external_asset",
+            ),
+        ],
+    )
+    def test_validation_rejects_bad_output(self, bad_deck, code):
+        from src.api.services import slide_style_preview_queue as q
+
+        with pytest.raises(ValueError) as exc:
+            q._sanitize_and_validate(bad_deck)
+        assert str(exc.value) == code
+
+    def test_scripts_are_stripped(self):
+        from src.api.services import slide_style_preview_queue as q
+
+        deck = {
+            "slides": [
+                {"html": "<div class='slide'>a<script>alert(1)</script></div>"},
+                {"html": "<div class='slide'>b</div>"},
+            ],
+            "css": ".x{}",
+        }
+        slides, css, manifest = q._sanitize_and_validate(deck)
+        assert all("<script" not in s for s in slides)
+
+    def test_failure_preserves_last_known_good(self, patched_db, db_factory, monkeypatch):
+        from src.api.services import slide_style_preview_queue as q
+
+        style_id = _make_style(db_factory)
+        # First, a successful generation establishes last-known-good.
+        q.try_enqueue(style_id)
+        monkeypatch.setattr(q, "_generate_deck", lambda sid: _deck(slides=2))
+        q.process_preview_job(style_id)
+        s = db_factory()
+        good_payload_id = s.get(SlideStyleLibrary, style_id).preview_payload_id
+        s.close()
+        assert good_payload_id is not None
+
+        # Now force a failing regeneration; the good payload must survive.
+        s = db_factory()
+        s.get(SlideStyleLibrary, style_id).preview_status = "queued"
+        s.commit(); s.close()
+
+        def _boom(sid):
+            raise RuntimeError("provider down")
+
+        monkeypatch.setattr(q, "_generate_deck", _boom)
+        q.process_preview_job(style_id)
+
+        s = db_factory()
+        style = s.get(SlideStyleLibrary, style_id)
+        assert style.preview_status == "failed"
+        assert style.preview_error_code == "generation_error"
+        assert style.preview_payload_id == good_payload_id  # preserved
+        s.close()
+
+    def test_revision_race_discards_stale_generation(self, patched_db, db_factory, monkeypatch):
+        from src.api.services import slide_style_preview_queue as q
+
+        style_id = _make_style(db_factory)
+        q.try_enqueue(style_id)
+
+        # Simulate a concurrent edit: bump style_revision DURING generation so the
+        # write-back guard (revision unchanged) fails and the result is discarded.
+        def _generate_then_edit(sid):
+            s = db_factory()
+            style = s.get(SlideStyleLibrary, sid)
+            style.style_revision = (style.style_revision or 0) + 1
+            s.commit(); s.close()
+            return _deck(slides=2)
+
+        monkeypatch.setattr(q, "_generate_deck", _generate_then_edit)
+        q.process_preview_job(style_id)
+
+        s = db_factory()
+        style = s.get(SlideStyleLibrary, style_id)
+        # Not promoted to ready; no pointer written.
+        assert style.preview_status != "ready"
+        assert style.preview_payload_id is None
+        s.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration idempotency
+# ---------------------------------------------------------------------------
+class TestMigrationIdempotency:
+    def _cols_without_preview(self):
+        return [{"name": n} for n in ("id", "name", "style_content", "is_active")]
+
+    def test_adds_all_columns_first_run_then_none(self):
+        from src.core.database import _migrate_slide_style_preview_columns
+
+        conn = MagicMock()
+        insp = MagicMock()
+        insp.get_columns.return_value = self._cols_without_preview()
+        _qual = lambda t: t
+
+        _migrate_slide_style_preview_columns(conn, insp, None, _qual, is_sqlite=True)
+        first = conn.execute.call_count
+        # 12 ALTERs (one per new column) + 1 idempotent style_revision backfill UPDATE.
+        assert first == 13
+
+        # Second run: all columns present -> no ALTERs, but the idempotent
+        # style_revision backfill UPDATE still runs (a no-op WHERE ... IS NULL).
+        insp.get_columns.return_value = self._cols_without_preview() + [
+            {"name": n}
+            for n in (
+                "preview_status", "preview_fingerprint", "preview_content_hash",
+                "preview_payload_id", "preview_asset_manifest", "preview_total_bytes",
+                "preview_error_code", "preview_error_message", "preview_generated_at",
+                "preview_attempted_at", "preview_failed_at", "style_revision",
+            )
+        ]
+        _migrate_slide_style_preview_columns(conn, insp, None, _qual, is_sqlite=True)
+        # Only the backfill UPDATE (no ALTERs).
+        assert conn.execute.call_count - first == 1
+
+    def test_skips_when_table_missing(self):
+        from src.core.database import _migrate_slide_style_preview_columns
+
+        conn = MagicMock()
+        insp = MagicMock()
+        insp.get_columns.side_effect = Exception("no such table")
+        _migrate_slide_style_preview_columns(conn, insp, None, lambda t: t, is_sqlite=True)
+        conn.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Endpoints (auth + read visibility)
+# ---------------------------------------------------------------------------
+class TestPreviewEndpoints:
+    def test_regenerate_requires_admin_dependency(self):
+        """The regenerate route is server-side admin-gated (not just UI)."""
+        from src.api.routes.settings.slide_styles import router, regenerate_slide_style_preview
+        from src.api.routes._authz import require_admin
+
+        route = next(
+            r for r in router.routes
+            if getattr(r, "endpoint", None) is regenerate_slide_style_preview
+        )
+        dep_calls = [d.call for d in route.dependant.dependencies]
+        assert require_admin in dep_calls
+
+    def test_get_preview_route_is_not_admin_gated(self):
+        """The read endpoint mirrors GET /{id} visibility — no admin dependency."""
+        from src.api.routes.settings.slide_styles import router, get_slide_style_preview
+        from src.api.routes._authz import require_admin
+
+        route = next(
+            r for r in router.routes
+            if getattr(r, "endpoint", None) is get_slide_style_preview
+        )
+        dep_calls = [d.call for d in route.dependant.dependencies]
+        assert require_admin not in dep_calls
+
+    def test_get_preview_404_when_style_missing(self):
+        """Read endpoint 404s for an unknown style (visibility parity)."""
+        from fastapi import HTTPException
+        from src.api.routes.settings.slide_styles import get_slide_style_preview
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        with pytest.raises(HTTPException) as exc:
+            get_slide_style_preview(424242, db=mock_db)
+        assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
A slide style is prose the model interprets, not deterministic CSS, so the only faithful "what will my slides look like" preview is a **generated sample deck**. This adds a cached, background-generated sample deck shown in:
- the **Settings → Slide Style Library** (expand a style), and
- the **AgentConfigBar** (when a slide style — not a design system — is selected).

Previews use the **same model as real decks (Claude Opus 4.6)** for fidelity, generated once and cached (generation is non-deterministic at `temperature 0.7`).

## Backend
- **Fixture + fingerprint**: fixed canonical brief (cover/content/data slides) + structured generation fingerprint (style text + brief/prompt/generator/renderer/model versions) so previews invalidate on any preview-affecting change or release.
- **Offloaded payload storage**: gzipped HTML/CSS bundle in a dedicated `bytea` table (`slide_style_preview_payload`); `slide_style_library` keeps only a pointer + manifest + status so library reads stay light.
- **DB-backed dedup generation queue** (mirrors the export queue): conditional-update lock, revision guard, bounded retries, hostile-output sanitization/validation, last-known-good preservation.
- **Endpoints**: read-only `GET /slide-styles/{id}/preview` (never generates inline), admin-only `POST /slide-styles/{id}/preview/regenerate`; transactional cache invalidation + `style_revision` bump on edits.
- Idempotent migration for the new columns + payload table.

## Frontend
- `getSlideStylePreview`/`regenerate` client with query cache, polling + backoff, and cancellation.
- `SlideStylePreviewFrame`: strict `sandbox=""` iframe + slide CSP, fixed dims, all status states, a11y, hero thumbnail + focus-trapped mini-deck modal; lazy-mounted in `SlideStyleList`, shown for the settled `AgentConfigBar` selection.

## Performance
- Pre-warm previews on style create/edit + bounded startup backfill so viewers hit a warm cache instead of a cold generation.
- Tighter polling backoff (max 3s) so finished previews surface promptly.
- Preview-only `max_tokens` cap (12k) keeping Opus 4.6 — same model/fidelity, smaller thinking budget for lower latency; folded into the fingerprint.

## Fixes
- **NULL-safe generation write-back guard + migration backfill of `style_revision`**: branch-inherited rows had `style_revision = NULL`, and `NULL == 0` in SQL discarded every generation, so previews never reached `ready`. Root-caused via deployed-app logs (generation completed → immediately `discarded_stale_generation`).

## Tests
- Backend unit tests: fingerprint, dedup, revision race, **NULL-revision regression**, validation, last-known-good, migration idempotency, warm backfill, endpoint auth.
- Frontend e2e: lazy load (no per-card fan-out), status states, modal a11y; existing slide-styles e2e updated for the new expanded layout.

## Notes for reviewers
- Verified end-to-end on a devloop deploy: warm backfill enqueues active styles, previews reach `ready` with zero discards.
- The push triggered the org secret-scan hook on an **already-merged upstream ancestor commit** (`f6b1506`, example/CI Postgres strings in `.env.example` / `test.yml`) — none of the findings are in this PR's changes.